### PR TITLE
implements E2E tests for machine controller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,8 @@ jobs:
           name: Test create and destroy ubuntu on vsphere
           command: ./test/tools/integration/create-and-destroy-machine.sh ubuntu vsphere
       - run:
-          name: Test create and destroy ubuntu machine
-          command: ./test/tools/integration/create-and-destroy-machine.sh
+          name:  Run E2E test
+          command: ./test/tools/integration/run_e2e_tests.sh
       - run:
           name: Test create and destroy centos machine
           command: ./test/tools/integration/create-and-destroy-machine.sh centos

--- a/test/e2e/provisioning/aws_e2e_test.go
+++ b/test/e2e/provisioning/aws_e2e_test.go
@@ -1,0 +1,102 @@
+// +build e2e
+
+package provisioning
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+const (
+	aws_manifest = "./testdata/machine-aws.yaml"
+)
+
+var awsScenarios = []struct {
+	// name holds short description of the test scenario, it is also used to create machines and nodes names
+	// so please don't put "strange" characters there
+	name                    string
+	osName                  string
+	containerRuntime        string
+	containerRuntimeVersion string
+	// if the -short flag was provided and this variable is set
+	// the test scenario will be run otherwise it will be skipped.
+	short bool
+}{
+	{
+		name:                    "scenario 1 Ubuntu Docker 1.13",
+		osName:                  "ubuntu",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "1.13",
+		short: true,
+	},
+
+	{
+		name:                    "scenario 2 Ubuntu Docker 17.03",
+		osName:                  "ubuntu",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "17.03",
+	},
+
+	{
+		name:                    "scenario 3 Ubuntu CRI-O 1.9",
+		osName:                  "ubuntu",
+		containerRuntime:        "cri-o",
+		containerRuntimeVersion: "1.9",
+	},
+
+	{
+		name:                    "scenario 4 CoreOS Docker 1.13",
+		osName:                  "coreos",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "1.13",
+	},
+
+	{
+		name:                    "scenario 5 CoreOS Docker 17.03",
+		osName:                  "coreos",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "17.03",
+	},
+}
+
+// TestAWSProvisioning - a test suite that exercises AWS provider
+// by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
+func TestAWSProvisioningE2E(t *testing.T) {
+	if testing.Short() {
+		t.Parallel()
+	}
+
+	// test data
+	awsKeyID := os.Getenv("AWS_E2E_TESTS_KEY_ID")
+	awsSecret := os.Getenv("AWS_E2E_TESTS_SECRET")
+	if len(awsKeyID) == 0 || len(awsSecret) == 0 {
+		t.Fatal("unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
+	}
+
+	// act
+	for _, scenario := range awsScenarios {
+		scenario := scenario // capture range variable
+		t.Run(scenario.name, func(t *testing.T) {
+			if testing.Short() == true && scenario.short == false {
+				t.SkipNow()
+			}
+			t.Parallel()
+
+			nameSufix := strings.Replace(scenario.name, " ", "-", -1)
+			nameSufix = strings.ToLower(nameSufix)
+			nameSufix = fmt.Sprintf("aws-%s", nameSufix)
+			machineName := fmt.Sprintf("machine-%s", nameSufix)
+			nodeName := fmt.Sprintf("node-%s", nameSufix)
+			params := fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s,<< AWS_SECRET_ACCESS_KEY >>=%s", awsKeyID, awsSecret)
+			params = fmt.Sprintf("%s,<< MACHINE_NAME >>=%s,<< NODE_NAME >>=%s", params, machineName, nodeName)
+			params = fmt.Sprintf("%s,<< OS_NAME >>=%s,<< CONTAINER_RUNTIME >>=%s,<< CONTAINER_RUNTIME_VERSION >>=%s", params, scenario.osName, scenario.containerRuntime, scenario.containerRuntimeVersion)
+
+			err := runVerifyTool(aws_manifest, params)
+			if err != nil {
+				t.Errorf("verify tool failed due to %v", err)
+			}
+		})
+	}
+}

--- a/test/e2e/provisioning/aws_e2e_test.go
+++ b/test/e2e/provisioning/aws_e2e_test.go
@@ -5,7 +5,6 @@ package provisioning
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -13,13 +12,12 @@ const (
 	aws_manifest = "./testdata/machine-aws.yaml"
 )
 
-var awsScenarios = []scenarios{
+var awsScenarios = []scenario{
 	{
 		name:                    "scenario 1 Ubuntu Docker 1.13",
 		osName:                  "ubuntu",
 		containerRuntime:        "docker",
 		containerRuntimeVersion: "1.13",
-		short: true,
 	},
 
 	{
@@ -64,27 +62,6 @@ func TestAWSProvisioningE2E(t *testing.T) {
 	}
 
 	// act
-	for _, scenario := range awsScenarios {
-		scenario := scenario // capture range variable
-		t.Run(scenario.name, func(t *testing.T) {
-			if testing.Short() == true && scenario.short == false {
-				t.SkipNow()
-			}
-			t.Parallel()
-
-			nameSufix := strings.Replace(scenario.name, " ", "-", -1)
-			nameSufix = strings.ToLower(nameSufix)
-			nameSufix = fmt.Sprintf("aws-%s", nameSufix)
-			machineName := fmt.Sprintf("machine-%s", nameSufix)
-			nodeName := fmt.Sprintf("node-%s", nameSufix)
-			params := fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s,<< AWS_SECRET_ACCESS_KEY >>=%s", awsKeyID, awsSecret)
-			params = fmt.Sprintf("%s,<< MACHINE_NAME >>=%s,<< NODE_NAME >>=%s", params, machineName, nodeName)
-			params = fmt.Sprintf("%s,<< OS_NAME >>=%s,<< CONTAINER_RUNTIME >>=%s,<< CONTAINER_RUNTIME_VERSION >>=%s", params, scenario.osName, scenario.containerRuntime, scenario.containerRuntimeVersion)
-
-			err := runVerifyTool(aws_manifest, params)
-			if err != nil {
-				t.Errorf("verify tool failed due to %v", err)
-			}
-		})
-	}
+	params := fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s,<< AWS_SECRET_ACCESS_KEY >>=%s", awsKeyID, awsSecret)
+	runScenarios(t, awsScenarios, params, aws_manifest, "aws")
 }

--- a/test/e2e/provisioning/aws_e2e_test.go
+++ b/test/e2e/provisioning/aws_e2e_test.go
@@ -54,9 +54,7 @@ var awsScenarios = []scenarios{
 // TestAWSProvisioning - a test suite that exercises AWS provider
 // by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
 func TestAWSProvisioningE2E(t *testing.T) {
-	if testing.Short() {
-		t.Parallel()
-	}
+	t.Parallel()
 
 	// test data
 	awsKeyID := os.Getenv("AWS_E2E_TESTS_KEY_ID")

--- a/test/e2e/provisioning/aws_e2e_test.go
+++ b/test/e2e/provisioning/aws_e2e_test.go
@@ -12,43 +12,6 @@ const (
 	aws_manifest = "./testdata/machine-aws.yaml"
 )
 
-var awsScenarios = []scenario{
-	{
-		name:                    "scenario 1 Ubuntu Docker 1.13",
-		osName:                  "ubuntu",
-		containerRuntime:        "docker",
-		containerRuntimeVersion: "1.13",
-	},
-
-	{
-		name:                    "scenario 2 Ubuntu Docker 17.03",
-		osName:                  "ubuntu",
-		containerRuntime:        "docker",
-		containerRuntimeVersion: "17.03",
-	},
-
-	{
-		name:                    "scenario 3 Ubuntu CRI-O 1.9",
-		osName:                  "ubuntu",
-		containerRuntime:        "cri-o",
-		containerRuntimeVersion: "1.9",
-	},
-
-	{
-		name:                    "scenario 4 CoreOS Docker 1.13",
-		osName:                  "coreos",
-		containerRuntime:        "docker",
-		containerRuntimeVersion: "1.13",
-	},
-
-	{
-		name:                    "scenario 5 CoreOS Docker 17.03",
-		osName:                  "coreos",
-		containerRuntime:        "docker",
-		containerRuntimeVersion: "17.03",
-	},
-}
-
 // TestAWSProvisioning - a test suite that exercises AWS provider
 // by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
 func TestAWSProvisioningE2E(t *testing.T) {
@@ -63,5 +26,5 @@ func TestAWSProvisioningE2E(t *testing.T) {
 
 	// act
 	params := fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s,<< AWS_SECRET_ACCESS_KEY >>=%s", awsKeyID, awsSecret)
-	runScenarios(t, awsScenarios, params, aws_manifest, "aws")
+	runScenarios(t, scenarios, params, aws_manifest, "aws")
 }

--- a/test/e2e/provisioning/aws_e2e_test.go
+++ b/test/e2e/provisioning/aws_e2e_test.go
@@ -13,17 +13,7 @@ const (
 	aws_manifest = "./testdata/machine-aws.yaml"
 )
 
-var awsScenarios = []struct {
-	// name holds short description of the test scenario, it is also used to create machines and nodes names
-	// so please don't put "strange" characters there
-	name                    string
-	osName                  string
-	containerRuntime        string
-	containerRuntimeVersion string
-	// if the -short flag was provided and this variable is set
-	// the test scenario will be run otherwise it will be skipped.
-	short bool
-}{
+var awsScenarios = []scenarios{
 	{
 		name:                    "scenario 1 Ubuntu Docker 1.13",
 		osName:                  "ubuntu",

--- a/test/e2e/provisioning/digital_ocean_e2e_test.go
+++ b/test/e2e/provisioning/digital_ocean_e2e_test.go
@@ -56,9 +56,7 @@ var digitalOceanScenarios = []scenarios{
 //
 // note that tests require  a valid API Token that is read from the DO_E2E_TEST_TOKEN environmental variable.
 func TestDigitalOceanProvisioningE2E(t *testing.T) {
-	if testing.Short() {
-		t.Parallel()
-	}
+	t.Parallel()
 
 	// test data
 	doToken := os.Getenv("DO_E2E_TESTS_TOKEN")

--- a/test/e2e/provisioning/digital_ocean_e2e_test.go
+++ b/test/e2e/provisioning/digital_ocean_e2e_test.go
@@ -13,17 +13,7 @@ const (
 	do_manifest = "./testdata/machine-digitalocean.yaml"
 )
 
-var digitalOceanScenarios = []struct {
-	// name holds short description of the test scenario, it is also used to create machines and nodes names
-	// so please don't put "strange" characters there
-	name                    string
-	osName                  string
-	containerRuntime        string
-	containerRuntimeVersion string
-	// if the -short flag was provided and this variable is set
-	// the test scenario will be run otherwise it will be skipped.
-	short bool
-}{
+var digitalOceanScenarios = []scenarios{
 	{
 		name:                    "scenario 1 Ubuntu Docker 1.13",
 		osName:                  "ubuntu",

--- a/test/e2e/provisioning/digital_ocean_e2e_test.go
+++ b/test/e2e/provisioning/digital_ocean_e2e_test.go
@@ -1,0 +1,102 @@
+// +build e2e
+
+package provisioning
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+const (
+	do_manifest = "./testdata/machine-digitalocean.yaml"
+)
+
+var digitalOceanScenarios = []struct {
+	// name holds short description of the test scenario, it is also used to create machines and nodes names
+	// so please don't put "strange" characters there
+	name                    string
+	osName                  string
+	containerRuntime        string
+	containerRuntimeVersion string
+	// if the -short flag was provided and this variable is set
+	// the test scenario will be run otherwise it will be skipped.
+	short bool
+}{
+	{
+		name:                    "scenario 1 Ubuntu Docker 1.13",
+		osName:                  "ubuntu",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "1.13",
+		short: true,
+	},
+
+	{
+		name:                    "scenario 2 Ubuntu Docker 17.03",
+		osName:                  "ubuntu",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "17.03",
+	},
+
+	{
+		name:                    "scenario 3 Ubuntu CRI-O 1.9",
+		osName:                  "ubuntu",
+		containerRuntime:        "cri-o",
+		containerRuntimeVersion: "1.9",
+	},
+
+	{
+		name:                    "scenario 4 CoreOS Docker 1.13",
+		osName:                  "coreos",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "1.13",
+	},
+
+	{
+		name:                    "scenario 5 CoreOS Docker 17.03",
+		osName:                  "coreos",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "17.03",
+	},
+}
+
+// TestDigitalOceanProvisioning - a test suite that exercises digital ocean provider
+// by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
+//
+// note that tests require  a valid API Token that is read from the DO_E2E_TEST_TOKEN environmental variable.
+func TestDigitalOceanProvisioningE2E(t *testing.T) {
+	if testing.Short() {
+		t.Parallel()
+	}
+
+	// test data
+	doToken := os.Getenv("DO_E2E_TESTS_TOKEN")
+	if len(doToken) == 0 {
+		t.Fatal("unable to run the test suite, DO_E2E_TESTS_TOKEN environement varialbe cannot be empty")
+	}
+
+	// act
+	for _, scenario := range digitalOceanScenarios {
+		scenario := scenario // capture range variable
+		t.Run(scenario.name, func(t *testing.T) {
+			if testing.Short() == true && scenario.short == false {
+				t.SkipNow()
+			}
+			t.Parallel()
+
+			nameSufix := strings.Replace(scenario.name, " ", "-", -1)
+			nameSufix = strings.ToLower(nameSufix)
+			nameSufix = fmt.Sprintf("do-%s", nameSufix)
+			machineName := fmt.Sprintf("machine-%s", nameSufix)
+			nodeName := fmt.Sprintf("node-%s", nameSufix)
+			params := fmt.Sprintf("<< MACHINE_NAME >>=%s,<< DIGITALOCEAN_TOKEN >>=%s,<< NODE_NAME >>=%s", machineName, doToken, nodeName)
+			params = fmt.Sprintf("%s,<< OS_NAME >>=%s,<< CONTAINER_RUNTIME >>=%s,<< CONTAINER_RUNTIME_VERSION >>=%s", params, scenario.osName, scenario.containerRuntime, scenario.containerRuntimeVersion)
+
+			err := runVerifyTool(do_manifest, params)
+			if err != nil {
+				t.Errorf("verify tool failed due to %v", err)
+			}
+		})
+	}
+}

--- a/test/e2e/provisioning/digital_ocean_e2e_test.go
+++ b/test/e2e/provisioning/digital_ocean_e2e_test.go
@@ -12,43 +12,6 @@ const (
 	do_manifest = "./testdata/machine-digitalocean.yaml"
 )
 
-var digitalOceanScenarios = []scenario{
-	{
-		name:                    "scenario 1 Ubuntu Docker 1.13",
-		osName:                  "ubuntu",
-		containerRuntime:        "docker",
-		containerRuntimeVersion: "1.13",
-	},
-
-	{
-		name:                    "scenario 2 Ubuntu Docker 17.03",
-		osName:                  "ubuntu",
-		containerRuntime:        "docker",
-		containerRuntimeVersion: "17.03",
-	},
-
-	{
-		name:                    "scenario 3 Ubuntu CRI-O 1.9",
-		osName:                  "ubuntu",
-		containerRuntime:        "cri-o",
-		containerRuntimeVersion: "1.9",
-	},
-
-	{
-		name:                    "scenario 4 CoreOS Docker 1.13",
-		osName:                  "coreos",
-		containerRuntime:        "docker",
-		containerRuntimeVersion: "1.13",
-	},
-
-	{
-		name:                    "scenario 5 CoreOS Docker 17.03",
-		osName:                  "coreos",
-		containerRuntime:        "docker",
-		containerRuntimeVersion: "17.03",
-	},
-}
-
 // TestDigitalOceanProvisioning - a test suite that exercises digital ocean provider
 // by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
 //
@@ -64,5 +27,5 @@ func TestDigitalOceanProvisioningE2E(t *testing.T) {
 
 	// act
 	params := fmt.Sprintf("<< DIGITALOCEAN_TOKEN >>=%s", doToken)
-	runScenarios(t, digitalOceanScenarios, params, do_manifest, "do")
+	runScenarios(t, scenarios, params, do_manifest, "do")
 }

--- a/test/e2e/provisioning/digital_ocean_e2e_test.go
+++ b/test/e2e/provisioning/digital_ocean_e2e_test.go
@@ -5,7 +5,6 @@ package provisioning
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -13,13 +12,12 @@ const (
 	do_manifest = "./testdata/machine-digitalocean.yaml"
 )
 
-var digitalOceanScenarios = []scenarios{
+var digitalOceanScenarios = []scenario{
 	{
 		name:                    "scenario 1 Ubuntu Docker 1.13",
 		osName:                  "ubuntu",
 		containerRuntime:        "docker",
 		containerRuntimeVersion: "1.13",
-		short: true,
 	},
 
 	{
@@ -65,26 +63,6 @@ func TestDigitalOceanProvisioningE2E(t *testing.T) {
 	}
 
 	// act
-	for _, scenario := range digitalOceanScenarios {
-		scenario := scenario // capture range variable
-		t.Run(scenario.name, func(t *testing.T) {
-			if testing.Short() == true && scenario.short == false {
-				t.SkipNow()
-			}
-			t.Parallel()
-
-			nameSufix := strings.Replace(scenario.name, " ", "-", -1)
-			nameSufix = strings.ToLower(nameSufix)
-			nameSufix = fmt.Sprintf("do-%s", nameSufix)
-			machineName := fmt.Sprintf("machine-%s", nameSufix)
-			nodeName := fmt.Sprintf("node-%s", nameSufix)
-			params := fmt.Sprintf("<< MACHINE_NAME >>=%s,<< DIGITALOCEAN_TOKEN >>=%s,<< NODE_NAME >>=%s", machineName, doToken, nodeName)
-			params = fmt.Sprintf("%s,<< OS_NAME >>=%s,<< CONTAINER_RUNTIME >>=%s,<< CONTAINER_RUNTIME_VERSION >>=%s", params, scenario.osName, scenario.containerRuntime, scenario.containerRuntimeVersion)
-
-			err := runVerifyTool(do_manifest, params)
-			if err != nil {
-				t.Errorf("verify tool failed due to %v", err)
-			}
-		})
-	}
+	params := fmt.Sprintf("<< DIGITALOCEAN_TOKEN >>=%s", doToken)
+	runScenarios(t, digitalOceanScenarios, params, do_manifest, "do")
 }

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -8,6 +8,18 @@ import (
 	"path/filepath"
 )
 
+type scenarios struct {
+	// name holds short description of the test scenario, it is also used to create machines and nodes names
+	// so please don't put "strange" characters there
+	name                    string
+	osName                  string
+	containerRuntime        string
+	containerRuntimeVersion string
+	// if the -short flag was provided and this variable is set
+	// the test scenario will be run otherwise it will be skipped.
+	short bool
+}
+
 func runVerifyTool(manifestPath string, params string) error {
 	homeDir := os.Getenv("HOME")
 	kubeConfigDir := filepath.Join(homeDir, ".kube/config")

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -6,18 +6,41 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
+	"testing"
 )
 
-type scenarios struct {
+type scenario struct {
 	// name holds short description of the test scenario, it is also used to create machines and nodes names
 	// so please don't put "strange" characters there
 	name                    string
 	osName                  string
 	containerRuntime        string
 	containerRuntimeVersion string
-	// if the -short flag was provided and this variable is set
-	// the test scenario will be run otherwise it will be skipped.
-	short bool
+}
+
+func runScenarios(t *testing.T, testCases []scenario, testParams string, manifestPath string, cloudProvider string) {
+	for _, testCase := range testCases {
+		testCase := testCase // capture range variable
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			nameSufix := strings.Replace(testCase.name, " ", "-", -1)
+			nameSufix = strings.ToLower(nameSufix)
+			nameSufix = fmt.Sprintf("%s-%s", cloudProvider, nameSufix)
+			machineName := fmt.Sprintf("machine-%s", nameSufix)
+			nodeName := fmt.Sprintf("node-%s", nameSufix)
+			params := testParams
+			params = fmt.Sprintf("%s,<< MACHINE_NAME >>=%s,<< NODE_NAME >>=%s", params, machineName, nodeName)
+			params = fmt.Sprintf("%s,<< OS_NAME >>=%s,<< CONTAINER_RUNTIME >>=%s,<< CONTAINER_RUNTIME_VERSION >>=%s", params, testCase.osName, testCase.containerRuntime, testCase.containerRuntimeVersion)
+
+			err := runVerifyTool(manifestPath, params)
+			if err != nil {
+				t.Errorf("verify tool failed due to %v", err)
+			}
+		})
+	}
+
 }
 
 func runVerifyTool(manifestPath string, params string) error {

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -10,6 +10,43 @@ import (
 	"testing"
 )
 
+var scenarios = []scenario{
+	{
+		name:                    "scenario 1 Ubuntu Docker 1.13",
+		osName:                  "ubuntu",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "1.13",
+	},
+
+	{
+		name:                    "scenario 2 Ubuntu Docker 17.03",
+		osName:                  "ubuntu",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "17.03",
+	},
+
+	{
+		name:                    "scenario 3 Ubuntu CRI-O 1.9",
+		osName:                  "ubuntu",
+		containerRuntime:        "cri-o",
+		containerRuntimeVersion: "1.9",
+	},
+
+	{
+		name:                    "scenario 4 CoreOS Docker 1.13",
+		osName:                  "coreos",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "1.13",
+	},
+
+	{
+		name:                    "scenario 5 CoreOS Docker 17.03",
+		osName:                  "coreos",
+		containerRuntime:        "docker",
+		containerRuntimeVersion: "17.03",
+	},
+}
+
 type scenario struct {
 	// name holds short description of the test scenario, it is also used to create machines and nodes names
 	// so please don't put "strange" characters there

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -1,0 +1,36 @@
+package provisioning
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func runVerifyTool(manifestPath string, params string) error {
+	homeDir := os.Getenv("HOME")
+	kubeConfigDir := filepath.Join(homeDir, ".kube/config")
+	args := []string{
+		"-input",
+		manifestPath,
+		"-parameters",
+		params,
+		"-kubeconfig",
+		kubeConfigDir,
+		"-machineReadyTimeout",
+		"40m",
+		"-logtostderr",
+		"true",
+	}
+
+	cmd := exec.Command("../../tools/verify/verify", args...)
+	var out bytes.Buffer
+	cmd.Stderr = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("verify tool failed with the error=%v, output=\n%v", err, out.String())
+	}
+	return nil
+}

--- a/test/e2e/provisioning/testdata/machine-aws.yaml
+++ b/test/e2e/provisioning/testdata/machine-aws.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # If you change the namespace/name, you must also
+  # adjust the rbac rules
+  name: machine-controller-aws
+  namespace: kube-system
+type: Opaque
+stringData:
+  accessKeyId: << AWS_ACCESS_KEY_ID >>
+  secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
+---
+apiVersion: "machine.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: << MACHINE_NAME >>
+spec:
+  metadata:
+    name: << NODE_NAME >>
+  providerConfig:
+    cloudProvider: "aws"
+    cloudProviderSpec:
+      accessKeyId:
+        secretKeyRef:
+          namespace: kube-system
+          name: machine-controller-aws
+          key: accessKeyId
+      secretAccessKey:
+        secretKeyRef:
+          namespace: kube-system
+          name: machine-controller-aws
+          key: secretAccessKey
+      region: "eu-west-2"
+      availabilityZone: "eu-west-2a"
+      vpcId: "vpc-40827629"
+      instanceType: "t2.micro"
+      diskSize: 50
+      diskType: "standard"
+      tags:
+      # you have to set this flag to real clusterID when running against our dev or prod
+      # otherwise you might have issues with your nodes not joining the cluster
+        "KubernetesCluster": "randomString"
+    # Can be 'ubuntu', 'coreos' or 'centos'
+    operatingSystem: "<< OS_NAME >>"
+    operatingSystemSpec:
+      disableAutoUpdate: true
+  roles:
+  - "Node"
+  versions:
+    kubelet: "v1.9.6"
+    containerRuntime:
+      # If you are using Ubuntu, you may choose 'cri-o' instead
+      name: "<< CONTAINER_RUNTIME >>"
+      # Only has an effect on Ubuntu, check pkg/userdata/ubuntu/docker.go for available versions
+      version: "<< CONTAINER_RUNTIME_VERSION >>"

--- a/test/e2e/provisioning/testdata/machine-digitalocean.yaml
+++ b/test/e2e/provisioning/testdata/machine-digitalocean.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # If you change the namespace/name, you must also
+  # adjust the rbac rules
+  name: machine-controller-digitalocean
+  namespace: kube-system
+type: Opaque
+stringData:
+  token: << DIGITALOCEAN_TOKEN >>
+---
+apiVersion: "machine.k8s.io/v1alpha1"
+kind: Machine
+metadata:
+  name: << MACHINE_NAME >>
+spec:
+  metadata:
+    name: << NODE_NAME >>
+  providerConfig:
+    sshPublicKeys:
+      - "<< YOUR_PUBLIC_KEY >>"
+    cloudProvider: "digitalocean"
+    cloudProviderSpec:
+      token:
+        secretKeyRef:
+          namespace: kube-system
+          name: machine-controller-digitalocean
+          key: token
+      region: fra1
+      size: 1gb
+      backups: false
+      ipv6: false
+      private_networking: true
+      monitoring: false
+      tags:
+        - "machine-controller"
+    # Can be 'ubuntu', 'coreos' or 'centos'
+    operatingSystem: "<< OS_NAME >>"
+    operatingSystemSpec:
+      disableAutoUpdate: true
+  roles:
+  - "Node"
+  versions:
+    kubelet: "v1.9.6"
+    containerRuntime:
+      # If you are using Ubuntu, you may choose 'cri-o' instead
+      name: "<< CONTAINER_RUNTIME >>"
+      # Only has an effect on Ubuntu, check pkg/userdata/ubuntu/docker.go for available versions
+      version: "<< CONTAINER_RUNTIME_VERSION >>"

--- a/test/tools/integration/provision_master.sh
+++ b/test/tools/integration/provision_master.sh
@@ -17,7 +17,7 @@ done
 
 
 rsync -av  -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
-    ../../../{examples,machine-controller,Dockerfile} ../verify/verify \
+    ../../../{examples,machine-controller,Dockerfile,test} ../verify/verify \
     root@$ADDR:/root/
 
 cat <<EOEXEC |ssh_exec
@@ -52,6 +52,11 @@ fi
 if ! ls kube-flannel.yml; then
   curl -LO https://raw.githubusercontent.com/coreos/flannel/v0.9.1/Documentation/kube-flannel.yml
   kubectl apply -f kube-flannel.yml
+fi
+if ! which go; then
+  apt-get update
+  apt-get install -y golang-1.10-go
+  echo 'PATH="$PATH:/usr/lib/go-1.10/bin"' >> /root/.profile
 fi
 
 if ! ls machine-controller-deployed; then

--- a/test/tools/integration/run_e2e_tests.sh
+++ b/test/tools/integration/run_e2e_tests.sh
@@ -15,5 +15,5 @@ export DO_E2E_TESTS_TOKEN=$DO_E2E_TESTS_TOKEN
 
 echo "Running E2E tests"
 cd test/e2e
-go test -tags=e2e -v -timeout 60m  ./... || (kubectl logs -n kube-system \$(kubectl get pods -n kube-system|egrep '^machine-con'|awk '{ print \$1 }'); exit 1)
+go test -tags=e2e -v -short -timeout 60m  ./... || (kubectl logs -n kube-system \$(kubectl get pods -n kube-system|egrep '^machine-con'|awk '{ print \$1 }'); exit 1)
 EOF

--- a/test/tools/integration/run_e2e_tests.sh
+++ b/test/tools/integration/run_e2e_tests.sh
@@ -15,5 +15,5 @@ export DO_E2E_TESTS_TOKEN=$DO_E2E_TESTS_TOKEN
 
 echo "Running E2E tests"
 cd test/e2e
-go test -tags=e2e -v -short -timeout 60m  ./... || (kubectl logs -n kube-system \$(kubectl get pods -n kube-system|egrep '^machine-con'|awk '{ print \$1 }'); exit 1)
+go test -tags=e2e -v -timeout 60m  ./... || (kubectl logs -n kube-system \$(kubectl get pods -n kube-system|egrep '^machine-con'|awk '{ print \$1 }'); exit 1)
 EOF

--- a/test/tools/integration/run_e2e_tests.sh
+++ b/test/tools/integration/run_e2e_tests.sh
@@ -15,5 +15,5 @@ export DO_E2E_TESTS_TOKEN=$DO_E2E_TESTS_TOKEN
 
 echo "Running E2E tests"
 cd test/e2e
-go test -tags=e2e -v -timeout 60m  ./... || (kubectl logs -n kube-system \$(kubectl get pods -n kube-system|egrep '^machine-con'|awk '{ print \$1 }'); exit 1)
+go test -tags=e2e -parallel 24 -v -timeout 60m  ./... || (kubectl logs -n kube-system \$(kubectl get pods -n kube-system|egrep '^machine-con'|awk '{ print \$1 }'); exit 1)
 EOF

--- a/test/tools/integration/run_e2e_tests.sh
+++ b/test/tools/integration/run_e2e_tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# vim: tw=500
+
+set -euo pipefail
+
+cd $(dirname $0)
+export ADDR=$(cat terraform.tfstate |jq -r '.modules[0].resources["hcloud_server.machine-controller-test"].primary.attributes.ipv4_address')
+
+ssh_exec() { ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@$ADDR $@; }
+cat <<EOF |ssh_exec
+set -e
+export AWS_E2E_TESTS_KEY_ID=$AWS_E2E_TESTS_KEY_ID
+export AWS_E2E_TESTS_SECRET=$AWS_E2E_TESTS_SECRET
+export DO_E2E_TESTS_TOKEN=$DO_E2E_TESTS_TOKEN
+
+echo "Running E2E tests"
+cd test/e2e
+go test -tags=e2e -v -timeout 60m -short ./... || (kubectl logs -n kube-system \$(kubectl get pods -n kube-system|egrep '^machine-con'|awk '{ print \$1 }'); exit 1)
+EOF

--- a/test/tools/integration/run_e2e_tests.sh
+++ b/test/tools/integration/run_e2e_tests.sh
@@ -15,5 +15,5 @@ export DO_E2E_TESTS_TOKEN=$DO_E2E_TESTS_TOKEN
 
 echo "Running E2E tests"
 cd test/e2e
-go test -tags=e2e -v -timeout 60m -short ./... || (kubectl logs -n kube-system \$(kubectl get pods -n kube-system|egrep '^machine-con'|awk '{ print \$1 }'); exit 1)
+go test -tags=e2e -v -timeout 60m  ./... || (kubectl logs -n kube-system \$(kubectl get pods -n kube-system|egrep '^machine-con'|awk '{ print \$1 }'); exit 1)
 EOF


### PR DESCRIPTION
**What this PR does / why we need it**: 
at the moment we have test scenarios for DO and AWS.
tests can be run in two modes -short and normal.
when run in -short mode only a subset of tests will be tested.
by default e2e tests are disabled, we require special build tag to be provided.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
