### PR TITLE
Add the delete finalizer at the latest possible point

### DIFF
--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/fake"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/hetzner"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere"
@@ -35,6 +36,9 @@ var (
 		},
 		providerconfig.CloudProviderAzure: func(cvr *providerconfig.ConfigVarResolver) cloud.Provider {
 			return azure.New(cvr)
+		},
+		providerconfig.CloudProviderFake: func(cvr *providerconfig.ConfigVarResolver) cloud.Provider {
+			return fake.New(cvr)
 		},
 	}
 )

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -1,0 +1,82 @@
+package fake
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/cloud"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
+	"github.com/kubermatic/machine-controller/pkg/machines/v1alpha1"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+
+	"github.com/golang/glog"
+)
+
+type provider struct{}
+
+type FakeCloudProviderConfig struct {
+	PassValidation bool `json:"passValidation"`
+}
+
+type FakeCloudProviderInstance struct{}
+
+func (f FakeCloudProviderInstance) Name() string {
+	return ""
+}
+func (f FakeCloudProviderInstance) ID() string {
+	return ""
+}
+func (f FakeCloudProviderInstance) Addresses() []string {
+	return nil
+}
+func (f FakeCloudProviderInstance) Status() instance.Status {
+	return instance.StatusUnknown
+}
+
+// New returns a fake cloud provider
+func New(_ *providerconfig.ConfigVarResolver) cloud.Provider {
+	return &provider{}
+}
+
+func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, bool, error) {
+	return spec, false, nil
+}
+
+// Validate returns success or failure based according to its FakeCloudProviderConfig
+func (p *provider) Validate(machinespec v1alpha1.MachineSpec) error {
+	pconfig := providerconfig.Config{}
+	err := json.Unmarshal(machinespec.ProviderConfig.Raw, &pconfig)
+	if err != nil {
+		return err
+	}
+
+	fakeCloudProviderConfig := FakeCloudProviderConfig{}
+	if err = json.Unmarshal(pconfig.CloudProviderSpec.Raw, &fakeCloudProviderConfig); err != nil {
+		return err
+	}
+
+	if fakeCloudProviderConfig.PassValidation {
+		glog.V(4).Infof("succeeding validation as requested")
+		return nil
+	}
+
+	glog.V(4).Infof("failing validation as requested")
+	return fmt.Errorf("failing validation as requested")
+}
+
+func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+	return FakeCloudProviderInstance{}, nil
+}
+
+func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (string, string, error) {
+	return "", "", nil
+}
+
+// Create creates a cloud instance according to the given machine
+func (p *provider) Create(_ *v1alpha1.Machine, _ string) (instance.Instance, error) {
+	return FakeCloudProviderInstance{}, nil
+}
+
+func (p *provider) Delete(_ *v1alpha1.Machine, _ instance.Instance) error {
+	return nil
+}

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -66,7 +66,9 @@ func (p *provider) getConfig(s runtime.RawExtension) (*Config, *providerconfig.C
 	}
 
 	rawConfig := RawConfig{}
-	err = json.Unmarshal(pconfig.CloudProviderSpec.Raw, &rawConfig)
+	if err = json.Unmarshal(pconfig.CloudProviderSpec.Raw, &rawConfig); err != nil {
+		return nil, nil, err
+	}
 
 	c := Config{}
 	c.Token, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Token, "HZ_TOKEN")

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -507,17 +507,11 @@ func (c *Controller) ensureInstanceExistsForMachine(prov cloud.Provider, machine
 				return fmt.Errorf("failed get userdata: %v", err)
 			}
 
