### PR TITLE
Adds marshallJSON to configVar types

### DIFF
--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -187,9 +187,8 @@ func (configVarBool ConfigVarBool) MarshalJSON() ([]byte, error) {
 		buffer.WriteString(fmt.Sprintf(`%s"configMapKeyRef":%s`, leadingComma, jsonVal))
 	}
 
-	buffer.WriteString(fmt.Sprintf(`,"value":%v`, configVarBool.Value))
+	buffer.WriteString(fmt.Sprintf(`,"value":%v}`, configVarBool.Value))
 
-	buffer.WriteString("}")
 	return buffer.Bytes(), nil
 }
 

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -84,13 +84,17 @@ func (configVarString ConfigVarString) MarshalJSON() ([]byte, error) {
 		configMapKeyRefEmpty = true
 	}
 
+	if secretKeyRefEmpty && configMapKeyRefEmpty {
+		return []byte(fmt.Sprintf(`"%s"`, configVarString.Value)), nil
+	}
+
 	buffer := bytes.NewBufferString("{")
 	if !secretKeyRefEmpty {
 		jsonVal, err := json.Marshal(configVarString.SecretKeyRef)
 		if err != nil {
 			return nil, err
 		}
-		buffer.WriteString(fmt.Sprintf("\"secretKeyRef\":%s", string(jsonVal)))
+		buffer.WriteString(fmt.Sprintf(`"secretKeyRef":%s`, string(jsonVal)))
 	}
 
 	if !configMapKeyRefEmpty {
@@ -102,15 +106,11 @@ func (configVarString ConfigVarString) MarshalJSON() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		buffer.WriteString(fmt.Sprintf("%s\"configMapKeyRef\":%s", leadingComma, jsonVal))
+		buffer.WriteString(fmt.Sprintf(`%s"configMapKeyRef":%s`, leadingComma, jsonVal))
 	}
 
 	if configVarString.Value != "" {
-		if !secretKeyRefEmpty || !configMapKeyRefEmpty {
-			buffer.WriteString(fmt.Sprintf(",\"value\":\"%s\"", configVarString.Value))
-		} else {
-			return []byte(fmt.Sprintf(`"%s"`, configVarString.Value)), nil
-		}
+		buffer.WriteString(fmt.Sprintf(`,"value":"%s"`, configVarString.Value))
 	}
 
 	buffer.WriteString("}")

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -148,7 +148,7 @@ type configVarBoolWithoutUnmarshaller ConfigVarBool
 // This is done to not have the json object cluttered with empty strings
 // This will eventually hopefully be resolved within golang itself
 // https://github.com/golang/go/issues/11939
