### PR TITLE
Avoid overwrite of cloud provider args in centos

### DIFF
--- a/pkg/userdata/centos/testdata/docker-1.13-aws.golden
+++ b/pkg/userdata/centos/testdata/docker-1.13-aws.golden
@@ -54,6 +54,10 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStartPre=/usr/sbin/modprobe br_netfilter
+    # This is required because it contains an empty KUBELET_EXTRA_ARGS= variable which has precedence over the one
+    # defined in /etc/systemd/system/kubelet.service.d/20-extra.conf
+    # We remove it here as /etc/systemd/system/kubelet.service comes from the package
+    ExecStartPre=/usr/bin/rm -f /etc/sysconfig/kubelet
     ExecStart=/usr/bin/kubeadm join \
       --token my-token \
       --discovery-token-ca-cert-hash sha256:6caecce9fedcb55d4953d61a27dc6997361a2f226ad86d7e6004dde7526fc4b1 \

--- a/pkg/userdata/centos/userdata.go
+++ b/pkg/userdata/centos/userdata.go
@@ -213,6 +213,10 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStartPre=/usr/sbin/modprobe br_netfilter
+    # This is required because it contains an empty KUBELET_EXTRA_ARGS= variable which has precedence over the one
+    # defined in /etc/systemd/system/kubelet.service.d/20-extra.conf
+    # We remove it here as /etc/systemd/system/kubelet.service comes from the package
+    ExecStartPre=/usr/bin/rm -f /etc/sysconfig/kubelet
     ExecStart=/usr/bin/kubeadm join \
       --token {{ .BoostrapToken }} \
       --discovery-token-ca-cert-hash sha256:{{ .KubeadmCACertHash }} \


### PR DESCRIPTION
This is only required on CentOS as we do not install via package in
Ubuntu.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
