### PR TITLE
add status handling for better handling of terminating machines. Also make aws ami configurable

### DIFF
--- a/pkg/cloudprovider/instance/instance.go
+++ b/pkg/cloudprovider/instance/instance.go
@@ -5,4 +5,15 @@ type Instance interface {
 	Name() string
 	ID() string
 	Addresses() []string
+	Status() Status
 }
+
+type Status string
+
+const (
+	StatusRunning  Status = "running"
+	StatusDeleting Status = "deleting"
+	StatusDeleted  Status = "deleted"
+	StatusCreating Status = "creating"
+	StatusUnknown  Status = "unknown"
+)

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -128,12 +128,13 @@ type Config struct {
 	SubnetID string `json:"subnetId"`
 
 	InstanceType string            `json:"instanceType"`
+	AMI          string            `json:"ami"`
 	DiskSize     int64             `json:"diskSize"`
 	DiskType     string            `json:"diskType"`
 	Tags         map[string]string `json:"tags"`
 }
 
-func getAMIID(os providerconfig.OperatingSystem, region string) (string, error) {
+func getDefaultAMIID(os providerconfig.OperatingSystem, region string) (string, error) {
 	amis, osSupported := amis[os]
 	if !osSupported {
 		return "", fmt.Errorf("operating system %q not supported", os)
@@ -192,14 +193,22 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to parse config: %v", err)
 	}
 
-	_, err = getAMIID(pc.OperatingSystem, config.Region)
-	if err != nil {
-		return fmt.Errorf("invalid region+os configuration: %v", err)
-	}
-
 	ec2Client, err := getEC2client(config.AccessKeyID, config.SecretAccessKey, config.Region)
 	if err != nil {
 		return fmt.Errorf("failed to create ec2 client: %v", err)
+	}
+	if config.AMI != "" {
+		_, err := ec2Client.DescribeImages(&ec2.DescribeImagesInput{
+			ImageIds: aws.StringSlice([]string{config.AMI}),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to validate ami: %v", err)
+		}
+	} else {
+		_, err := getDefaultAMIID(pc.OperatingSystem, config.Region)
+		if err != nil {
+			return fmt.Errorf("invalid region+os configuration: %v", err)
+		}
 	}
 
 	if _, err := getVpc(ec2Client, config.VpcID); err != nil {
@@ -466,9 +475,13 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 		return nil, fmt.Errorf("failed ensure that the ssh key '%s' exists: %v", p.privateKey.Name(), err)
 	}
 
-	amiID, err := getAMIID(pc.OperatingSystem, config.Region)
-	if err != nil {
-		return nil, fmt.Errorf("invalid region+os configuration: %v", err)
+	amiID := config.AMI
+	if amiID == "" {
+		if amiID, err = getDefaultAMIID(pc.OperatingSystem, config.Region); err != nil {
+			if err != nil {
+				return nil, fmt.Errorf("invalid region+os configuration: %v", err)
+			}
+		}
 	}
 
 	tags := []*ec2.Tag{
@@ -567,14 +580,17 @@ func (p *provider) Delete(machine *v1alpha1.Machine) error {
 		return fmt.Errorf("failed to create ec2 client: %v", err)
 	}
 
-	_, err = ec2Client.TerminateInstances(&ec2.TerminateInstancesInput{
+	tOut, err := ec2Client.TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: aws.StringSlice([]string{i.ID()}),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to terminate instance: %v", err)
 	}
 
-	glog.V(4).Infof("successfully deleted instance %s at aws", i.ID())
+	if *tOut.TerminatingInstances[0].PreviousState.Name != *tOut.TerminatingInstances[0].CurrentState.Name {
+		glog.V(4).Infof("successfully triggered termination of instance %s at aws", i.ID())
+	}
+
 	return nil
 }
 
@@ -632,6 +648,21 @@ func (d *awsInstance) Addresses() []string {
 		aws.StringValue(d.instance.PublicDnsName),
 		aws.StringValue(d.instance.PrivateIpAddress),
 		aws.StringValue(d.instance.PrivateDnsName),
+	}
+}
+
+func (d *awsInstance) Status() instance.Status {
+	switch *d.instance.State.Name {
+	case ec2.InstanceStateNameRunning:
+		return instance.StatusRunning
+	case ec2.InstanceStateNamePending:
+		return instance.StatusCreating
+	case ec2.InstanceStateNameTerminated:
+		return instance.StatusDeleted
+	case ec2.InstanceStateNameShuttingDown:
+		return instance.StatusDeleting
+	default:
+		return instance.StatusUnknown
 	}
 }
 

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -333,3 +333,14 @@ func (d *doInstance) Addresses() []string {
 	}
 	return addresses
 }
+
+func (d *doInstance) Status() instance.Status {
+	switch d.droplet.Status {
+	case "new":
+		return instance.StatusCreating
+	case "active":
+		return instance.StatusRunning
+	default:
+		return instance.StatusUnknown
+	}
+}

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -273,3 +273,14 @@ func (s *hetznerServer) Addresses() []string {
 
 	return append(addresses, s.server.PublicNet.IPv4.IP.String(), s.server.PublicNet.IPv6.IP.String())
 }
+
+func (d *hetznerServer) Status() instance.Status {
+	switch d.server.Status {
+	case hcloud.ServerStatusInitializing:
+		return instance.StatusCreating
+	case hcloud.ServerStatusRunning:
+		return instance.StatusRunning
+	default:
+		return instance.StatusUnknown
+	}
+}

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -477,3 +477,14 @@ func (d *osInstance) Addresses() []string {
 
 	return addresses
 }
+
+func (d *osInstance) Status() instance.Status {
+	switch d.server.Status {
+	case "IN_PROGRESS":
+		return instance.StatusCreating
+	case "ACTIVE":
+		return instance.StatusRunning
+	default:
+		return instance.StatusUnknown
+	}
+}

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -61,7 +61,7 @@ const (
 	finalizerDeleteInstance = "machine-delete-finalizer"
 
 	metricsUpdatePeriod     = 10 * time.Second
-	deletionRetryWaitPeriod = 1 * time.Second
+	deletionRetryWaitPeriod = 5 * time.Second
 
 	machineKind = "Machine"
 )
@@ -276,6 +276,11 @@ func (c *Controller) syncHandler(key string) error {
 
 		//Check that the instance has really gone
 		if providerInstance, err = c.getProviderInstance(prov, machine); err == nil {
+			if sets.NewString(string(instance.StatusDeleted), string(instance.StatusDeleting)).Has(string(providerInstance.Status())) {
+				glog.V(4).Infof("deletion of instance %s got triggered. Waiting until it fully disappears", providerInstance.ID())
+				c.workqueue.AddAfter(machine.Name, deletionRetryWaitPeriod)
+				return nil
+			}
 			glog.V(2).Infof("instance %s of machine %s is not deleted yet", providerInstance.ID(), machine.Name)
 			c.workqueue.AddAfter(machine.Name, deletionRetryWaitPeriod)
 			return nil

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -27,6 +27,7 @@ type fakeInstance struct {
 	name      string
 	id        string
 	addresses []string
+	status    instance.Status
 }
 
 func (i *fakeInstance) Name() string {
@@ -35,6 +36,10 @@ func (i *fakeInstance) Name() string {
 
 func (i *fakeInstance) ID() string {
 	return i.id
+}
+
+func (i *fakeInstance) Status() instance.Status {
+	return i.status
 }
 
 func (i *fakeInstance) Addresses() []string {


### PR DESCRIPTION
**What this PR does / why we need it**:
- Makes aws ami configurable
- Improves aws instance deletion.
AWS instances stay for longer as they go into a `terminated` state for a few minutes when they get deleted.

Fixes #93