### PR TITLE
remove crd readiness check

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -122,7 +122,6 @@ func main() {
 
 	health := healthcheck.NewHandler()
 	health.AddReadinessCheck("apiserver-connection", machinehealth.ApiserverReachable(kubeClient))
-	health.AddReadinessCheck("custom-resource-definitions-exist", machinehealth.CustomResourceDefinitionsEstablished(extclient))
 	for name, c := range c.ReadinessChecks() {
 		health.AddReadinessCheck(name, c)
 	}

--- a/pkg/health/readiness.go
+++ b/pkg/health/readiness.go
@@ -1,11 +1,7 @@
 package health
 
 import (
-	"errors"
-
 	"github.com/heptiolabs/healthcheck"
-	"github.com/kubermatic/machine-controller/pkg/machines"
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -14,18 +10,5 @@ func ApiserverReachable(client kubernetes.Interface) healthcheck.Check {
 	return func() error {
 		_, err := client.CoreV1().Namespaces().List(metav1.ListOptions{})
 		return err
-	}
-}
-
-func CustomResourceDefinitionsEstablished(clientset apiextensionsclient.Interface) healthcheck.Check {
-	return func() error {
-		exist, err := machines.AllCustomResourceDefinitionsExists(clientset)
-		if err != nil {
-			return err
-		}
-		if !exist {
-			return errors.New("custom resource definitions do not exist / are established")
-		}
-		return nil
 	}
 }

--- a/pkg/machines/register.go
+++ b/pkg/machines/register.go
@@ -36,17 +36,6 @@ func EnsureCustomResourceDefinitions(clientset apiextensionsclient.Interface) er
 	return nil
 }
 
-func AllCustomResourceDefinitionsExists(clientset apiextensionsclient.Interface) (bool, error) {
-	for _, res := range resourceNames {
-		name := res.plural + "." + v1alpha1.GroupName
-		exists, err := CustomResourceDefinitionExists(name, clientset)
-		if err != nil || !exists {
-			return false, err
-		}
-	}
-	return true, nil
-}
-
 func CustomResourceDefinitionExists(name string, clientset apiextensionsclient.Interface) (bool, error) {
 	crd, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(name, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
We ensure in the main.go if the crd's exist and create them if necessary. If something fails we exit with a fatal. After we ensured that the crd's exist we start the health endpoints. There is absolutely no need to have a dedicated readiness check for the crd as it cannot fail at this moment.