### PR TITLE
run machine controller via leader election

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -210,6 +210,12 @@
   revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/golang/groupcache"
+  packages = ["lru"]
+  revision = "66deaeb636dff1ac7d938ce666d090556056a4b0"
+
+[[projects]]
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -360,6 +366,12 @@
   packages = ["pbutil"]
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/pborman/uuid"
+  packages = ["."]
+  revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
+  version = "v1.1"
 
 [[projects]]
   branch = "master"
@@ -613,16 +625,20 @@
     "pkg/util/framer",
     "pkg/util/intstr",
     "pkg/util/json",
+    "pkg/util/mergepatch",
     "pkg/util/net",
     "pkg/util/rand",
     "pkg/util/runtime",
     "pkg/util/sets",
+    "pkg/util/strategicpatch",
+    "pkg/util/uuid",
     "pkg/util/validation",
     "pkg/util/validation/field",
     "pkg/util/wait",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
+    "third_party/forked/golang/json",
     "third_party/forked/golang/reflect"
   ]
   revision = "19e3f5aa3adca672c153d324e6b7d82ff8935f03"
@@ -766,8 +782,11 @@
     "tools/clientcmd/api",
     "tools/clientcmd/api/latest",
     "tools/clientcmd/api/v1",
+    "tools/leaderelection",
+    "tools/leaderelection/resourcelock",
     "tools/metrics",
     "tools/pager",
+    "tools/record",
     "tools/reference",
     "transport",
     "util/buffer",
@@ -808,12 +827,15 @@
 [[projects]]
   branch = "master"
   name = "k8s.io/kube-openapi"
-  packages = ["pkg/common"]
+  packages = [
+    "pkg/common",
+    "pkg/util/proto"
+  ]
   revision = "275e2ce91dec4c05a4094a7b1daee5560b555ac9"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "758a9a6967935b0b8805e44e66aef043d7563d7a332db83ab7080c71c710344e"
+  inputs-digest = "b71cf33ce348f7cb8313b1e8ba4bb71e5dc366f8a7723b1945a95500877a21c1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -17,18 +17,35 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	kubeinformers "k8s.io/client-go/informers"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/golang/glog"
 	"github.com/heptiolabs/healthcheck"
 	machineclientset "github.com/kubermatic/machine-controller/pkg/client/clientset/versioned"
 	machineinformers "github.com/kubermatic/machine-controller/pkg/client/informers/externalversions"
+	machinesv1alpha1 "github.com/kubermatic/machine-controller/pkg/client/informers/externalversions/machines/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/clusterinfo"
 	"github.com/kubermatic/machine-controller/pkg/controller"
 	machinehealth "github.com/kubermatic/machine-controller/pkg/health"
@@ -36,12 +53,6 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/signals"
 	"github.com/kubermatic/machine-controller/pkg/ssh"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	apiextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeinformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 var (
@@ -52,6 +63,51 @@ var (
 	listenAddress string
 	workerCount   int
 )
+
+const (
+	controllerName                     = "machine-controller"
+	defaultLeaderElectionNamespace     = "kube-system"
+	defaultLeaderElectionLeaseDuration = 15 * time.Second
+	defaultLeaderElectionRenewDeadline = 10 * time.Second
+	defaultLeaderElectionRetryPeriod   = 2 * time.Second
+)
+
+// controllerRunOptions holds data that are required to create and run machine controller
+type controllerRunOptions struct {
+	// kubeClient a client that knows how to consume kubernetes API
+	kubeClient *kubernetes.Clientset
+
+	// extClient a client that knows how to consume kubernetes extension API
+	extClient *apiextclient.Clientset
+
+	// machineClient a client that knows how to consume Machine resources
+	machineClient *machineclientset.Clientset
+
+	// sshKeyPair sets a trust between the controller and a machine by
+	// pre-installing public part of that key on a machine.
+	sshKeyPair *ssh.PrivateKey
+
+	// this essentially sets the cluster DNS IP addresses. The list is passed to kubelet and then down to pods.
+	clusterDNSIPs []net.IP
+
+	// metrics a struct that holds all metrics we want to collect
+	metrics *MachineControllerMetrics
+
+	// leaderElectionClient holds a client that is used by the leader election library
+	leaderElectionClient *kubernetes.Clientset
+
+	// nodeInformer holds a shared informer and lister for Nodes
+	nodeInformer corev1informers.NodeInformer
+
+	// configMapInformer holds a shared informer and lister for ConfigMaps
+	configMapInformer corev1informers.ConfigMapInformer
+
+	// machineInformer holds a shared informer and lister for Machines
+	machineInformer machinesv1alpha1.MachineInformer
+
+	// kubeconfigProvider knows how to get cluster information stored under a ConfigMap
+	kubeconfigProvider controller.KubeconfigProvider
+}
 
 func main() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
@@ -68,30 +124,45 @@ func main() {
 		glog.Fatalf("invalid cluster dns specified: %v", err)
 	}
 
-	// set up signals so we handle the first shutdown signal gracefully
+	// TODO: add graceful shutdown, propagate stopCh to run method and to http server
 	stopCh := signals.SetupSignalHandler()
 
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
 	if err != nil {
-		glog.Fatalf("Error building kubeconfig: %v", err)
+		glog.Fatalf("error building kubeconfig: %v", err)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		glog.Fatalf("Error building kubernetes clientset: %v", err)
+		glog.Fatalf("error building kubernetes clientset for kubeClient: %v", err)
 	}
 
-	extclient := apiextclient.NewForConfigOrDie(cfg)
-	err = machines.EnsureCustomResourceDefinitions(extclient)
+	extClient, err := apiextclient.NewForConfig(cfg)
 	if err != nil {
-		glog.Fatalf("failed to create CustomResourceDefinition: %v", err)
+		glog.Fatalf("error building kubernetes clientset for extClient: %v", err)
 	}
 
 	machineClient, err := machineclientset.NewForConfig(cfg)
 	if err != nil {
-		glog.Fatalf("Error building example clientset: %v", err)
+		glog.Fatalf("error building example clientset for machineClient: %v", err)
 	}
 
+	leaderElectionClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		glog.Fatalf("error building kubernetes clientset for leaderElectionClient: %v", err)
+	}
+
+	err = machines.EnsureCustomResourceDefinitions(extClient)
+	if err != nil {
+		glog.Fatalf("failed to create CustomResourceDefinition: %v", err)
+	}
+
+	key, err := ssh.EnsureSSHKeypairSecret(sshKeyName, kubeClient)
+	if err != nil {
+		glog.Fatalf("failed to get/create ssh key configmap: %v", err)
+	}
+
+	// before we acquire a lock we actually warm up caches mirroring the state of the API server
 	machineInformerFactory := machineinformers.NewSharedInformerFactory(machineClient, time.Second*30)
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Second*30)
 	kubePublicKubeInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(kubeClient, time.Second*30, metav1.NamespacePublic, nil)