-func (configVarBool *ConfigVarBool) MarshalJSON() ([]byte, error) {
+func (configVarBool ConfigVarBool) MarshalJSON() ([]byte, error) {
 	var secretKeyRefEmpty, configMapKeyRefEmpty bool
 	if configVarBool.SecretKeyRef.ObjectReference.Namespace == "" &&
 		configVarBool.SecretKeyRef.ObjectReference.Name == "" &&
@@ -184,7 +184,7 @@ func (configVarBool *ConfigVarBool) MarshalJSON() ([]byte, error) {
 	}
 
 	if secretKeyRefEmpty && configMapKeyRefEmpty {
-		buffer.WriteString(fmt.Sprintf("\"value\":%v", configVarBool.Value))
+		return []byte(fmt.Sprintf("%v", configVarBool.Value)), nil
 	}
 
 	buffer.WriteString("}")

--- a/pkg/providerconfig/types_test.go
+++ b/pkg/providerconfig/types_test.go
@@ -109,7 +109,17 @@ func TestConfigVarStringMarshallingAndUnmarshalling(t *testing.T) {
 	testCases := []ConfigVarString{
 		ConfigVarString{Value: "val"},
 		ConfigVarString{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		ConfigVarString{Value: "val", SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
 		ConfigVarString{ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		ConfigVarString{
+			ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+			SecretKeyRef:    GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+		},
+		ConfigVarString{
+			Value:           "val",
+			ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+			SecretKeyRef:    GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+		},
 	}
 
 	for _, cvs := range testCases {

--- a/pkg/providerconfig/types_test.go
+++ b/pkg/providerconfig/types_test.go
@@ -87,3 +87,31 @@ func TestConfigVarStringMarshalling(t *testing.T) {
 		}
 	}
 }
+
+func TestConfigVarBoolMarshalling(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		cvb      ConfigVarBool
+		expected string
+	}{
+		{
+			cvb:      ConfigVarBool{Value: true},
+			expected: `true`,
+		},
+		{
+			cvb:      ConfigVarBool{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"}}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, err := json.Marshal(testCase.cvb)
+		if err != nil {
+			t.Errorf("Failed to marshall config var bool: %v", err)
+		}
+		if string(result) != testCase.expected {
+			t.Errorf("Result '%s' of config var bool marshalling does not match expected '%s'", string(result), testCase.expected)
+		}
+	}
+}

--- a/pkg/providerconfig/types_test.go
+++ b/pkg/providerconfig/types_test.go
@@ -48,7 +48,6 @@ func TestConfigVarBoolUnmarshalling(t *testing.T) {
 }
 
 func TestConfigVarStringMarshalling(t *testing.T) {
-	t.Parallel()
 
 	testCases := []struct {
 		cvs      ConfigVarString
@@ -76,7 +75,6 @@ func TestConfigVarStringMarshalling(t *testing.T) {
 }
 
 func TestConfigVarBoolMarshalling(t *testing.T) {
-	t.Parallel()
 
 	testCases := []struct {
 		cvb      ConfigVarBool
@@ -104,7 +102,6 @@ func TestConfigVarBoolMarshalling(t *testing.T) {
 }
 
 func TestConfigVarStringMarshallingAndUnmarshalling(t *testing.T) {
-	t.Parallel()
 
 	testCases := []ConfigVarString{
 		ConfigVarString{Value: "val"},
@@ -140,7 +137,6 @@ func TestConfigVarStringMarshallingAndUnmarshalling(t *testing.T) {
 }
 
 func TestConfigVarBoolMarshallingAndUnmarshalling(t *testing.T) {
-	t.Parallel()
 
 	testCases := []ConfigVarBool{
 		ConfigVarBool{Value: true},

--- a/pkg/providerconfig/types_test.go
+++ b/pkg/providerconfig/types_test.go
@@ -30,34 +30,21 @@ func TestConfigVarStringUnmarshalling(t *testing.T) {
 
 func TestConfigVarBoolUnmarshalling(t *testing.T) {
 	jsonBool := []byte("true")
-	jsonString := []byte(`"true"`)
 	jsonMapBool := []byte(`{"value":true}`)
-	jsonMapString := []byte(`{"value":"true"}`)
 
 	expectedResult := ConfigVarBool{Value: true}
 
 	var jsonBoolTarget ConfigVarBool
-	var jsonStringTarget ConfigVarBool
 	var jsonMapBoolTarget ConfigVarBool
-	var jsonMapStringTarget ConfigVarBool
 
 	err := json.Unmarshal(jsonBool, &jsonBoolTarget)
 	if err != nil || !reflect.DeepEqual(expectedResult, jsonBoolTarget) {
 		t.Fatalf("Decoding raw bool into configVarBool failed! Error: '%v'", err)
 	}
-	err = json.Unmarshal(jsonString, &jsonStringTarget)
-	if err != nil || !reflect.DeepEqual(expectedResult, jsonStringTarget) {
-		t.Fatalf("Decoding raw string bool into configVarBool failed! Error: '%v'", err)
-	}
 	err = json.Unmarshal(jsonMapBool, &jsonMapBoolTarget)
 	if err != nil || !reflect.DeepEqual(expectedResult, jsonMapBoolTarget) {
 		t.Fatalf("Decoding map bool into configVarBool failed! Error: '%v'", err)
 	}
-	err = json.Unmarshal(jsonMapString, &jsonMapStringTarget)
-	if err != nil || !reflect.DeepEqual(expectedResult, jsonMapStringTarget) {
-		t.Fatalf("Decoding map string bool into configVarBool failed! Error: '%v'", err)
-	}
-
 }
 
 func TestConfigVarStringMarshalling(t *testing.T) {
@@ -101,7 +88,7 @@ func TestConfigVarBoolMarshalling(t *testing.T) {
 		},
 		{
 			cvb:      ConfigVarBool{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
-			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"}}`,
+			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"},"value":false}`,
 		},
 	}
 
@@ -112,6 +99,69 @@ func TestConfigVarBoolMarshalling(t *testing.T) {
 		}
 		if string(result) != testCase.expected {
 			t.Errorf("Result '%s' of config var bool marshalling does not match expected '%s'", string(result), testCase.expected)
+		}
+	}
+}
+
+func TestConfigVarStringMarshallingAndUnmarshalling(t *testing.T) {
+	t.Parallel()
+
+	testCases := []ConfigVarString{
+		ConfigVarString{Value: "val"},
+		ConfigVarString{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		ConfigVarString{ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+	}
+
+	for _, cvs := range testCases {
+		marshalled, err := json.Marshal(cvs)
+		if err != nil {
+			t.Errorf("Failed to marshall config var string: %v", err)
+		}
+
+		var unmarshalled ConfigVarString
+		err = json.Unmarshal(marshalled, &unmarshalled)
+		if err != nil {
+			t.Errorf("Failed to unmarshall config var string after marshalling: %v", err)
+		}
+		if !reflect.DeepEqual(cvs, unmarshalled) {
+			t.Errorf("ConfigVarString object is not equal after marshalling and unmarshalling, old: '%+v', new: '%+v'", cvs, unmarshalled)
+		}
+	}
+}
+
+func TestConfigVarBoolMarshallingAndUnmarshalling(t *testing.T) {
+	t.Parallel()
+
+	testCases := []ConfigVarBool{
+		ConfigVarBool{Value: true},
+		ConfigVarBool{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		ConfigVarBool{Value: true, SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		ConfigVarBool{ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		ConfigVarBool{Value: true, ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		ConfigVarBool{
+			ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+			SecretKeyRef:    GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+		},
+		ConfigVarBool{
+			Value:           true,
+			ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+			SecretKeyRef:    GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+		},
+	}
+
+	for _, cvs := range testCases {
+		marshalled, err := json.Marshal(cvs)
+		if err != nil {
+			t.Errorf("Failed to marshall config var string: %v", err)
+		}
+
+		var unmarshalled ConfigVarBool
+		err = json.Unmarshal(marshalled, &unmarshalled)
+		if err != nil {
+			t.Errorf("Failed to unmarshall config var bool after marshalling: %v, '%v'", err, string(marshalled))
+		}
+		if !reflect.DeepEqual(cvs, unmarshalled) {
+			t.Errorf("ConfigVarBool object is not equal after marshalling and unmarshalling, old: '%+v', new: '%+v'", cvs, unmarshalled)
 		}
 	}
 }

--- a/pkg/providerconfig/types_test.go
+++ b/pkg/providerconfig/types_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"k8s.io/api/core/v1"
 )
 
 func TestConfigVarStringUnmarshalling(t *testing.T) {
@@ -56,4 +58,32 @@ func TestConfigVarBoolUnmarshalling(t *testing.T) {
 		t.Fatalf("Decoding map string bool into configVarBool failed! Error: '%v'", err)
 	}
 
+}
+
+func TestConfigVarStringMarshalling(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		cvs      ConfigVarString
+		expected string
+	}{
+		{
+			cvs:      ConfigVarString{Value: "val"},
+			expected: `"val"`,
+		},
+		{
+			cvs:      ConfigVarString{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"}}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, err := json.Marshal(testCase.cvs)
+		if err != nil {
+			t.Errorf("Failed to marshall config var string: %v", err)
+		}
+		if string(result) != testCase.expected {
+			t.Errorf("Result '%s' of config var string marshalling does not match expected '%s'", string(result), testCase.expected)
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds marshallJSON to configVar types, this avoids having a huge cluttered machine definition when the spec gets written back after defaulting.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #130 

**Special notes for your reviewer**:
