### PR TITLE
Use Prometheus collector pattern for stateless metrics

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/machines"
 	"github.com/kubermatic/machine-controller/pkg/signals"
 	"github.com/oklog/run"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -220,6 +221,14 @@ func main() {
 	ctx, ctxDone := context.WithCancel(context.Background())
 	var g run.Group
 	{
+		prometheus.MustRegister(controller.NewMachineCollector(
+			machineInformerFactory.Machine().V1alpha1().Machines().Lister(),
+		))
+
+		prometheus.MustRegister(controller.NewNodeController(
+			kubeInformerFactory.Core().V1().Nodes().Lister(),
+		))
+
 		s := createUtilHttpServer(kubeClient, kubeconfigProvider)
 		g.Add(func() error {
 			return s.ListenAndServe()

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -202,7 +202,14 @@ func main() {
 	machineInformerFactory.Start(stopCh)
 	kubeSystemInformerFactory.Start(stopCh)
 
-	for _, syncsMap := range []map[reflect.Type]bool{kubeInformerFactory.WaitForCacheSync(stopCh), kubePublicKubeInformerFactory.WaitForCacheSync(stopCh), machineInformerFactory.WaitForCacheSync(stopCh), defaultKubeInformerFactory.WaitForCacheSync(stopCh), kubeSystemInformerFactory.WaitForCacheSync(stopCh)} {
+	syncsMaps := []map[reflect.Type]bool{
+		kubeInformerFactory.WaitForCacheSync(stopCh),
+		kubePublicKubeInformerFactory.WaitForCacheSync(stopCh),
+		machineInformerFactory.WaitForCacheSync(stopCh),
+		defaultKubeInformerFactory.WaitForCacheSync(stopCh),
+		kubeSystemInformerFactory.WaitForCacheSync(stopCh),
+	}
+	for _, syncsMap := range syncsMaps {
 		for key, synced := range syncsMap {
 			if !synced {
 				glog.Fatalf("unable to sync %s", key)

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -225,10 +225,6 @@ func main() {
 			machineInformerFactory.Machine().V1alpha1().Machines().Lister(),
 		))
 
-		prometheus.MustRegister(controller.NewNodeCollector(
-			kubeInformerFactory.Core().V1().Nodes().Lister(),
-		))
-
 		s := createUtilHttpServer(kubeClient, kubeconfigProvider)
 		g.Add(func() error {
 			return s.ListenAndServe()

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -225,7 +225,7 @@ func main() {
 			machineInformerFactory.Machine().V1alpha1().Machines().Lister(),
 		))
 
-		prometheus.MustRegister(controller.NewNodeController(
+		prometheus.MustRegister(controller.NewNodeCollector(
 			kubeInformerFactory.Core().V1().Nodes().Lister(),
 		))
 

--- a/examples/alerts.yaml
+++ b/examples/alerts.yaml
@@ -7,13 +7,18 @@ groups:
     labels:
       severity: critical
     annotations:
-      description: "Machine Controller in namespace {{ $labels.namespace }} is down for more than 5 minutes."
-      summary: "Machine Controller is down"
+      message: "Machine Controller in namespace {{ $labels.namespace }} is down for more than 5 minutes."
   - alert: MachineControllerTooManyErrors
     expr: sum(rate(machine_controller_errors_total[5m])) by (namespace) > 0.01
     for: 10m
     labels:
       severity: warning
     annotations:
-      description: "Machine Controller in {{ $labels.namespace }} has too many errors in its loop."
-      summary: "Machine Controller has many errors"
+      message: "Machine Controller in {{ $labels.namespace }} has too many errors in its loop."
+  - alert: MachineControllerDeleting
+    expr: machine_controller_machine_deleted > 0
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      message: "Unable to delete machine {{ $labels.machine }}"

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -4,55 +4,25 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const metricsPrefix = "machine_controller_"
+
 // NewMachineControllerMetrics creates new MachineControllerMetrics
 // with default values initialized, so metrics always show up.
 func NewMachineControllerMetrics() *MetricsCollection {
-	namespace := "machine"
-	subsystem := "controller"
-
 	cm := &MetricsCollection{
-		Machines: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "machines",
-			Help:      "The number of machines",
-		}),
 		Workers: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "workers",
-			Help:      "The number of running machine controller workers",
-		}),
-		Nodes: prometheus.NewGauge(prometheus.GaugeOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "nodes",
-			Help:      "The number of nodes created by a machine",
+			Name: metricsPrefix + "workers",
+			Help: "The number of running machine controller workers",
 		}),
 		Errors: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "errors_total",
-			Help:      "The total number or unexpected errors the controller encountered",
+			Name: metricsPrefix + "errors_total",
+			Help: "The total number or unexpected errors the controller encountered",
 		}),
-		ControllerOperation: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "controller_operation_duration_seconds",
-			Help:      "The duration it takes to execute an operation",
-		}, []string{"operation"}),
-		NodeJoinDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "node_join_duration_seconds",
-			Help:      "The time it takes from creation of the machine resource and the final creation of the node resource",
-		}, []string{}),
 	}
 
 	// Set default values, so that these metrics always show up
-	cm.Machines.Set(0)
 	cm.Workers.Set(0)
-	cm.Nodes.Set(0)
+	cm.Errors.Add(0)
 
 	return cm
 }

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -97,7 +97,7 @@ func (mc MachineCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-type NodeController struct {
+type NodeCollector struct {
 	lister v1.NodeLister
 
 	nodes       *prometheus.Desc
@@ -105,8 +105,8 @@ type NodeController struct {
 	nodeDeleted *prometheus.Desc
 }
 
-func NewNodeController(lister v1.NodeLister) *NodeController {
-	return &NodeController{
+func NewNodeCollector(lister v1.NodeLister) *NodeCollector {
+	return &NodeCollector{
 		lister: lister,
 
 		nodes: prometheus.NewDesc(
@@ -127,11 +127,11 @@ func NewNodeController(lister v1.NodeLister) *NodeController {
 	}
 }
 
-func (nc *NodeController) Describe(ch chan<- *prometheus.Desc) {
+func (nc *NodeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- nc.nodes
 }
 
-func (nc *NodeController) Collect(ch chan<- prometheus.Metric) {
+func (nc *NodeCollector) Collect(ch chan<- prometheus.Metric) {
 	nodes, err := nc.lister.List(labels.Everything())
 	if err != nil {
 		return

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -4,7 +4,6 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/client/listers/machines/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/listers/core/v1"
 )
 
 const metricsPrefix = "machine_controller_"
@@ -92,71 +91,6 @@ func (mc MachineCollector) Collect(ch chan<- prometheus.Metric) {
 				prometheus.GaugeValue,
 				float64(machine.DeletionTimestamp.Unix()),
 				machine.Name,
-			)
-		}
-	}
-}
-
-type NodeCollector struct {
-	lister v1.NodeLister
-
-	nodes       *prometheus.Desc
-	nodeCreated *prometheus.Desc
-	nodeDeleted *prometheus.Desc
-}
-
-func NewNodeCollector(lister v1.NodeLister) *NodeCollector {
-	return &NodeCollector{
-		lister: lister,
-
-		nodes: prometheus.NewDesc(
-			metricsPrefix+"nodes",
-			"The number of nodes created by a machine",
-			nil, nil,
-		),
-		nodeCreated: prometheus.NewDesc(
-			metricsPrefix+"node_created",
-			"The number of nodes created by a machine",
-			[]string{"node"}, nil,
-		),
-		nodeDeleted: prometheus.NewDesc(
-			metricsPrefix+"node_deleted",
-			"The number of nodes created by a machine",
-			[]string{"node"}, nil,
-		),
-	}
-}
-
-func (nc *NodeCollector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- nc.nodes
-}
-
-func (nc *NodeCollector) Collect(ch chan<- prometheus.Metric) {
-	nodes, err := nc.lister.List(labels.Everything())
-	if err != nil {
-		return
-	}
-
-	ch <- prometheus.MustNewConstMetric(
-		nc.nodes,
-		prometheus.GaugeValue,
-		float64(len(nodes)),
-	)
-
-	for _, node := range nodes {
-		ch <- prometheus.MustNewConstMetric(
-			nc.nodeCreated,
-			prometheus.GaugeValue,
-			float64(node.CreationTimestamp.Unix()),
-			node.Name,
-		)
-
-		if node.DeletionTimestamp != nil {
-			ch <- prometheus.MustNewConstMetric(
-				nc.nodeDeleted,
-				prometheus.GaugeValue,
-				float64(node.DeletionTimestamp.Unix()),
-				node.Name,
 			)
 		}
 	}

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -1,7 +1,10 @@
 package controller
 
 import (
+	"github.com/kubermatic/machine-controller/pkg/client/listers/machines/v1alpha1"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/listers/core/v1"
 )
 
 const metricsPrefix = "machine_controller_"
@@ -25,4 +28,136 @@ func NewMachineControllerMetrics() *MetricsCollection {
 	cm.Errors.Add(0)
 
 	return cm
+}
+
+type MachineCollector struct {
+	lister v1alpha1.MachineLister
+
+	machines       *prometheus.Desc
+	machineCreated *prometheus.Desc
+	machineDeleted *prometheus.Desc
+}
+
+func NewMachineCollector(lister v1alpha1.MachineLister) *MachineCollector {
+	return &MachineCollector{
+		lister: lister,
+
+		machines: prometheus.NewDesc(
+			metricsPrefix+"machines",
+			"The number of machines managed by this machine controller",
+			nil, nil,
+		),
+		machineCreated: prometheus.NewDesc(
+			metricsPrefix+"machine_created",
+			"Timestamp of the machine's creation time",
+			[]string{"machine"}, nil,
+		),
+		machineDeleted: prometheus.NewDesc(
+			metricsPrefix+"machine_deleted",
+			"Timestamp of the machine's deletion time",
+			[]string{"machine"}, nil,
+		),
+	}
+}
+
+func (mc MachineCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- mc.machines
+	ch <- mc.machineCreated
+	ch <- mc.machineDeleted
+}
+
+func (mc MachineCollector) Collect(ch chan<- prometheus.Metric) {
+	machines, err := mc.lister.List(labels.Everything())
+	if err != nil {
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		mc.machines,
+		prometheus.GaugeValue,
+		float64(len(machines)),
+	)
+
+	for _, machine := range machines {
+		ch <- prometheus.MustNewConstMetric(
+			mc.machineCreated,
+			prometheus.GaugeValue,
+			float64(machine.CreationTimestamp.Unix()),
+			machine.Name,
+		)
+
+		if machine.DeletionTimestamp != nil {
+			ch <- prometheus.MustNewConstMetric(
+				mc.machineDeleted,
+				prometheus.GaugeValue,
+				float64(machine.DeletionTimestamp.Unix()),
+				machine.Name,
+			)
+		}
+	}
+}
+
+type NodeController struct {
+	lister v1.NodeLister
+
+	nodes       *prometheus.Desc
+	nodeCreated *prometheus.Desc
+	nodeDeleted *prometheus.Desc
+}
+
+func NewNodeController(lister v1.NodeLister) *NodeController {
+	return &NodeController{
+		lister: lister,
+
+		nodes: prometheus.NewDesc(
+			metricsPrefix+"nodes",
+			"The number of nodes created by a machine",
+			nil, nil,
+		),
+		nodeCreated: prometheus.NewDesc(
+			metricsPrefix+"node_created",
+			"The number of nodes created by a machine",
+			[]string{"node"}, nil,
+		),
+		nodeDeleted: prometheus.NewDesc(
+			metricsPrefix+"node_deleted",
+			"The number of nodes created by a machine",
+			[]string{"node"}, nil,
+		),
+	}
+}
+
+func (nc *NodeController) Describe(ch chan<- *prometheus.Desc) {
+	ch <- nc.nodes
+}
+
+func (nc *NodeController) Collect(ch chan<- prometheus.Metric) {
+	nodes, err := nc.lister.List(labels.Everything())
+	if err != nil {
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		nc.nodes,
+		prometheus.GaugeValue,
+		float64(len(nodes)),
+	)
+
+	for _, node := range nodes {
+		ch <- prometheus.MustNewConstMetric(
+			nc.nodeCreated,
+			prometheus.GaugeValue,
+			float64(node.CreationTimestamp.Unix()),
+			node.Name,
+		)
+
+		if node.DeletionTimestamp != nil {
+			ch <- prometheus.MustNewConstMetric(
+				nc.nodeDeleted,
+				prometheus.GaugeValue,
+				float64(node.DeletionTimestamp.Unix()),
+				node.Name,
+			)
+		}
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
If a machine can't be deleted we want to alert on it.
With the old approach we had state in the metrics that we couldn't delete. Hence a machine that once existed still had metrics which made us unable to alert on the metric, even when the machine was long gone.

By using the Prometheus collector pattern we simply query the informers to give us a list of machines and nodes. We iterate over those lists and forget about the state afterwards.
This improvement allows metrics of deleted machines to not show up anymore.
We can now tell, that if a `machine_controller_machine_deleted` metric is there for more than 10min the machine is not able to be deleted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
I've also removed the histograms for the operations as they were utterly broken.
Example histogram:
```
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="0.005"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="0.01"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="0.025"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="0.05"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="0.1"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="0.25"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="0.5"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="1"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="2.5"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="5"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="10"} 64
machine_controller_controller_operation_duration_seconds_bucket{operation="validate-machine",le="+Inf"} 64
machine_controller_controller_operation_duration_seconds_sum{operation="validate-machine"} 0.00042467500000000006
machine_controller_controller_operation_duration_seconds_count{operation="validate-machine"} 64
```
In this example, all buckets were hit 64 making them useless. For all the other machine-controller histograms I looked at I saw the same results.