@@ -103,23 +174,6 @@ func main() {
 	machineInformer := machineInformerFactory.Machine().V1alpha1().Machines()
 
 	kubeconfigProvider := clusterinfo.New(cfg, configMapInformer.Lister(), endpointInformer.Lister())
-
-	key, err := ssh.EnsureSSHKeypairSecret(sshKeyName, kubeClient)
-	if err != nil {
-		glog.Fatalf("failed to get/create ssh key configmap: %v", err)
-	}
-
-	metrics := NewMachineControllerMetrics()
-	machineMetrics := controller.MetricsCollection{
-		Machines:            metrics.Machines,
-		Workers:             metrics.Workers,
-		Errors:              metrics.Errors,
-		Nodes:               metrics.Nodes,
-		ControllerOperation: metrics.ControllerOperation,
-		NodeJoinDuration:    metrics.NodeJoinDuration,
-	}
-
-	c := controller.NewMachineController(kubeClient, machineClient, nodeInformer, configMapInformer, machineInformer, key, ips, machineMetrics, kubeconfigProvider)
 
 	go kubeInformerFactory.Start(stopCh)
 	go kubePublicKubeInformerFactory.Start(stopCh)
@@ -134,16 +188,148 @@ func main() {
 		}
 	}
 
+	runOptions := controllerRunOptions{
+		kubeClient:           kubeClient,
+		extClient:            extClient,
+		machineClient:        machineClient,
+		sshKeyPair:           key,
+		metrics:              NewMachineControllerMetrics(),
+		clusterDNSIPs:        ips,
+		leaderElectionClient: leaderElectionClient,
+		nodeInformer:         nodeInformer,
+		configMapInformer:    configMapInformer,
+		machineInformer:      machineInformer,
+		kubeconfigProvider:   kubeconfigProvider,
+	}
+
+	startUtilHttpServerOrDie(kubeClient, kubeconfigProvider, stopCh)
+	startControllerViaLeaderElectionOrDie(runOptions)
+}
+
+// startControllerViaLeaderElectionOrDie starts machine controller only if a proper lock was acquired.
+// This essentially means that we can have multiple instances and at the same time only one is operational.
+// The program terminates when the leadership was lost.
+func startControllerViaLeaderElectionOrDie(runOptions controllerRunOptions) {
+	id, err := os.Hostname()
+	if err != nil {
+		glog.Fatalf("error getting hostname: %s", err.Error())
+	}
+	// add a seed to the id, so that two processes on the same host don't accidentally both become active
+	id = id + "_" + string(uuid.NewUUID())
+
+	rl := resourcelock.EndpointsLock{
+		EndpointsMeta: metav1.ObjectMeta{
+			Namespace: defaultLeaderElectionNamespace,
+			Name:      controllerName,
+		},
+		Client: runOptions.leaderElectionClient.CoreV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity:      id + fmt.Sprintf("-%s", controllerName),
+			EventRecorder: createRecorder(runOptions.kubeClient),
+		},
+	}
+
+	run := func(stopCh <-chan struct{}) {
+		machineController := controller.NewMachineController(
+			runOptions.kubeClient,
+			runOptions.machineClient,
+			runOptions.nodeInformer,
+			runOptions.configMapInformer,
+			runOptions.machineInformer,
+			runOptions.sshKeyPair,
+			runOptions.clusterDNSIPs,
+			controller.MetricsCollection{
+				Machines:            runOptions.metrics.Machines,
+				Workers:             runOptions.metrics.Workers,
+				Errors:              runOptions.metrics.Errors,
+				Nodes:               runOptions.metrics.Nodes,
+				ControllerOperation: runOptions.metrics.ControllerOperation,
+				NodeJoinDuration:    runOptions.metrics.NodeJoinDuration,
+			},
+			runOptions.kubeconfigProvider)
+
+		if err = machineController.Run(workerCount, stopCh); err != nil {
+			glog.Fatalf("error running controller: %v", err)
+		}
+	}
+
+	leaderelection.RunOrDie(leaderelection.LeaderElectionConfig{
+		Lock:          &rl,
+		LeaseDuration: defaultLeaderElectionLeaseDuration,
+		RenewDeadline: defaultLeaderElectionRenewDeadline,
+		RetryPeriod:   defaultLeaderElectionRetryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: run,
+			OnStoppedLeading: func() {
+				glog.Fatalf("leaderelection lost, closing the app")
+			},
+		},
+	})
+}
+
+// startUtilHttpServer starts a new HTTP server asynchronously
+func startUtilHttpServerOrDie(kubeClient *kubernetes.Clientset, kubeconfigProvider controller.KubeconfigProvider, stopCh <-chan struct{}) {
 	health := healthcheck.NewHandler()
 	health.AddReadinessCheck("apiserver-connection", machinehealth.ApiserverReachable(kubeClient))
-	for name, c := range c.ReadinessChecks() {
+
+	for name, c := range readinessChecks(kubeconfigProvider) {
 		health.AddReadinessCheck(name, c)
 	}
-	go serveUtilHttpServer(health)
 
-	if err = c.Run(workerCount, stopCh); err != nil {
-		glog.Fatalf("Error running controller: %v", err)
+	serveUtilHttpServer := func(health healthcheck.Handler) {
+		m := http.NewServeMux()
+		m.Handle("/metrics", promhttp.Handler())
+		m.Handle("/live", http.HandlerFunc(health.LiveEndpoint))
+		m.Handle("/ready", http.HandlerFunc(health.ReadyEndpoint))
+
+		s := http.Server{
+			Addr:    listenAddress,
+			Handler: m,
+		}
+		glog.V(4).Infof("serving util http server on %s", listenAddress)
+		glog.Fatalf("util http server died: %v", s.ListenAndServe())
 	}
+
+	go serveUtilHttpServer(health)
+}
+
+func readinessChecks(kubeconfigProvider controller.KubeconfigProvider) map[string]healthcheck.Check {
+	return map[string]healthcheck.Check{
+		"valid-info-kubeconfig": func() error {
+			cm, err := kubeconfigProvider.GetKubeconfig()
+			if err != nil {
+				return err
+			}
+			if len(cm.Clusters) != 1 {
+				err := errors.New("invalid kubeconfig: no clusters found")
+				glog.V(2).Info(err)
+				return err
+			}
+			for name, c := range cm.Clusters {
+				if len(c.CertificateAuthorityData) == 0 {
+					err := fmt.Errorf("invalid kubeconfig: no certificate authority data was specified for kuberconfig.clusters.['%s']", name)
+					glog.V(2).Info(err)
+					return err
+				}
+				if len(c.Server) == 0 {
+					err := fmt.Errorf("invalid kubeconfig: no server was specified for kuberconfig.clusters.['%s']", name)
+					glog.V(2).Info(err)
+					return err
+				}
+			}
+			return nil
+		},
+	}
+}
+
+// createRecorder creates a new event recorder which is later used by the leader election
+// library to broadcast events
+func createRecorder(kubeClient *kubernetes.Clientset) record.EventRecorder {
+	glog.V(4).Info("creating event broadcaster")
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.V(4).Infof)
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	return eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerName})
 }
 
 func parseClusterDNSIPs(s string) ([]net.IP, error) {
@@ -157,18 +343,4 @@ func parseClusterDNSIPs(s string) ([]net.IP, error) {
 		ips = append(ips, ip)
 	}
 	return ips, nil
-}
-
-func serveUtilHttpServer(health healthcheck.Handler) {
-	m := http.NewServeMux()
-	m.Handle("/metrics", promhttp.Handler())
-	m.Handle("/live", http.HandlerFunc(health.LiveEndpoint))
-	m.Handle("/ready", http.HandlerFunc(health.ReadyEndpoint))
-
-	s := http.Server{
-		Addr:    listenAddress,
-		Handler: m,
-	}
-	glog.V(4).Infof("serving util http server on %s", listenAddress)
-	glog.Fatalf("util http server died: %v", s.ListenAndServe())
 }


### PR DESCRIPTION
**What this PR does / why we need it**: runs the machine controller via leader election this essentially means that we can have multiple instances and at the same time only one is operational.
before we acquire a lock we actually warm up caches mirroring the state of the API server.
machine controller will be run only if a proper lock was acquired.
note that the program terminates when the leadership was lost.

**Which issue(s) this PR fixes**: Fixes #58 

