### PR TITLE
Fix cri-o by using versioned meta package

### DIFF
--- a/pkg/userdata/ubuntu/crio.go
+++ b/pkg/userdata/ubuntu/crio.go
@@ -6,9 +6,9 @@ import (
 
 var crioInstallCandidates = []installCandidate{
 	{
-		versions:   []string{"1.9", "1.9.2"},
-		pkg:        "cri-o",
-		pkgVersion: "1.9.2-1~ubuntu16.04.2~ppa1",
+		versions:   []string{"1.9"},
+		pkg:        "cri-o-1.9",
+		pkgVersion: "",
 	},
 }
 

--- a/pkg/userdata/ubuntu/crio_test.go
+++ b/pkg/userdata/ubuntu/crio_test.go
@@ -23,18 +23,11 @@ func TestGetCRIOInstallCandidate(t *testing.T) {
 			resVer:  "",
 		},
 		{
-			name:    "get patch version",
-			version: "1.9.2",
-			resErr:  nil,
-			resPkg:  "cri-o",
-			resVer:  "1.9.2-1~ubuntu16.04.2~ppa1",
-		},
-		{
 			name:    "get minor version",
 			version: "1.9",
 			resErr:  nil,
-			resPkg:  "cri-o",
-			resVer:  "1.9.2-1~ubuntu16.04.2~ppa1",
+			resPkg:  "cri-o-1.9",
+			resVer:  "",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/userdata/ubuntu/userdata.go
+++ b/pkg/userdata/ubuntu/userdata.go
@@ -332,6 +332,9 @@ packages:
 - "socat"
 - "util-linux"
 {{- if .CRAptPackage }}
+{{- if ne .CRAptPackageVersion "" }}
 - ["{{ .CRAptPackage }}", "{{ .CRAptPackageVersion }}"]
-{{- end }}
+{{- else }}
+- "{{ .CRAptPackage }}"
+{{- end }}{{ end }}
 `

--- a/pkg/userdata/ubuntu/userdata_test.go
+++ b/pkg/userdata/ubuntu/userdata_test.go
@@ -460,7 +460,7 @@ packages:
 - "nfs-common"
 - "socat"
 - "util-linux"
-- ["cri-o", "1.9.2-1~ubuntu16.04.2~ppa1"]
+- "cri-o-1.9"
 `
 
 	docker1703DistupgradeOpenstack = `#cloud-config


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Manually verified this by running e2e tests  with cri-o instead of docker:

```
root@machine-controller-test-local ~ # kubectl get nodes testnode-local -o yaml|grep -i cr
  creationTimestamp: 2018-03-10T13:26:22Z
    - gcr.io/google_containers/kube-proxy-amd64@sha256:19277373ca983423c3ff82dbb14f079a2f37b84926a4c569375314fa39a4ee96
    - gcr.io/google_containers/kube-proxy-amd64:v1.9.3
    containerRuntimeVersion: cri-o://1.9.9
```