### PR TITLE
reads some fields of cloudProviderSpec from env variables.

### DIFF
--- a/examples/machine-aws.yaml
+++ b/examples/machine-aws.yaml
@@ -22,11 +22,13 @@ spec:
       - "<< YOUR_PUBLIC_KEY >>"
     cloudProvider: "aws"
     cloudProviderSpec:
+    # If empty, can be set via AWS_ACCESS_KEY_ID env var
       accessKeyId:
         secretKeyRef:
           namespace: kube-system
           name: machine-controller-aws
           key: accessKeyId
+    # If empty, can be set via AWS_SECRET_ACCESS_KEY env var
       secretAccessKey:
         secretKeyRef:
           namespace: kube-system

--- a/examples/machine-digitalocean.yaml
+++ b/examples/machine-digitalocean.yaml
@@ -21,6 +21,7 @@ spec:
       - "<< YOUR_PUBLIC_KEY >>"
     cloudProvider: "digitalocean"
     cloudProviderSpec:
+    # If empty, can be set via DO_TOKEN env var
       token:
         secretKeyRef:
           namespace: kube-system

--- a/examples/machine-hetzner.yaml
+++ b/examples/machine-hetzner.yaml
@@ -21,6 +21,7 @@ spec:
       - "<< YOUR_PUBLIC_KEY >>"
     cloudProvider: "hetzner"
     cloudProviderSpec:
+    # If empty, can be set via HZ_TOKEN env var
       token:
         secretKeyRef:
           namespace: kube-system

--- a/examples/machine-openstack.yaml
+++ b/examples/machine-openstack.yaml
@@ -35,26 +35,31 @@ spec:
       - "<< YOUR_PUBLIC_KEY >>"
     cloudProvider: "openstack"
     cloudProviderSpec:
+    # If empty, ca be set via OS_AUTH_URL env var
       identityEndpoint:
         secretKeyRef:
           namespace: kube-system
           name: machine-controller-openstack
           key: identityEndpoint
+    # If empty, ca be set via OS_USER_NAME env var
       username:
         secretKeyRef:
           namespace: kube-system
           name: machine-controller-openstack
           key: username
+    # If empty, ca be set via OS_PASSWORD env var
       password:
         secretKeyRef:
           namespace: kube-system
           name: machine-controller-openstack
           key: password
+    # If empty, ca be set via OS_DOMAIN_NAME env var
       domainName:
         secretKeyRef:
           namespace: kube-system
           name: machine-controller-openstack
           key: domainName
+    # If empty, ca be set via OS_TENANT_NAME env var
       tenantName:
         secretKeyRef:
           namespace: kube-system

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -189,13 +189,13 @@ func (p *provider) getConfig(s runtime.RawExtension) (*Config, *providerconfig.C
 	rawConfig := RawConfig{}
 	err = json.Unmarshal(pconfig.CloudProviderSpec.Raw, &rawConfig)
 	c := Config{}
-	c.AccessKeyID, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.AccessKeyID)
+	c.AccessKeyID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.AccessKeyID, "AWS_ACCESS_KEY_ID")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get the value of \"accessKeyId\" field, error = %v", err)
 	}
-	c.SecretAccessKey, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.SecretAccessKey)
+	c.SecretAccessKey, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.SecretAccessKey, "AWS_SECRET_ACCESS_KEY")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get the value of \"secretAccessKey\" field, error = %v", err)
 	}
 	c.Region, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Region)
 	if err != nil {

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -111,9 +111,9 @@ func (p *provider) getConfig(s runtime.RawExtension) (*Config, *providerconfig.C
 	}
 
 	c := Config{}
-	c.Token, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Token)
+	c.Token, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Token, "DO_TOKEN")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get the value of \"token\" field, error = %v", err)
 	}
 	c.Region, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Region)
 	if err != nil {

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -72,9 +72,9 @@ func (p *provider) getConfig(s runtime.RawExtension) (*Config, *providerconfig.C
 	err = json.Unmarshal(pconfig.CloudProviderSpec.Raw, &rawConfig)
 
 	c := Config{}
-	c.Token, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Token)
+	c.Token, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Token, "HZ_TOKEN")
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get the value of \"token\" field, error = %v", err)
 	}
 	c.ServerType, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.ServerType)
 	if err != nil {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -95,25 +95,25 @@ func (p *provider) getConfig(s runtime.RawExtension) (*Config, *providerconfig.C
 		return nil, nil, nil, err
 	}
 	c := Config{}
-	c.IdentityEndpoint, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.IdentityEndpoint)
+	c.IdentityEndpoint, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.IdentityEndpoint, "OS_AUTH_URL")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to get the value of \"identityEndpoint\" field, error = %v", err)
 	}
-	c.Username, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Username)
+	c.Username, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Username, "OS_USER_NAME")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to get the value of \"username\" field, error = %v", err)
 	}
-	c.Password, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Password)
+	c.Password, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Password, "OS_PASSWORD")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to get the value of \"password\" field, error = %v", err)
 	}
-	c.DomainName, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.DomainName)
+	c.DomainName, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.DomainName, "OS_DOMAIN_NAME")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to get the value of \"domainName\" field, error = %v", err)
 	}
-	c.TenantName, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.TenantName)
+	c.TenantName, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantName, "OS_TENANT_NAME")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, fmt.Errorf("failed to get the value of \"tenantName\" field, error = %v", err)
 	}
 	c.TokenID, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.TokenID)
 	if err != nil {

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -171,7 +171,7 @@ func (configVarResolver *ConfigVarResolver) GetConfigVarStringValueOrEnv(configV
 
 	envVal, envValFound := os.LookupEnv(envVarName)
 	if !envValFound {
-		return "", fmt.Errorf("all machanisms(value, secret, configMap) of getting the value failed, including reading from environment varialbe = %s which was not set", envVarName)
+		return "", fmt.Errorf("all machanisms(value, secret, configMap) of getting the value failed, including reading from environment variable = %s which was not set", envVarName)
 	}
 	return envVal, nil
 }

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"os"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -157,6 +159,21 @@ func (configVarResolver *ConfigVarResolver) GetConfigVarStringValue(configVar Co
 	}
 
 	return configVar.Value, nil
+}
+
+// GetConfigVarStringValueOrEvn tries to get the value from ConfigVarString, when it fails, it falls back to
+// getting the value from an environment variable specified by envVarName parameter
+func (configVarResolver *ConfigVarResolver) GetConfigVarStringValueOrEnv(configVar ConfigVarString, envVarName string) (string, error) {
+	cfgVar, err := configVarResolver.GetConfigVarStringValue(configVar)
+	if err == nil && len(cfgVar) > 0 {
+		return cfgVar, err
+	}
+
+	envVal, envValFound := os.LookupEnv(envVarName)
+	if !envValFound {
+		return "", fmt.Errorf("all machanisms(value, secret, configMap) of getting the value failed, including reading from environment varialbe = %s which was not set", envVarName)
+	}
+	return envVal, nil
 }
 
 func (configVarResolver *ConfigVarResolver) GetConfigVarBoolValue(configVar ConfigVarBool) (bool, error) {


### PR DESCRIPTION
**What this PR does / why we need it**: reads some fields of cloudProviderSpec from env variables.
the names of variables are hardcoded in the source code and cannot be changed.
there are other mechanisms through which the fields can be set, we only fallback
to reading from env variables when all fails.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #123 

**Special notes for your reviewer**:
