### PR TITLE
decreases verify tool timeout

### DIFF
--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -131,7 +131,13 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 
 	kubeConfig := filepath.Join(projectDir, ".kubeconfig")
 
-	err := verify(kubeConfig, manifestPath, scenarioParams, 60*time.Hour)
+	// the golang test runtime waits for individual subtests to complete before reporting the status.
+	// if one of them is blocking/waiting and the global timeout is reached the status will not be reported/visible.
+	//
+	// we decided to keep this time lower that the global timeout to prevent the following:
+	// the global timeout is set to 20 minutes and the verify tool waits up to 60 hours for a machine to show up.
+	// thus one faulty scenario prevents from showing the results for the whole group, which is confusing because it looks like all tests are broken.
+	err := verify(kubeConfig, manifestPath, scenarioParams, 15*time.Minute)
 	if err != nil {
 		t.Errorf("verify failed due to error=%v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: the golang test runtime waits for individual subtests to complete before reporting the status. if one of them is blocking/waiting and the global timeout is reached the status will not be reported/visible.

the global timeout is set to 20 minutes and the verify tool waits up to 60 hours for a machine to show up.
thus one faulty scenario prevents from showing the whole test runs status which is confusing because it looks like all tests are broken.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
