### PR TITLE
setting read/write http timeouts

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -362,8 +362,10 @@ func createUtilHttpServer(kubeClient *kubernetes.Clientset, kubeconfigProvider c
 	m.Handle("/ready", http.HandlerFunc(health.ReadyEndpoint))
 
 	return &http.Server{
-		Addr:    listenAddress,
-		Handler: m,
+		Addr:         listenAddress,
+		Handler:      m,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: this pr sets read and write http timeouts. As by default these timeouts are off, it means that clients can hold up connections indefinitely this in turn can potentially use up all available connections in a pool.