### PR TITLE
Deploy K8s CACert with kubelet and use it to verify requests

### DIFF
--- a/pkg/clusterinfo/configmap.go
+++ b/pkg/clusterinfo/configmap.go
@@ -45,6 +45,22 @@ func (p *KubeconfigProvider) GetKubeconfig() (*clientcmdapi.Config, error) {
 	return cm, nil
 }
 
+func (p *KubeconfigProvider) GetCACert() (string, error) {
+	//Need the kubeconfig to extract the CACert for the userdata rendering
+	cm, err := p.GetKubeconfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to get kubeconfig: '%v'", err)
+	}
+	if len(cm.Clusters) != 1 {
+		return "", fmt.Errorf("kubeconfig does not contain exactly one cluster, can not extract cacert...")
+	}
+	for _, clusterConfig := range cm.Clusters {
+		return string(clusterConfig.CertificateAuthorityData), nil
+	}
+
+	return "", fmt.Errorf("No CACert found!")
+}
+
 func (p *KubeconfigProvider) getKubeconfigFromConfigMap() (*clientcmdapi.Config, error) {
 	cm, err := p.configMapLister.ConfigMaps(metav1.NamespacePublic).Get(configMapName)
 	if err != nil {

--- a/pkg/clusterinfo/configmap.go
+++ b/pkg/clusterinfo/configmap.go
@@ -58,7 +58,7 @@ func (p *KubeconfigProvider) GetCACert() (string, error) {
 		return string(clusterConfig.CertificateAuthorityData), nil
 	}
 
-	return "", fmt.Errorf("No CACert found!")
+	return "", fmt.Errorf("no CACert found!")
 }
 
 func (p *KubeconfigProvider) getKubeconfigFromConfigMap() (*clientcmdapi.Config, error) {

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -86,6 +86,7 @@ type Controller struct {
 
 type KubeconfigProvider interface {
 	GetKubeconfig() (*clientcmdapi.Config, error)
+	GetCACert() (string, error)
 }
 
 // MetricsCollection is a struct of all metrics used in
@@ -404,24 +405,17 @@ func (c *Controller) syncHandler(key string) error {
 					return fmt.Errorf("failed to create bootstrap kubeconfig: %v", err)
 				}
 
-				//Need the kubeconfig to extract the CACert for the userdata rendering
-				cm, err := c.kubeconfigProvider.GetKubeconfig()
+				clusterCACert, err := c.kubeconfigProvider.GetCACert()
 				if err != nil {
-					return fmt.Errorf("failed to get kubeconfig: '%v'", err)
+					return fmt.Errorf("Error getting CACert: '%v'", err)
 				}
-				if len(cm.Clusters) != 1 {
-					return fmt.Errorf("kubeconfig does not contain exactly one cluster, can not extract cacert...")
-				}
-				var userData string
-				for _, clusterConfig := range cm.Clusters {
-					userData, err = userdataProvider.UserData(machine.Spec, kubeconfig, prov, c.clusterDNSIPs, string(clusterConfig.CertificateAuthorityData))
-					if err != nil {
-						return fmt.Errorf("failed get userdata: %v", err)
-					}
+				userdata, err := userdataProvider.UserData(machine.Spec, kubeconfig, prov, c.clusterDNSIPs, clusterCACert)
+				if err != nil {
+					return fmt.Errorf("failed get userdata: %v", err)
 				}
 
 				glog.Infof("creating instance...")
-				if providerInstance, err = c.createProviderInstance(prov, machine, userData); err != nil {
+				if providerInstance, err = c.createProviderInstance(prov, machine, userdata); err != nil {
 					if _, errNested := c.updateMachineError(machine, machinev1alpha1.CreateMachineError, err.Error()); errNested != nil {
 						return fmt.Errorf("failed to update machine error after failed machine creation: %v", errNested)
 					}

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -407,7 +407,7 @@ func (c *Controller) syncHandler(key string) error {
 
 				clusterCACert, err := c.kubeconfigProvider.GetCACert()
 				if err != nil {
-					return fmt.Errorf("Error getting CACert: '%v'", err)
+					return fmt.Errorf("error getting CACert: '%v'", err)
 				}
 				userdata, err := userdataProvider.UserData(machine.Spec, kubeconfig, prov, c.clusterDNSIPs, clusterCACert)
 				if err != nil {

--- a/pkg/userdata/coreos/userdata.go
+++ b/pkg/userdata/coreos/userdata.go
@@ -55,8 +55,7 @@ func (p Provider) SupportedContainerRuntimes() (runtimes []machinesv1alpha1.Cont
 	}
 }
 
-func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string, ccProvider cloud.ConfigProvider, clusterDNSIPs []net.IP, caCert string) (string, error) {
-	_ = caCert
+func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string, ccProvider cloud.ConfigProvider, clusterDNSIPs []net.IP, kubernetesCACert string) (string, error) {
 	tmpl, err := template.New("user-data").Funcs(machinetemplate.TxtFuncMap()).Parse(ctTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse user-data template: %v", err)
@@ -91,6 +90,7 @@ func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string,
 		CloudConfig       string
 		HyperkubeImageTag string
 		ClusterDNSIPs     []net.IP
+		KubernetesCACert  string
 	}{
 		MachineSpec:       spec,
 		ProviderConfig:    pconfig,
@@ -100,6 +100,7 @@ func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string,
 		CloudConfig:       cpConfig,
 		HyperkubeImageTag: fmt.Sprintf("v%s_coreos.0", kubeletVersion.String()),
 		ClusterDNSIPs:     clusterDNSIPs,
+		KubernetesCACert:  kubernetesCACert,
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -197,7 +198,9 @@ systemd:
           --lock-file=/var/run/lock/kubelet.lock \
           --exit-on-lock-contention \
           --read-only-port 0 \
-          --authorization-mode=Webhook
+          --authorization-mode=Webhook \
+          --anonymous-auth=false \
+          --client-ca-file=/etc/kubernetes/ca.crt
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -219,6 +222,13 @@ storage:
       contents:
         inline: |
 {{ .CloudConfig | indent 10 }}
+
+    - path: /etc/kubernetes/ca.crt
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+{{ .KubernetesCACert | indent 10 }}
 
 {{- if contains "1.12" .MachineSpec.Versions.ContainerRuntime.Version }}
     - path: /etc/coreos/docker-1.12

--- a/pkg/userdata/coreos/userdata.go
+++ b/pkg/userdata/coreos/userdata.go
@@ -55,7 +55,8 @@ func (p Provider) SupportedContainerRuntimes() (runtimes []machinesv1alpha1.Cont
 	}
 }
 
-func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string, ccProvider cloud.ConfigProvider, clusterDNSIPs []net.IP) (string, error) {
+func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string, ccProvider cloud.ConfigProvider, clusterDNSIPs []net.IP, caCert string) (string, error) {
+	_ = caCert
 	tmpl, err := template.New("user-data").Funcs(machinetemplate.TxtFuncMap()).Parse(ctTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse user-data template: %v", err)

--- a/pkg/userdata/ubuntu/userdata.go
+++ b/pkg/userdata/ubuntu/userdata.go
@@ -54,7 +54,8 @@ func (p Provider) SupportedContainerRuntimes() (runtimes []machinesv1alpha1.Cont
 	return runtimes
 }
 
-func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string, ccProvider cloud.ConfigProvider, clusterDNSIPs []net.IP) (string, error) {
+func (p Provider) UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string, ccProvider cloud.ConfigProvider, clusterDNSIPs []net.IP, caCert string) (string, error) {
+	_ = caCert
 	tmpl, err := template.New("user-data").Funcs(machinetemplate.TxtFuncMap()).Parse(ctTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse user-data template: %v", err)

--- a/pkg/userdata/userdata.go
+++ b/pkg/userdata/userdata.go
@@ -28,6 +28,6 @@ func ForOS(os providerconfig.OperatingSystem) (Provider, error) {
 }
 
 type Provider interface {
-	UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string, ccProvider cloud.ConfigProvider, clusterDNSIPs []net.IP) (string, error)
+	UserData(spec machinesv1alpha1.MachineSpec, kubeconfig string, ccProvider cloud.ConfigProvider, clusterDNSIPs []net.IP, caCert string) (string, error)
 	SupportedContainerRuntimes() []machinesv1alpha1.ContainerRuntimeInfo
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow the API server to authenticate itself as valid client for the Kubelets REST api

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I manually verified logs and exec through the APIserver work again but do not work when just curling the Kubelet.