### PR TITLE
Unique ssh key name

### DIFF
--- a/pkg/cloudprovider/cloud/provider.go
+++ b/pkg/cloudprovider/cloud/provider.go
@@ -1,8 +1,6 @@
 package cloud
 
 import (
-	"crypto/rsa"
-
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
 	"github.com/kubermatic/machine-controller/pkg/machines/v1alpha1"
 )
@@ -12,6 +10,6 @@ type Provider interface {
 	Validate(machinespec v1alpha1.MachineSpec) error
 	Get(machine *v1alpha1.Machine) (instance.Instance, error)
 	GetCloudConfig(spec v1alpha1.MachineSpec) (config string, name string, err error)
-	Create(machine *v1alpha1.Machine, userdata string, key rsa.PublicKey) (instance.Instance, error)
+	Create(machine *v1alpha1.Machine, userdata string) (instance.Instance, error)
 	Delete(machine *v1alpha1.Machine) error
 }

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -8,23 +8,26 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+	machinessh "github.com/kubermatic/machine-controller/pkg/ssh"
 )
+
+type providerInitializer = func(key *machinessh.PrivateKey) cloud.Provider
 
 var (
 	// ErrProviderNotFound tells that the requested cloud provider was not found
 	ErrProviderNotFound = errors.New("cloudprovider not found")
 
-	providers = map[providerconfig.CloudProvider]cloud.Provider{
-		providerconfig.CloudProviderDigitalocean: digitalocean.New(),
-		providerconfig.CloudProviderAWS:          aws.New(),
-		providerconfig.CloudProviderOpenstack:    openstack.New(),
+	providers = map[providerconfig.CloudProvider]providerInitializer{
+		providerconfig.CloudProviderDigitalocean: func(key *machinessh.PrivateKey) cloud.Provider { return digitalocean.New(key) },
+		providerconfig.CloudProviderAWS:          func(key *machinessh.PrivateKey) cloud.Provider { return aws.New(key) },
+		providerconfig.CloudProviderOpenstack:    func(key *machinessh.PrivateKey) cloud.Provider { return openstack.New(key) },
 	}
 )
 
 // ForProvider returns a CloudProvider actuator for the requested provider
-func ForProvider(p providerconfig.CloudProvider) (cloud.Provider, error) {
+func ForProvider(p providerconfig.CloudProvider, key *machinessh.PrivateKey) (cloud.Provider, error) {
 	if p, found := providers[p]; found {
-		return p, nil
+		return p(key), nil
 	}
 	return nil, ErrProviderNotFound
 }

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -11,13 +11,11 @@ import (
 	machinessh "github.com/kubermatic/machine-controller/pkg/ssh"
 )
 
-type providerInitializer = func(key *machinessh.PrivateKey) cloud.Provider
-
 var (
 	// ErrProviderNotFound tells that the requested cloud provider was not found
 	ErrProviderNotFound = errors.New("cloudprovider not found")
 
-	providers = map[providerconfig.CloudProvider]providerInitializer{
+	providers = map[providerconfig.CloudProvider]func(key *machinessh.PrivateKey) cloud.Provider{
 		providerconfig.CloudProviderDigitalocean: func(key *machinessh.PrivateKey) cloud.Provider { return digitalocean.New(key) },
 		providerconfig.CloudProviderAWS:          func(key *machinessh.PrivateKey) cloud.Provider { return aws.New(key) },
 		providerconfig.CloudProviderOpenstack:    func(key *machinessh.PrivateKey) cloud.Provider { return openstack.New(key) },

--- a/pkg/ssh/configmap.go
+++ b/pkg/ssh/configmap.go
@@ -2,7 +2,6 @@ package ssh
 
 import (
 	"bytes"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -16,12 +15,13 @@ import (
 
 const (
 	privateKeyDataIndex = "id_rsa"
+	privateKeyNameIndex = "name"
 	secretName          = "machine-controller-ssh-key"
 	rsaPrivateKey       = "RSA PRIVATE KEY"
 )
 
 // EnsureSSHKeypairSecret
-func EnsureSSHKeypairSecret(client kubernetes.Interface) (*rsa.PrivateKey, error) {
+func EnsureSSHKeypairSecret(name string, client kubernetes.Interface) (*PrivateKey, error) {
 	if client == nil {
 		return nil, fmt.Errorf("got an nil k8s client")
 	}
@@ -35,12 +35,12 @@ func EnsureSSHKeypairSecret(client kubernetes.Interface) (*rsa.PrivateKey, error
 	}
 
 	glog.V(4).Info("generating master ssh keypair")
-	pk, err := NewPrivateKey()
+	pk, err := NewPrivateKey(name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ssh keypair: %v", err)
 	}
 
-	privateKeyPEM := &pem.Block{Type: rsaPrivateKey, Bytes: x509.MarshalPKCS1PrivateKey(pk)}
+	privateKeyPEM := &pem.Block{Type: rsaPrivateKey, Bytes: x509.MarshalPKCS1PrivateKey(pk.key)}
 	privBuf := bytes.Buffer{}
 	err = pem.Encode(&privBuf, privateKeyPEM)
 	if err != nil {
@@ -54,6 +54,7 @@ func EnsureSSHKeypairSecret(client kubernetes.Interface) (*rsa.PrivateKey, error
 		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			privateKeyDataIndex: privBuf.Bytes(),
+			privateKeyNameIndex: []byte(name),
 		},
 	}
 
@@ -65,7 +66,7 @@ func EnsureSSHKeypairSecret(client kubernetes.Interface) (*rsa.PrivateKey, error
 
 }
 
-func keyFromSecret(secret *v1.Secret) (*rsa.PrivateKey, error) {
+func keyFromSecret(secret *v1.Secret) (*PrivateKey, error) {
 	b, exists := secret.Data[privateKeyDataIndex]
 	if !exists {
 		return nil, fmt.Errorf("key data not found in secret '%s/%s' (secret.data['%s']). remove it and a new one will be created", secret.Namespace, secret.Name, privateKeyDataIndex)
@@ -84,5 +85,13 @@ func keyFromSecret(secret *v1.Secret) (*rsa.PrivateKey, error) {
 		return nil, fmt.Errorf("failed to parse private key: %v", err)
 	}
 
-	return pk, nil
+	name, _ := secret.Data[privateKeyNameIndex]
+	if string(name) == "" {
+		return nil, fmt.Errorf("invalid name in secret '%s/%s'. remove it and a new one will be created", secret.Namespace, secret.Name)
+	}
+
+	return &PrivateKey{
+		key:  pk,
+		name: string(name),
+	}, nil
 }

--- a/pkg/ssh/configmap.go
+++ b/pkg/ssh/configmap.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 
 	"github.com/golang/glog"
-	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -47,11 +47,11 @@ func EnsureSSHKeypairSecret(name string, client kubernetes.Interface) (*PrivateK
 		return nil, err
 	}
 
-	secret = &v1.Secret{
+	secret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: secretName,
 		},
-		Type: v1.SecretTypeOpaque,
+		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
 			privateKeyDataIndex: privBuf.Bytes(),
 			privateKeyNameIndex: []byte(name),
@@ -66,7 +66,7 @@ func EnsureSSHKeypairSecret(name string, client kubernetes.Interface) (*PrivateK
 
 }
 
-func keyFromSecret(secret *v1.Secret) (*PrivateKey, error) {
+func keyFromSecret(secret *corev1.Secret) (*PrivateKey, error) {
 	b, exists := secret.Data[privateKeyDataIndex]
 	if !exists {
 		return nil, fmt.Errorf("key data not found in secret '%s/%s' (secret.data['%s']). remove it and a new one will be created", secret.Namespace, secret.Name, privateKeyDataIndex)

--- a/pkg/ssh/key.go
+++ b/pkg/ssh/key.go
@@ -8,8 +8,21 @@ import (
 
 const privateKeyBitSize = 2048
 
-// NewPrivateKey generates a new private key
-func NewPrivateKey() (key *rsa.PrivateKey, err error) {
+type PrivateKey struct {
+	key  *rsa.PrivateKey
+	name string
+}
+
+func (p *PrivateKey) Name() string {
+	return p.name
+}
+
+func (p *PrivateKey) PublicKey() rsa.PublicKey {
+	return p.key.PublicKey
+}
+
+// NewPrivateKey generates a new PrivateKey
+func NewPrivateKey(name string) (key *PrivateKey, err error) {
 	priv, err := rsa.GenerateKey(rand.Reader, privateKeyBitSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create private key: %v", err)
@@ -19,5 +32,5 @@ func NewPrivateKey() (key *rsa.PrivateKey, err error) {
 		return nil, fmt.Errorf("failed to validate private key: %v", err)
 	}
 
-	return priv, nil
+	return &PrivateKey{key: priv, name: name}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we create a public ssh key on the cloud providers with the same name.
As this breaks when you have multiple clusters, we need to make the name customizable.