### PR TITLE
export provider specific configs

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -117,7 +117,7 @@ var (
 	publicKeyCreationLock = &sync.Mutex{}
 )
 
-type config struct {
+type Config struct {
 	AccessKeyID     string `json:"accessKeyId"`
 	SecretAccessKey string `json:"secretAccessKey"`
 
@@ -147,13 +147,13 @@ func getAMIID(os providerconfig.OperatingSystem, region string) (string, error) 
 	return id, nil
 }
 
-func getConfig(s runtime.RawExtension) (*config, *providerconfig.Config, error) {
+func getConfig(s runtime.RawExtension) (*Config, *providerconfig.Config, error) {
 	pconfig := providerconfig.Config{}
 	err := json.Unmarshal(s.Raw, &pconfig)
 	if err != nil {
 		return nil, nil, err
 	}
-	c := config{}
+	c := Config{}
 	err = json.Unmarshal(pconfig.CloudProviderSpec.Raw, &c)
 	return &c, &pconfig, err
 }

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -36,7 +36,7 @@ func New(privateKey *machinessh.PrivateKey) cloud.Provider {
 	return &provider{privateKey: privateKey}
 }
 
-type config struct {
+type Config struct {
 	Token             string   `json:"token"`
 	Region            string   `json:"region"`
 	Size              string   `json:"size"`
@@ -85,13 +85,13 @@ func getClient(token string) *godo.Client {
 	return godo.NewClient(oauthClient)
 }
 
-func getConfig(s runtime.RawExtension) (*config, *providerconfig.Config, error) {
+func getConfig(s runtime.RawExtension) (*Config, *providerconfig.Config, error) {
 	pconfig := providerconfig.Config{}
 	err := json.Unmarshal(s.Raw, &pconfig)
 	if err != nil {
 		return nil, nil, err
 	}
-	c := config{}
+	c := Config{}
 	err = json.Unmarshal(pconfig.CloudProviderSpec.Raw, &c)
 	return &c, &pconfig, err
 }

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -35,7 +35,7 @@ func New(privateKey *machinessh.PrivateKey) cloud.Provider {
 	return &provider{privateKey: privateKey}
 }
 
-type config struct {
+type Config struct {
 	// Auth details
 	IdentityEndpoint string `json:"identityEndpoint"`
 	Username         string `json:"username"`
@@ -66,18 +66,18 @@ const (
 // Protects floating ip assignment
 var floatingIPAssignLock = &sync.Mutex{}
 
-func getConfig(s runtime.RawExtension) (*config, *providerconfig.Config, error) {
+func getConfig(s runtime.RawExtension) (*Config, *providerconfig.Config, error) {
 	pconfig := providerconfig.Config{}
 	err := json.Unmarshal(s.Raw, &pconfig)
 	if err != nil {
 		return nil, nil, err
 	}
-	c := config{}
+	c := Config{}
 	err = json.Unmarshal(pconfig.CloudProviderSpec.Raw, &c)
 	return &c, &pconfig, err
 }
 
-func getClient(c *config) (*gophercloud.ProviderClient, error) {
+func getClient(c *Config) (*gophercloud.ProviderClient, error) {
 	opts := gophercloud.AuthOptions{
 		IdentityEndpoint: c.IdentityEndpoint,
 		Username:         c.Username,

--- a/pkg/userdata/coreos/userdata.go
+++ b/pkg/userdata/coreos/userdata.go
@@ -18,12 +18,12 @@ import (
 
 type Provider struct{}
 
-type config struct {
+type Config struct {
 	DisableAutoUpdate bool `json:"disableAutoUpdate"`
 }
 
-func getConfig(r runtime.RawExtension) (*config, error) {
-	p := config{}
+func getConfig(r runtime.RawExtension) (*Config, error) {
+	p := Config{}
 	if len(r.Raw) == 0 {
 		return &p, nil
 	}
@@ -84,7 +84,7 @@ func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string,
 	data := struct {
 		MachineSpec       machinesv1alpha1.MachineSpec
 		ProviderConfig    *providerconfig.Config
-		CoreOSConfig      *config
+		CoreOSConfig      *Config
 		Kubeconfig        string
 		CloudProvider     string
 		CloudConfig       string

--- a/pkg/userdata/coreos/userdata_test.go
+++ b/pkg/userdata/coreos/userdata_test.go
@@ -33,7 +33,7 @@ func TestProvider_UserData(t *testing.T) {
 		spec           machinesv1alpha1.MachineSpec
 		kubeconfig     string
 		ccProvider     cloud.ConfigProvider
-		osConfig       *config
+		osConfig       *Config
 		providerConfig *providerconfig.Config
 		DNSIPs         []net.IP
 		resErr         error
@@ -59,7 +59,7 @@ func TestProvider_UserData(t *testing.T) {
 			kubeconfig: "kubeconfig",
 			DNSIPs:     []net.IP{net.ParseIP("10.10.10.10")},
 			resErr:     nil,
-			osConfig:   &config{DisableAutoUpdate: true},
+			osConfig:   &Config{DisableAutoUpdate: true},
 			userdata:   docker12DisableAutoUpdateAWS,
 		},
 		{
@@ -82,7 +82,7 @@ func TestProvider_UserData(t *testing.T) {
 			kubeconfig: "kubeconfig",
 			DNSIPs:     []net.IP{net.ParseIP("10.10.10.10"), net.ParseIP("10.10.10.11"), net.ParseIP("10.10.10.12")},
 			resErr:     nil,
-			osConfig:   &config{DisableAutoUpdate: false},
+			osConfig:   &Config{DisableAutoUpdate: false},
 			userdata:   docker12AutoUpdateOpenstackMultipleDNS,
 		},
 		{
@@ -105,7 +105,7 @@ func TestProvider_UserData(t *testing.T) {
 			kubeconfig: "kubeconfig",
 			DNSIPs:     []net.IP{net.ParseIP("10.10.10.10")},
 			resErr:     nil,
-			osConfig:   &config{DisableAutoUpdate: false},
+			osConfig:   &Config{DisableAutoUpdate: false},
 			userdata:   docker12AutoUpdateOpenstack,
 		},
 	}

--- a/pkg/userdata/ubuntu/userdata.go
+++ b/pkg/userdata/ubuntu/userdata.go
@@ -19,7 +19,7 @@ import (
 
 type Provider struct{}
 
-type config struct {
+type Config struct {
 	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
 }
 
@@ -27,8 +27,8 @@ var (
 	NoInstallCandidateAvailableErr = errors.New("no install candidate available for the desired version")
 )
 
-func getConfig(r runtime.RawExtension) (*config, error) {
-	p := config{}
+func getConfig(r runtime.RawExtension) (*Config, error) {
+	p := Config{}
 	if len(r.Raw) == 0 {
 		return &p, nil
 	}
@@ -98,7 +98,7 @@ func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string,
 	data := struct {
 		MachineSpec         machinesv1alpha1.MachineSpec
 		ProviderConfig      *providerconfig.Config
-		OSConfig            *config
+		OSConfig            *Config
 		Kubeconfig          string
 		CloudProvider       string
 		CloudConfig         string

--- a/pkg/userdata/ubuntu/userdata_test.go
+++ b/pkg/userdata/ubuntu/userdata_test.go
@@ -33,7 +33,7 @@ func TestProvider_UserData(t *testing.T) {
 		spec           machinesv1alpha1.MachineSpec
 		kubeconfig     string
 		ccProvider     cloud.ConfigProvider
-		osConfig       *config
+		osConfig       *Config
 		providerConfig *providerconfig.Config
 		DNSIPs         []net.IP
 		resErr         error
@@ -59,7 +59,7 @@ func TestProvider_UserData(t *testing.T) {
 			kubeconfig: "kubeconfig",
 			DNSIPs:     []net.IP{net.ParseIP("10.10.10.10")},
 			resErr:     nil,
-			osConfig:   &config{DistUpgradeOnBoot: true},
+			osConfig:   &Config{DistUpgradeOnBoot: true},
 			userdata:   docker12DistupgradeAWS,
 		},
 		{
@@ -82,7 +82,7 @@ func TestProvider_UserData(t *testing.T) {
 			kubeconfig: "kubeconfig",
 			DNSIPs:     []net.IP{net.ParseIP("10.10.10.10")},
 			resErr:     nil,
-			osConfig:   &config{DistUpgradeOnBoot: false},
+			osConfig:   &Config{DistUpgradeOnBoot: false},
 			userdata:   CRIO19Digitalocean,
 		},
 		{
@@ -105,7 +105,7 @@ func TestProvider_UserData(t *testing.T) {
 			kubeconfig: "kubeconfig",
 			DNSIPs:     []net.IP{net.ParseIP("10.10.10.10"), net.ParseIP("10.10.10.11"), net.ParseIP("10.10.10.12")},
 			resErr:     nil,
-			osConfig:   &config{DistUpgradeOnBoot: true},
+			osConfig:   &Config{DistUpgradeOnBoot: true},
 			userdata:   docker1703DistupgradeOpenstackMultipleDNS,
 		},
 		{
@@ -128,7 +128,7 @@ func TestProvider_UserData(t *testing.T) {
 			kubeconfig: "kubeconfig",
 			DNSIPs:     []net.IP{net.ParseIP("10.10.10.10")},
 			resErr:     nil,
-			osConfig:   &config{DistUpgradeOnBoot: true},
+			osConfig:   &Config{DistUpgradeOnBoot: true},
 			userdata:   docker1703DistupgradeOpenstack,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
It exports the provider configs so they can be used outside of the machine-controller