### PR TITLE
Fix DNS options for ubuntu and centos.

### DIFF
--- a/pkg/userdata/centos/testdata/docker-1.13-kubelet-v1.11-aws.golden
+++ b/pkg/userdata/centos/testdata/docker-1.13-kubelet-v1.11-aws.golden
@@ -38,6 +38,7 @@ write_files:
 
 - path: "/etc/sysconfig/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \

--- a/pkg/userdata/centos/testdata/docker-1.13-kubelet-v1.8-aws.golden
+++ b/pkg/userdata/centos/testdata/docker-1.13-kubelet-v1.8-aws.golden
@@ -38,6 +38,7 @@ write_files:
 
 - path: "/etc/sysconfig/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \

--- a/pkg/userdata/centos/testdata/docker-1.13-kubelet-v1.9-aws.golden
+++ b/pkg/userdata/centos/testdata/docker-1.13-kubelet-v1.9-aws.golden
@@ -38,6 +38,7 @@ write_files:
 
 - path: "/etc/sysconfig/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \

--- a/pkg/userdata/centos/userdata.go
+++ b/pkg/userdata/centos/userdata.go
@@ -219,6 +219,7 @@ write_files:
 
 - path: "/etc/sysconfig/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       {{- if .CloudProvider }}
       --cloud-provider={{ .CloudProvider }} \

--- a/pkg/userdata/ubuntu/testdata/docker-1.13-dist-upgrade-on-boot-aws.golden
+++ b/pkg/userdata/ubuntu/testdata/docker-1.13-dist-upgrade-on-boot-aws.golden
@@ -204,6 +204,7 @@ write_files:
 
 - path: "/etc/default/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \

--- a/pkg/userdata/ubuntu/testdata/docker-1.13-kubelet-1.11-aws.golden
+++ b/pkg/userdata/ubuntu/testdata/docker-1.13-kubelet-1.11-aws.golden
@@ -203,6 +203,7 @@ write_files:
 
 - path: "/etc/default/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \

--- a/pkg/userdata/ubuntu/testdata/docker-17.03-openstack-kubelet-v-version-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/docker-17.03-openstack-kubelet-v-version-prefix.golden
@@ -204,6 +204,7 @@ write_files:
 
 - path: "/etc/default/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \

--- a/pkg/userdata/ubuntu/testdata/docker-17.03-openstack-multiple-dns.golden
+++ b/pkg/userdata/ubuntu/testdata/docker-17.03-openstack-multiple-dns.golden
@@ -204,6 +204,7 @@ write_files:
 
 - path: "/etc/default/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \

--- a/pkg/userdata/ubuntu/testdata/docker-17.03-openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/docker-17.03-openstack-overwrite-cloud-config.golden
@@ -206,6 +206,7 @@ write_files:
 
 - path: "/etc/default/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \

--- a/pkg/userdata/ubuntu/userdata.go
+++ b/pkg/userdata/ubuntu/userdata.go
@@ -380,6 +380,7 @@ write_files:
 
 - path: "/etc/default/kubelet-overwrite"
   content: |
+    KUBELET_DNS_ARGS=
     KUBELET_EXTRA_ARGS=--authentication-token-webhook=true \
       {{- if .CloudProvider }}
       --cloud-provider={{ .CloudProvider }} \


### PR DESCRIPTION
**What this PR does / why we need it**:

For kubelet flags a systemd-unit overwrite is used to specify DNS options.
What is missing is the clearing out $KUBELET_DNS_ARGS (from kubeadm)
to make the overwrite take any effect.
This fixes the userdata for ubuntu and centos.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
