### PR TITLE
running dep ensure is enough.

### DIFF
--- a/test/tools/verify/cmd/main.go
+++ b/test/tools/verify/cmd/main.go
@@ -23,7 +23,6 @@ const (
 	machineReadyCheckTimeout = 5 * time.Minute
 )
 
-// TODO(lukasz): put the binary under github.com/kubermatic/machine-controller/tree/master/cmd
 func main() {
 	var manifestPath string
 	var parameters string


### PR DESCRIPTION
**What this PR does / why we need it**: the dep tool should restore vendored packages that we depend on. There is no need to move the tool to a different location unless we want.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #47 