### PR TITLE
leader election: increase the log level of successfully renewer lease

### DIFF
--- a/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/vendor/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -196,7 +196,7 @@ func (le *LeaderElector) renew() {
 		le.maybeReportTransition()
 		desc := le.config.Lock.Describe()
 		if err == nil {
-			glog.V(4).Infof("successfully renewed lease %v", desc)
+			glog.V(6).Infof("successfully renewed lease %v", desc)
 			return
 		}
 		le.config.Lock.RecordEvent("stopped leading")


### PR DESCRIPTION
The current log level (4) floods over things that are actually of note during debugging.

**What this PR does / why we need it**:
Setting log level to 4 uncovers some important information that gets drowned in renewed lease messages coming every second. Although it is something worth debug-logging, it isn't even a significant state change - thus I'd like to move it to the higher log level for improved clarity.