### PR TITLE
Add build number to e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,19 +136,19 @@ workflows:
               only: /v.*/
       - test:
           requires:
-            - check-dependencies
+            - checkout_code
           filters:
             tags:
               only: /v.*/
       - build:
           requires:
-            - check-dependencies
+            - checkout_code
           filters:
             tags:
               only: /v.*/
       - verify-tool:
           requires:
-            - check-dependencies
+            - checkout_code
           filters:
             tags:
               only: /v.*/

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -113,7 +113,7 @@ func runScenarios(t *testing.T, excludeSelector *scenarioSelector, testParams st
 			machineName := fmt.Sprintf("machine-%s", nameSufix)
 			nodeName := fmt.Sprintf("node-%s", nameSufix)
 			params := testParams
-			params = fmt.Sprintf("%s,<< MACHINE_NAME >>=%s,<< NODE_NAME >>=%s", params, machineName, nodeName)
+			params = fmt.Sprintf("%s,<< MACHINE_NAME >>=%s,<< NODE_NAME >>=%s-%s", params, machineName, nodeName, os.Getenv("CIRCLE_BUILD_NUM"))
 			params = fmt.Sprintf("%s,<< OS_NAME >>=%s,<< CONTAINER_RUNTIME >>=%s,<< CONTAINER_RUNTIME_VERSION >>=%s", params, testCase.osName, testCase.containerRuntime, testCase.containerRuntimeVersion)
 
 			err := runVerifyTool(manifestPath, params)


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes our e2e tests concurrency-safe, also I took the freedom of putting the `check-dependencies` job to the same stage as the `build`, `verify-tool` and `test` steps which gains us ~30 seconds less overall build time

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
