### PR TITLE
Allow machine-controller to create events

### DIFF
--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -84,6 +84,7 @@ rules:
   - ""
   resources:
   - secrets
+  - events
   verbs:
   - create
 - apiGroups:


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes `round_trippers.go:436] POST https://10.96.0.1:443/api/v1/namespaces/kube-system/events 403 Forbidden in 2 milliseconds`