-			// Set the finalizer
-			if !sets.NewString(machine.Finalizers...).Has(finalizerDeleteInstance) {
-				finalizers := sets.NewString(machine.Finalizers...)
-				finalizers.Insert(finalizerDeleteInstance)
-				machine.Finalizers = finalizers.List()
-				if machine, err = c.updateMachine(machine); err != nil {
-					return fmt.Errorf("failed to update machine after adding the delete instance finalizer: %v", err)
-				}
-				glog.V(4).Infof("Added delete finalizer to machine %s", machine.Name)
+			// We will create the instance, so ensure finalizer is there
+			machine, err = c.ensureDeleteFinalizerExists(machine)
+			if err != nil {
+				return err
 			}
-
 			// Create the instance
 			if providerInstance, err = c.createProviderInstance(prov, machine, userdata); err != nil {
 				c.recorder.Eventf(machine, corev1.EventTypeWarning, "CreateInstanceFailed", "Instance creation failed: %v", err)
@@ -541,6 +535,11 @@ func (c *Controller) ensureInstanceExistsForMachine(prov cloud.Provider, machine
 
 		// case 2.3: transient error was returned, requeue the request and try again in the future
 		return fmt.Errorf("failed to get instance from provider: %v", err)
+	}
+	// Instance exists, so ensure finalizer does as well
+	machine, err = c.ensureDeleteFinalizerExists(machine)
+	if err != nil {
+		return err
 	}
 
 	// case 3: retrieving the instance from cloudprovider was successfull
@@ -896,4 +895,17 @@ func (c *Controller) updateNodesMetric() {
 func (c *Controller) updateMetrics() {
 	c.updateMachinesMetric()
 	c.updateNodesMetric()
+}
+
+func (c *Controller) ensureDeleteFinalizerExists(machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
+	if !sets.NewString(machine.Finalizers...).Has(finalizerDeleteInstance) {
+		finalizers := sets.NewString(machine.Finalizers...)
+		finalizers.Insert(finalizerDeleteInstance)
+		machine.Finalizers = finalizers.List()
+		if _, err := c.updateMachine(machine); err != nil {
+			return nil, fmt.Errorf("failed to update machine after adding the delete instance finalizer: %v", err)
+		}
+		glog.V(4).Infof("Added delete finalizer to machine %s", machine.Name)
+	}
+	return machine, nil
 }

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -179,63 +179,67 @@ func TestController_GetNode(t *testing.T) {
 
 func TestController_AddDeleteFinalizerOnlyIfValidationSucceeded(t *testing.T) {
 	tests := []struct {
+		name              string
 		cloudProviderSpec string
 		finalizerExpected bool
 		err               string
 	}{
 		{
+			name:              "Finalizer gets added on sucessfull validation",
 			cloudProviderSpec: `{"passValidation": true}`,
 			finalizerExpected: true,
 		},
 		{
+			name:              "Finalizer does not get added on failed validation",
 			cloudProviderSpec: `{"passValidation": false}`,
 			err:               "invalid provider config: failing validation as requested",
 			finalizerExpected: false,
 		},
 	}
 	for _, test := range tests {
-		providerConfig := fmt.Sprintf(`{"cloudProvider": "fake", "operatingSystem": "coreos",
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			providerConfig := fmt.Sprintf(`{"cloudProvider": "fake", "operatingSystem": "coreos",
 		"cloudProviderSpec": %s}`, test.cloudProviderSpec)
-		machine := v1alpha1.Machine{}
-		machine.Name = "testmachine"
-		machine.Spec.ProviderConfig.Raw = []byte(providerConfig)
+			machine := v1alpha1.Machine{}
+			machine.Name = "testmachine"
+			machine.Spec.ProviderConfig.Raw = []byte(providerConfig)
 
-		client := machinefake.NewSimpleClientset(runtime.Object(&machine))
-		kubeclient := kubefake.NewSimpleClientset()
-		kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeclient, 10*time.Millisecond)
-		machineInformerFactory := machineinformers.NewSharedInformerFactory(client, 10*time.Millisecond)
+			client := machinefake.NewSimpleClientset(runtime.Object(&machine))
+			kubeclient := kubefake.NewSimpleClientset()
+			kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeclient, 10*time.Millisecond)
+			machineInformerFactory := machineinformers.NewSharedInformerFactory(client, 10*time.Millisecond)
 
-		stopChannel := make(chan struct{})
-		defer close(stopChannel)
+			stopChannel := make(chan struct{})
+			defer close(stopChannel)
 
-		controller := Controller{
-			machineClient:   client,
-			machinesLister:  machineInformerFactory.Machine().V1alpha1().Machines().Lister(),
-			metrics:         NewMachineControllerMetrics(),
-			nodesLister:     kubeInformerFactory.Core().V1().Nodes().Lister(),
-			recorder:        &record.FakeRecorder{},
-			validationCache: map[string]bool{},
-		}
-		machineInformerFactory.Start(stopChannel)
-		machineInformerFactory.WaitForCacheSync(stopChannel)
-		kubeInformerFactory.Start(stopChannel)
-		kubeInformerFactory.WaitForCacheSync(stopChannel)
+			controller := Controller{
+				machineClient:   client,
+				machinesLister:  machineInformerFactory.Machine().V1alpha1().Machines().Lister(),
+				metrics:         NewMachineControllerMetrics(),
+				nodesLister:     kubeInformerFactory.Core().V1().Nodes().Lister(),
+				recorder:        &record.FakeRecorder{},
+				validationCache: map[string]bool{},
+			}
+			machineInformerFactory.Start(stopChannel)
+			machineInformerFactory.WaitForCacheSync(stopChannel)
+			kubeInformerFactory.Start(stopChannel)
+			kubeInformerFactory.WaitForCacheSync(stopChannel)
 
-		// Just ignore errors here, the controller throws one if validation fails
-		// but we just wannt to ensure there is no finalizer in that case
-		err := controller.syncHandler("testmachine")
-		if err != nil && err.Error() != test.err {
-			t.Fatalf("Expected test to have err '%s' but was '%v'", test.err, err)
-		}
-		machineInformerFactory.WaitForCacheSync(stopChannel)
-		syncedMachine, err := client.Machine().Machines().Get("testmachine", metav1.GetOptions{})
-		if err != nil {
-			t.Errorf("Failed to get machine: %v", err)
-		}
-		hasFinalizer := sets.NewString(syncedMachine.Finalizers...).Has(finalizerDeleteInstance)
-		if hasFinalizer != test.finalizerExpected {
-			t.Errorf("Finalizer expected: %v, but was:%v", test.finalizerExpected, hasFinalizer)
-		}
+			err := controller.syncHandler("testmachine")
+			if err != nil && err.Error() != test.err {
+				t.Fatalf("Expected test to have err '%s' but was '%v'", test.err, err)
+			}
+			machineInformerFactory.WaitForCacheSync(stopChannel)
+			syncedMachine, err := client.Machine().Machines().Get("testmachine", metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("Failed to get machine: %v", err)
+			}
+			hasFinalizer := sets.NewString(syncedMachine.Finalizers...).Has(finalizerDeleteInstance)
+			if hasFinalizer != test.finalizerExpected {
+				t.Errorf("Finalizer expected: %v, but was:%v", test.finalizerExpected, hasFinalizer)
+			}
+		})
 	}
 
 }

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -23,6 +23,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
 )
 
 type fakeInstance struct {
@@ -180,6 +181,7 @@ func TestController_AddDeleteFinalizerOnlyIfValidationSucceeded(t *testing.T) {
 	tests := []struct {
 		cloudProviderSpec string
 		finalizerExpected bool
+		err               string
 	}{
 		{
 			cloudProviderSpec: `{"passValidation": true}`,
@@ -187,34 +189,45 @@ func TestController_AddDeleteFinalizerOnlyIfValidationSucceeded(t *testing.T) {
 		},
 		{
 			cloudProviderSpec: `{"passValidation": false}`,
+			err:               "invalid provider config: failing validation as requested",
 			finalizerExpected: false,
 		},
 	}
 	for _, test := range tests {
-		providerConfig := fmt.Sprintf(`{"cloudProvider": "fake", "cloudProviderSpec": %s}`,
-			test.cloudProviderSpec)
-		t.Logf("Testing providerconfig \n%s", providerConfig)
+		providerConfig := fmt.Sprintf(`{"cloudProvider": "fake", "operatingSystem": "coreos",
+		"cloudProviderSpec": %s}`, test.cloudProviderSpec)
 		machine := v1alpha1.Machine{}
 		machine.Name = "testmachine"
 		machine.Spec.ProviderConfig.Raw = []byte(providerConfig)
 
 		client := machinefake.NewSimpleClientset(runtime.Object(&machine))
+		kubeclient := kubefake.NewSimpleClientset()
+		kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeclient, 10*time.Millisecond)
 		machineInformerFactory := machineinformers.NewSharedInformerFactory(client, 10*time.Millisecond)
 
 		stopChannel := make(chan struct{})
 		defer close(stopChannel)
 
-		controller := Controller{machinesLister: machineInformerFactory.Machine().V1alpha1().Machines().Lister()}
+		controller := Controller{
+			machineClient:   client,
+			machinesLister:  machineInformerFactory.Machine().V1alpha1().Machines().Lister(),
+			metrics:         NewMachineControllerMetrics(),
+			nodesLister:     kubeInformerFactory.Core().V1().Nodes().Lister(),
+			recorder:        &record.FakeRecorder{},
+			validationCache: map[string]bool{},
+		}
 		machineInformerFactory.Start(stopChannel)
 		machineInformerFactory.WaitForCacheSync(stopChannel)
+		kubeInformerFactory.Start(stopChannel)
+		kubeInformerFactory.WaitForCacheSync(stopChannel)
 
 		// Just ignore errors here, the controller throws one if validation fails
 		// but we just wannt to ensure there is no finalizer in that case
 		err := controller.syncHandler("testmachine")
-		if err != nil {
-			// This is only for test debugging purposes
-			t.Logf("Sync handler error: %v", err)
+		if err != nil && err.Error() != test.err {
+			t.Fatalf("Expected test to have err '%s' but was '%v'", test.err, err)
 		}
+		machineInformerFactory.WaitForCacheSync(stopChannel)
 		syncedMachine, err := client.Machine().Machines().Get("testmachine", metav1.GetOptions{})
 		if err != nil {
 			t.Errorf("Failed to get machine: %v", err)

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -36,6 +36,7 @@ const (
 	CloudProviderOpenstack    CloudProvider = "openstack"
 	CloudProviderHetzner      CloudProvider = "hetzner"
 	CloudProviderVsphere      CloudProvider = "vsphere"
+	CloudProviderFake         CloudProvider = "fake"
 )
 
 type Config struct {


### PR DESCRIPTION
We currently add the delete finalizer to the machine at the very
beginning of the sync loop without even validating it before.

This moves the finalizer creation to happen right before the creation.

This will drastically reduce the occurence of situations where the
finalizer has to be manually deleted.

Related issue: #224

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #224 

**Special notes for your reviewer**:
