### PR TITLE
 pass a machine object updater to provider Create/Delete functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,11 @@ jobs:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
       - run: DEP_RELEASE_TAG=v0.4.1 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-      - run: dep status
+      - run: make vendor
+      - save_cache:
+          key: repo-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - /go/src/github.com/kubermatic/machine-controller
 
   test:
     <<: *defaults
@@ -34,6 +38,7 @@ jobs:
     steps:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
+      - run: DEP_RELEASE_TAG=v0.4.1 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
       - run: make machine-controller
       - save_cache:
           key: machine-controller-{{ .Revision }}
@@ -110,13 +115,13 @@ workflows:
               only: /v.*/
       - test:
           requires:
-            - checkout_code
+            - check-dependencies
           filters:
             tags:
               only: /v.*/
       - build:
           requires:
-            - checkout_code
+            - check-dependencies
           filters:
             tags:
               only: /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,7 @@ jobs:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
       - run: DEP_RELEASE_TAG=v0.4.1 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-      - run: make vendor
-      - save_cache:
-          key: repo-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - /go/src/github.com/kubermatic/machine-controller
+      - run: dep status
 
   test:
     <<: *defaults
@@ -115,13 +111,13 @@ workflows:
               only: /v.*/
       - test:
           requires:
-            - check-dependencies
+            - checkout_code
           filters:
             tags:
               only: /v.*/
       - build:
           requires:
-            - check-dependencies
+            - checkout_code
           filters:
             tags:
               only: /v.*/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -853,6 +853,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "92d567349eff6d249a0e942969fe9d8ace5b776813582405dc9700fc7c7e5a5a"
+  inputs-digest = "c8fb26b79267a3d4959d1cc5e91837a847ce8ce64808ce00620a24381c385d98"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -19,6 +19,10 @@ limitations under the License.
 package externalversions
 
 import (
+	"reflect"
+	"sync"
+	"time"
+
 	versioned "github.com/kubermatic/machine-controller/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/kubermatic/machine-controller/pkg/client/informers/externalversions/internalinterfaces"
 	machines "github.com/kubermatic/machine-controller/pkg/client/informers/externalversions/machines"
@@ -26,9 +30,6 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
-	reflect "reflect"
-	sync "sync"
-	time "time"
 )
 
 type sharedInformerFactory struct {

--- a/pkg/cloudprovider/cloud/provider.go
+++ b/pkg/cloudprovider/cloud/provider.go
@@ -25,7 +25,10 @@ type Provider interface {
 	GetCloudConfig(spec v1alpha1.MachineSpec) (config string, name string, err error)
 
 	// Create creates a cloud instance according to the given machine
-	Create(machine *v1alpha1.Machine, userdata string) (instance.Instance, error)
+	Create(machine *v1alpha1.Machine, update MachineUpdater, userdata string) (instance.Instance, error)
 
-	Delete(machine *v1alpha1.Machine, instance instance.Instance) error
+	Delete(machine *v1alpha1.Machine, update MachineUpdater, instance instance.Instance) error
 }
+
+// MachineUpdater defines a function to persist an update to a machine
+type MachineUpdater func(string, func(*v1alpha1.Machine)) (*v1alpha1.Machine, error)

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -503,7 +503,7 @@ func ensureDefaultInstanceProfileExists(client *iam.IAM) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	config, pc, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -630,7 +630,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 		Groups:     aws.StringSlice(securityGroupIDs),
 	})
 	if err != nil {
-		delErr := p.Delete(machine, awsInstance)
+		delErr := p.Delete(machine, update, awsInstance)
 		if delErr != nil {
 			return nil, awsErrorToTerminalError(err, fmt.Sprintf("failed to attach instance %s to security group %s & delete the created instance", aws.StringValue(runOut.Instances[0].InstanceId), defaultSecurityGroupName))
 		}
@@ -640,7 +640,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 	return awsInstance, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
 	config, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -640,7 +640,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	return awsInstance, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater, instance instance.Instance) error {
 	config, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -301,7 +301,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	return spec, false, nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	config, providerCfg, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -406,7 +406,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 	return &azureVM{vm: &vm, ipAddresses: ipAddresses, status: status}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
 	config, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return fmt.Errorf("failed to parse MachineSpec: %v", err)

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -301,7 +301,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	return spec, false, nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	config, providerCfg, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -406,7 +406,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	return &azureVM{vm: &vm, ipAddresses: ipAddresses, status: status}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater, instance instance.Instance) error {
 	config, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return fmt.Errorf("failed to parse MachineSpec: %v", err)

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -252,7 +252,7 @@ func uploadRandomSSHPublicKey(ctx context.Context, service godo.KeysService) (st
 	return newDoKey.Fingerprint, nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -324,7 +324,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	return &doInstance{droplet: droplet}, err
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater, instance instance.Instance) error {
 	c, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -252,7 +252,7 @@ func uploadRandomSSHPublicKey(ctx context.Context, service godo.KeysService) (st
 	return newDoKey.Fingerprint, nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -324,7 +324,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 	return &doInstance{droplet: droplet}, err
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
 	c, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -73,10 +73,10 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (string, string, er
 }
 
 // Create creates a cloud instance according to the given machine
-func (p *provider) Create(_ *v1alpha1.Machine, _ string) (instance.Instance, error) {
+func (p *provider) Create(_ *v1alpha1.Machine, _ cloud.MachineUpdater, _ string) (instance.Instance, error) {
 	return FakeCloudProviderInstance{}, nil
 }
 
-func (p *provider) Delete(_ *v1alpha1.Machine, _ instance.Instance) error {
+func (p *provider) Delete(_ *v1alpha1.Machine, _ cloud.MachineUpdater, _ instance.Instance) error {
 	return nil
 }

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -131,7 +131,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -211,7 +211,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 	return &hetznerServer{server: serverCreateRes.Server}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
 	c, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -131,7 +131,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -211,7 +211,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	return &hetznerServer{server: serverCreateRes.Server}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater, instance instance.Instance) error {
 	c, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -342,7 +342,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	c, _, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -465,7 +465,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	return &osInstance{server: &server}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater, instance instance.Instance) error {
 	c, _, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -342,7 +342,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	c, _, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -465,7 +465,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 	return &osInstance{server: &server}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, instance instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, instance instance.Instance) error {
 	c, _, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -298,7 +298,7 @@ func machineInvalidConfigurationTerminalError(err error) error {
 	}
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	config, pc, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config: %v", err)
@@ -386,7 +386,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	return VSphereServer{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, _ instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater, _ instance.Instance) error {
 	config, pc, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %v", err)

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -298,7 +298,7 @@ func machineInvalidConfigurationTerminalError(err error) error {
 	}
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
 	config, pc, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config: %v", err)
@@ -386,7 +386,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, userdata string) (instance.
 	return VSphereServer{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, _ instance.Instance) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater, _ instance.Instance) error {
 	config, pc, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %v", err)

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -57,6 +57,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/tools/reference"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -237,16 +238,36 @@ func (c *Controller) getNodeByNodeRef(nodeRef *corev1.ObjectReference) (*corev1.
 	return listerNode.DeepCopy(), nil
 }
 
-func (c *Controller) updateMachine(machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
-	machine.Status.LastUpdated = metav1.Now()
-	return c.machineClient.MachineV1alpha1().Machines().Update(machine)
+func (c *Controller) updateMachine(name string, modify func(*machinev1alpha1.Machine)) (*machinev1alpha1.Machine, error) {
+	var updatedMachine *machinev1alpha1.Machine
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		var retryErr error
+
+		//Get latest version from cache
+		cacheMachine, err := c.machineClient.Machine().Machines().Get(name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		currentMachine := cacheMachine.DeepCopy()
+
+		// Apply modifications
+		modify(currentMachine)
+
+		// Update the machine
+		updatedMachine, retryErr = c.machineClient.MachineV1alpha1().Machines().Update(currentMachine)
+		return retryErr
+	})
+
+	return updatedMachine, err
 }
 
 func (c *Controller) clearMachineErrorIfSet(machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
 	if machine.Status.ErrorMessage != nil || machine.Status.ErrorReason != nil {
-		machine.Status.ErrorMessage = nil
-		machine.Status.ErrorReason = nil
-		return c.updateMachine(machine)
+		return c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+			m.Status.ErrorMessage = nil
+			m.Status.ErrorReason = nil
+		})
 	}
 	return machine, nil
 }
@@ -254,9 +275,10 @@ func (c *Controller) clearMachineErrorIfSet(machine *machinev1alpha1.Machine) (*
 // updateMachine updates machine's ErrorMessage and ErrorReason regardless if they were set or not
 // this essentially overwrites previous values
 func (c *Controller) updateMachineError(machine *machinev1alpha1.Machine, reason machinev1alpha1.MachineStatusError, message string) (*machinev1alpha1.Machine, error) {
-	machine.Status.ErrorMessage = &message
-	machine.Status.ErrorReason = &reason
-	return c.updateMachine(machine)
+	return c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+		m.Status.ErrorMessage = &message
+		m.Status.ErrorReason = &reason
+	})
 }
 
 // updateMachineErrorIfTerminalError is a convenience method that will update machine's Status if the given err is terminal
@@ -365,8 +387,9 @@ func (c *Controller) syncHandler(key string) error {
 		//In case we cannot find a node for the NodeRef we must remove the NodeRef & recreate an instance on the next sync
 		if kerrors.IsNotFound(err) {
 			glog.V(4).Infof("found invalid NodeRef on machine %s. Deleting reference...", machine.Name)
-			machine.Status.NodeRef = nil
-			_, err = c.updateMachine(machine)
+			_, err = c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+				m.Status.NodeRef = nil
+			})
 			return err
 		}
 		return fmt.Errorf("failed to check if node for machine exists: '%s'", err)
@@ -391,10 +414,11 @@ func (c *Controller) cleanupMachineAfterDeletion(machine *machinev1alpha1.Machin
 	var err error
 	glog.V(4).Infof("Removing finalizers from machine machine %s", machine.Name)
 
-	finalizers := sets.NewString(machine.Finalizers...)
-	finalizers.Delete(finalizerDeleteInstance)
-	machine.Finalizers = finalizers.List()
-	if machine, err = c.updateMachine(machine); err != nil {
+	if machine, err = c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+		finalizers := sets.NewString(m.Finalizers...)
+		finalizers.Delete(finalizerDeleteInstance)
+		m.Finalizers = finalizers.List()
+	}); err != nil {
 		return fmt.Errorf("failed to update machine after removing the delete instance finalizer: %v", err)
 	}
 
@@ -456,10 +480,12 @@ func (c *Controller) ensureInstanceExistsForMachine(prov cloud.Provider, machine
 	if changed {
 		glog.V(4).Infof("updating machine '%s' with defaults...", machine.Name)
 		c.recorder.Event(machine, corev1.EventTypeNormal, "Defaulted", "Updated machine with defaults")
-		machine.Spec = defaultedMachineSpec
-		if machine, err = c.updateMachine(machine); err != nil {
+		if machine, err = c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+			m.Spec = defaultedMachineSpec
+		}); err != nil {
 			return fmt.Errorf("failed to update machine '%s' after adding defaults: '%v'", machine.Name, err)
 		}
+
 		glog.V(4).Infof("Successfully updated machine '%s' with defaults!", machine.Name)
 	}
 
@@ -635,7 +661,6 @@ func (c *Controller) updateMachineStatus(machine *machinev1alpha1.Machine, node 
 	}
 
 	var (
-		updated                     bool
 		runtimeName, runtimeVersion string
 		err                         error
 	)
@@ -644,39 +669,38 @@ func (c *Controller) updateMachineStatus(machine *machinev1alpha1.Machine, node 
 	if err != nil {
 		return fmt.Errorf("failed to get node reference for %s : %v", node.Name, err)
 	}
-	if !equality.Semantic.DeepEqual(machine.Status.NodeRef, ref) {
-		machine.Status.NodeRef = ref
-		updated = true
-	}
 
-	if machine.Status.Versions == nil {
-		machine.Status.Versions = &machinev1alpha1.MachineVersionInfo{}
-	}
-
-	if node.Status.NodeInfo.ContainerRuntimeVersion != "" {
-		runtimeName, runtimeVersion, err = parseContainerRuntime(node.Status.NodeInfo.ContainerRuntimeVersion)
-		if err != nil {
-			glog.V(2).Infof("failed to parse container runtime from node %s: %v", node.Name, err)
-			runtimeName = "unknown"
-			runtimeVersion = "unknown"
+	machine, err = c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+		if !equality.Semantic.DeepEqual(m.Status.NodeRef, ref) {
+			m.Status.NodeRef = ref
 		}
-		if machine.Status.Versions.ContainerRuntime.Name != runtimeName || machine.Status.Versions.ContainerRuntime.Version != runtimeVersion {
-			machine.Status.Versions.ContainerRuntime.Name = runtimeName
-			machine.Status.Versions.ContainerRuntime.Version = runtimeVersion
-			updated = true
+
+		if m.Status.Versions == nil {
+			m.Status.Versions = &machinev1alpha1.MachineVersionInfo{}
 		}
+
+		if node.Status.NodeInfo.ContainerRuntimeVersion != "" {
+			runtimeName, runtimeVersion, err = parseContainerRuntime(node.Status.NodeInfo.ContainerRuntimeVersion)
+			if err != nil {
+				glog.V(2).Infof("failed to parse container runtime from node %s: %v", node.Name, err)
+				runtimeName = "unknown"
+				runtimeVersion = "unknown"
+			}
+			if m.Status.Versions.ContainerRuntime.Name != runtimeName || m.Status.Versions.ContainerRuntime.Version != runtimeVersion {
+				m.Status.Versions.ContainerRuntime.Name = runtimeName
+				m.Status.Versions.ContainerRuntime.Version = runtimeVersion
+			}
+		}
+
+		if m.Status.Versions.Kubelet != node.Status.NodeInfo.KubeletVersion {
+			m.Status.Versions.Kubelet = node.Status.NodeInfo.KubeletVersion
+		}
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to update machine: %v", err)
 	}
 
-	if machine.Status.Versions.Kubelet != node.Status.NodeInfo.KubeletVersion {
-		machine.Status.Versions.Kubelet = node.Status.NodeInfo.KubeletVersion
-		updated = true
-	}
-
-	if updated {
-		if machine, err = c.updateMachine(machine); err != nil {
-			return fmt.Errorf("failed to update machine: %v", err)
-		}
-	}
 	return nil
 }
 
@@ -726,14 +750,20 @@ func (c *Controller) getNode(instance instance.Instance, provider providerconfig
 }
 
 func (c *Controller) defaultContainerRuntime(machine *machinev1alpha1.Machine, prov userdata.Provider) (*machinev1alpha1.Machine, error) {
+	var err error
+
 	if machine.Spec.Versions.Kubelet == "" {
-		machine.Spec.Versions.Kubelet = latestKubernetesVersion
+		if machine, err = c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+			m.Spec.Versions.Kubelet = latestKubernetesVersion
+		}); err != nil {
+			return nil, err
+		}
 	}
 
-	var err error
 	if machine.Spec.Versions.ContainerRuntime.Name == "" {
-		machine.Spec.Versions.ContainerRuntime.Name = containerruntime.Docker
-		if machine, err = c.updateMachine(machine); err != nil {
+		if machine, err = c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+			m.Spec.Versions.ContainerRuntime.Name = containerruntime.Docker
+		}); err != nil {
 			return nil, err
 		}
 	}
@@ -753,23 +783,27 @@ func (c *Controller) defaultContainerRuntime(machine *machinev1alpha1.Machine, p
 			return nil, fmt.Errorf("invalid container runtime. Supported: '%s'", containerruntime.Docker)
 		}
 
+		var newVersion string
 		providerSupportedVersions := prov.SupportedContainerRuntimes()
 		for _, v := range defaultVersions {
 			for _, sv := range providerSupportedVersions {
 				if sv.Version == v {
 					// we should not return asap as we prefer the highest supported version
-					machine.Spec.Versions.ContainerRuntime.Version = sv.Version
+					newVersion = sv.Version
 				}
 			}
 		}
-		if machine.Spec.Versions.ContainerRuntime.Version == "" {
+		if newVersion == "" {
 			return nil, fmt.Errorf("no supported versions available for '%s'", machine.Spec.Versions.ContainerRuntime.Name)
 		}
-		if machine, err = c.updateMachine(machine); err != nil {
+		machine, err = c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+			m.Spec.Versions.ContainerRuntime.Version = newVersion
+		})
+		if err != nil {
 			return nil, err
 		}
+		return machine, err
 	}
-
 	return machine, nil
 }
 
@@ -865,10 +899,12 @@ func (c *Controller) ReadinessChecks() map[string]healthcheck.Check {
 
 func (c *Controller) ensureDeleteFinalizerExists(machine *machinev1alpha1.Machine) (*machinev1alpha1.Machine, error) {
 	if !sets.NewString(machine.Finalizers...).Has(finalizerDeleteInstance) {
-		finalizers := sets.NewString(machine.Finalizers...)
-		finalizers.Insert(finalizerDeleteInstance)
-		machine.Finalizers = finalizers.List()
-		if _, err := c.updateMachine(machine); err != nil {
+		var err error
+		if machine, err = c.updateMachine(machine.Name, func(m *machinev1alpha1.Machine) {
+			finalizers := sets.NewString(m.Finalizers...)
+			finalizers.Insert(finalizerDeleteInstance)
+			m.Finalizers = finalizers.List()
+		}); err != nil {
 			return nil, fmt.Errorf("failed to update machine after adding the delete instance finalizer: %v", err)
 		}
 		glog.V(4).Infof("Added delete finalizer to machine %s", machine.Name)

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -243,13 +243,11 @@ func (c *Controller) updateMachine(name string, modify func(*machinev1alpha1.Mac
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var retryErr error
 
-		//Get latest version from cache
-		cacheMachine, err := c.machineClient.Machine().Machines().Get(name, metav1.GetOptions{})
+		//Get latest version from API
+		currentMachine, err := c.machineClient.Machine().Machines().Get(name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-
-		currentMachine := cacheMachine.DeepCopy()
 
 		// Apply modifications
 		modify(currentMachine)

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -300,11 +300,11 @@ func (c *Controller) getProviderInstance(prov cloud.Provider, machine *machinev1
 }
 
 func (c *Controller) deleteProviderInstance(prov cloud.Provider, machine *machinev1alpha1.Machine, instance instance.Instance) error {
-	return prov.Delete(machine, instance)
+	return prov.Delete(machine, c.updateMachine, instance)
 }
 
 func (c *Controller) createProviderInstance(prov cloud.Provider, machine *machinev1alpha1.Machine, userdata string) (instance.Instance, error) {
-	return prov.Create(machine, userdata)
+	return prov.Create(machine, c.updateMachine, userdata)
 }
 
 func (c *Controller) validateMachine(prov cloud.Provider, machine *machinev1alpha1.Machine) error {

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	"github.com/kubermatic/machine-controller/pkg/userdata"
 
-	"github.com/go-test/deep"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,6 +23,8 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/go-test/deep"
 )
 
 type fakeInstance struct {

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -208,16 +208,9 @@ func TestController_AddDeleteFinalizerOnlyIfValidationSucceeded(t *testing.T) {
 			machine.Name = "testmachine"
 			machine.Spec.ProviderConfig.Raw = []byte(providerConfig)
 
-			machineIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-			err := machineIndexer.Add(machine)
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			controller, fakeMachineClient := createTestMachineController(t, machine)
 
-			err = controller.syncHandler("testmachine")
-			if err != nil && err.Error() != test.err {
+			if err := controller.syncHandler("testmachine"); err != nil && err.Error() != test.err {
 				t.Fatalf("Expected test to have err '%s' but was '%v'", test.err, err)
 			}
 
@@ -328,13 +321,6 @@ func createTestMachineController(t *testing.T, objects ...runtime.Object) (*Cont
 	kubeInformersFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Millisecond*50)
 	kubeSystemInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Millisecond*50)
 	machineInformerFactory := machineinformers.NewSharedInformerFactory(machineClient, time.Millisecond*50)
-
-	machineIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
-	for _, o := range objects {
-		if err := machineIndexer.Add(o); err != nil {
-			t.Fatal(err)
-		}
-	}
 
 	ctrl := NewMachineController(
 		kubeClient,


### PR DESCRIPTION
**What this PR does / why we need it**:
This will allow cloud provider packages to add/remove finalizers on machine objects.