### PR TITLE
add os dependend root device path for aws

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/cloud"
@@ -190,7 +189,7 @@ func getDefaultRootDevicePath(os providerconfig.OperatingSystem) (string, error)
 		return "/dev/xvda", nil
 	}
 
-	return "", errors.New("no default root path found")
+	return "", fmt.Errorf("no default root path found for %s operating system", os)
 }
 
 func (p *provider) getConfig(s runtime.RawExtension) (*Config, *providerconfig.Config, error) {

--- a/test/e2e/provisioning/testdata/machine-aws.yaml
+++ b/test/e2e/provisioning/testdata/machine-aws.yaml
@@ -13,9 +13,9 @@ spec:
       region: "eu-west-2"
       availabilityZone: "eu-west-2a"
       vpcId: "vpc-40827629"
-      instanceType: "t2.micro"
+      instanceType: "t2.medium"
       diskSize: 50
-      diskType: "standard"
+      diskType: "gp2"
       tags:
       # you have to set this flag to real clusterID when running against our dev or prod
       # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machine-digitalocean.yaml
+++ b/test/e2e/provisioning/testdata/machine-digitalocean.yaml
@@ -12,7 +12,7 @@ spec:
     cloudProviderSpec:
       token: << DIGITALOCEAN_TOKEN >>
       region: fra1
-      size: 1gb
+      size: c-2
       backups: false
       ipv6: false
       private_networking: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Every image comes with a default root device.
As we dynamically set a device, depending on the user settings, we need to replace the default root device.
Otherwise we end up with a 8gb default device mounted at `/`  and a 50gb SSD unused.
