### PR TITLE
Feature/239 v sphere network change

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -255,7 +255,10 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 	}
 
 	// Map networks
-	updateNetworkForVM(context.TODO(), virtualMachine, config.TemplateNetName, config.VMNetName)
+	err = updateNetworkForVM(context.TODO(), virtualMachine, config.TemplateNetName, config.VMNetName)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't set network for vm: %v", err)
+	}
 
 	if pc.OperatingSystem != providerconfig.OperatingSystemCoreos {
 		localUserdataIsoFilePath, err := generateLocalUserdataIso(userdata, machine.Spec.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes the machine controller able to change the network of a newly created vm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #239

**Special notes for your reviewer**:
There's also a matching PR in kubermatic/api.