### PR TITLE
Vsphere vm folder

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -43,6 +43,7 @@ type RawConfig struct {
 	VSphereURL     providerconfig.ConfigVarString `json:"vsphereURL"`
 	Datacenter     providerconfig.ConfigVarString `json:"datacenter"`
 	Cluster        providerconfig.ConfigVarString `json:"cluster"`
+	Folder         providerconfig.ConfigVarString `json:"folder"`
 	Datastore      providerconfig.ConfigVarString `json:"datastore"`
 	CPUs           int32                          `json:"cpus"`
 	MemoryMB       int64                          `json:"memoryMB"`
@@ -56,6 +57,7 @@ type Config struct {
 	VSphereURL     string
 	Datacenter     string
 	Cluster        string
+	Folder         string
 	Datastore      string
 	AllowInsecure  bool
 	CPUs           int32
@@ -143,6 +145,11 @@ func (p *provider) getConfig(s runtime.RawExtension) (*Config, *providerconfig.C
 		return nil, nil, err
 	}
 
+	c.Folder, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Folder)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	c.Datastore, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Datastore)
 	if err != nil {
 		return nil, nil, err
@@ -214,6 +221,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 		config.TemplateVMName,
 		config.Datacenter,
 		config.Cluster,
+		config.Folder,
 		config.CPUs,
 		config.MemoryMB,
 		client,

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -108,6 +108,9 @@ func (p *provider) getConfig(s runtime.RawExtension) (*Config, *providerconfig.C
 
 	rawConfig := RawConfig{}
 	err = json.Unmarshal(pconfig.CloudProviderSpec.Raw, &rawConfig)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	c := Config{}
 	c.TemplateVMName, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.TemplateVMName)
@@ -158,6 +161,10 @@ func (p *provider) getConfig(s runtime.RawExtension) (*Config, *providerconfig.C
 
 func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	config, _, err := p.getConfig(spec.ProviderConfig)
+	if err != nil {
+		return err
+	}
+
 	client, err := getClient(config.Username, config.Password, config.VSphereURL, config.AllowInsecure)
 	if err != nil {
 		return fmt.Errorf("failed to get vsphere client: '%v'", err)

--- a/test/e2e/provisioning/testdata/machine-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machine-vsphere.yaml
@@ -16,6 +16,7 @@ spec:
       username: '<< VSPHERE_USERNAME >>'
       vsphereURL: 'https://<< VSPHERE_ADDRESS >>'
       datacenter: 'Datacenter'
+      folder: '/Datacenter/vm/e2e-tests'
       password: << VSPHERE_PASSWORD >>
       cluster: "test-cluster"
       datastore: datastore1


### PR DESCRIPTION
**What this PR does / why we need it**:
To avoid dumping all created VMs in the root directory of vsphere's VM hierarchy.

**Which issue(s) this PR fixes** 
Fixes ##204
