### PR TITLE
Use projects maketarget for circleci building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,12 @@ jobs:
           key: vendor-{{ checksum "Gopkg.lock" }}
       - setup_remote_docker
       - run: apk update && apk add make bash git
-      - run: make machine-controller-nodep
+      - run: |
+          set -e
+          docker create -v /go/src/github.com/kubermatic/machine-controller --name vol-container alpine /bin/true
+          docker cp . vol-container:/go/src/github.com/kubermatic/machine-controller/
+          export USE_VOLUME_CONTAINER=true && make machine-controller-nodep
+          docker cp vol-container:/go/src/github.com/kubermatic/machine-controller/machine-controller .
       - save_cache:
           key: machine-controller-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,14 +37,16 @@ jobs:
 
   build:
     docker:
-      - image: circleci/golang:1.9
+      - image: docker:stable
     working_directory: /go/src/github.com/kubermatic/machine-controller
     steps:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           key: vendor-{{ checksum "Gopkg.lock" }}
-      - run: go build -o machine-controller github.com/kubermatic/machine-controller/cmd/controller
+      - setup_remote_docker
+      - run: apk update && apk add make bash git
+      - run: make machine-controller-nodep
       - save_cache:
           key: machine-controller-{{ .Revision }}
           paths:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ vendor: Gopkg.lock Gopkg.toml
 	dep ensure -vendor-only
 
 machine-controller: $(shell find cmd pkg -name '*.go') vendor
+	make machine-controller-nodep
+
+machine-controller-nodep:
 		@docker run --rm \
 			-v $$PWD:/go/src/github.com/kubermatic/machine-controller \
 			-w /go/src/github.com/kubermatic/machine-controller \

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,23 @@ SHELL = /bin/bash
 REGISTRY ?= docker.io
 REGISTRY_NAMESPACE ?= kubermatic
 
+USE_VOLUME_CONTAINER ?= false
+
 IMAGE_TAG = \
 		$(shell echo $$(git rev-parse HEAD && if [[ -n $$(git status --porcelain) ]]; then echo '-dirty'; fi)|tr -d ' ')
 IMAGE_NAME = $(REGISTRY)/$(REGISTRY_NAMESPACE)/machine-controller:$(IMAGE_TAG)
+
+
+
+# Required because circlecCI can not use
+# Docker volumes, so we have to use a volume
+# container instead there
+ifeq ($(USE_VOLUME_CONTAINER),true)
+	VOL_ARG = --volumes-from vol-container
+else
+	VOL_ARG = -v $$PWD:/go/src/github.com/kubermatic/machine-controller
+endif
+
 
 vendor: Gopkg.lock Gopkg.toml
 	dep ensure -vendor-only
@@ -15,7 +29,7 @@ machine-controller: $(shell find cmd pkg -name '*.go') vendor
 
 machine-controller-nodep:
 		@docker run --rm \
-			-v $$PWD:/go/src/github.com/kubermatic/machine-controller \
+			$(VOL_ARG) \
 			-w /go/src/github.com/kubermatic/machine-controller \
 			golang:1.9.2 \
 			env CGO_ENABLED=0 go build \


### PR DESCRIPTION
**What this PR does / why we need it**:

Adjusts the circleci build to use the Maketarget in the projects root dir to ensure we always publish the exact same binary we test, including go version and build flags.

Background: The currently published docker image does not work, because it contains a dynamically linked binary but no linker:

```bash
$ docker run --rm -it --user root kubermatic/machine-controller:4baafd3c477fa64dabefca61c52ccb7171cd4773 sh
/ # apk update && apk add file && file /usr/local/bin/machine-controller 
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
v3.7.0-74-g1540930789 [http://dl-cdn.alpinelinux.org/alpine/v3.7/main]
v3.7.0-73-g5f006fb2a0 [http://dl-cdn.alpinelinux.org/alpine/v3.7/community]
OK: 9047 distinct packages available
(1/2) Installing libmagic (5.32-r0)
(2/2) Installing file (5.32-r0)
Executing busybox-1.27.2-r7.trigger
OK: 10 MiB in 14 packages
/usr/local/bin/machine-controller: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, with debug_info, not stripped
/ # ls -l /lib64/ld-linux-x86-64.so.2
ls: /lib64/ld-linux-x86-64.so.2: No such file or directory
```

Which results in

```
/ # /usr/local/bin/machine-controller --help
sh: /usr/local/bin/machine-controller: not found
```

In contrast to that, the binary built via the Makefile is statically linked (because of the `env CGO_ENABLED=0 `) thus it always worked perfectly fine in our tests:

```bash
$ file machine-controller 
machine-controller: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```