### PR TITLE
Default nodename to machine name

### DIFF
--- a/examples/machine-aws.yaml
+++ b/examples/machine-aws.yaml
@@ -15,8 +15,6 @@ kind: Machine
 metadata:
   name: machine1
 spec:
-  metadata:
-    name: node1
   providerConfig:
     sshPublicKeys:
       - "<< YOUR_PUBLIC_KEY >>"

--- a/examples/machine-azure.yaml
+++ b/examples/machine-azure.yaml
@@ -16,7 +16,6 @@ metadata:
   name: machine1
 spec:
   metadata:
-    name: node1
     labels:
       foo: "bar"
   providerConfig:

--- a/examples/machine-digitalocean.yaml
+++ b/examples/machine-digitalocean.yaml
@@ -14,8 +14,6 @@ kind: Machine
 metadata:
   name: machine1
 spec:
-  metadata:
-    name: node1
   providerConfig:
     sshPublicKeys:
       - "<< YOUR_PUBLIC_KEY >>"

--- a/examples/machine-hetzner.yaml
+++ b/examples/machine-hetzner.yaml
@@ -14,8 +14,6 @@ kind: Machine
 metadata:
   name: machine1
 spec:
-  metadata:
-    name: node1
   providerConfig:
     sshPublicKeys:
       - "<< YOUR_PUBLIC_KEY >>"

--- a/examples/machine-openstack.yaml
+++ b/examples/machine-openstack.yaml
@@ -27,7 +27,6 @@ metadata:
   name: machine1
 spec:
   metadata:
-    name: node1
     labels:
       foo: "bar"
   providerConfig:

--- a/examples/machine-vsphere.yaml
+++ b/examples/machine-vsphere.yaml
@@ -15,7 +15,6 @@ metadata:
   name: machine1
 spec:
   metadata:
-    name: node1
     labels:
       foo: "bar"
   providerConfig:

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -506,6 +506,9 @@ func (c *Controller) ensureInstanceExistsForMachine(prov cloud.Provider, machine
 				return fmt.Errorf("failed to create bootstrap kubeconfig: %v", err)
 			}
 
+			if machine.Spec.Name == "" {
+				machine.Spec.Name = machine.Name
+			}
 			userdata, err := userdataProvider.UserData(machine.Spec, kubeconfig, prov, c.clusterDNSIPs)
 			if err != nil {
 				c.recorder.Eventf(machine, corev1.EventTypeWarning, "UserdataRenderingFailed", "Userdata rendering failed: %v", err)

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -331,6 +331,13 @@ func (c *Controller) syncHandler(key string) error {
 	}
 	machine := listerMachine.DeepCopy()
 
+	if machine.Spec.Name == "" {
+		machine, err = c.updateMachine(machine.Name, func(modifiedMachine *machinev1alpha1.Machine) {
+			modifiedMachine.Spec.Name = modifiedMachine.Name
+		})
+		c.recorder.Eventf(machine, corev1.EventTypeNormal, "NodeName defaulted", "Defaulted nodename to %s", machine.Name)
+	}
+
 	// step 1: check if the machine can be processed by this controller.
 	// set the annotation "machine.k8s.io/controller": my-controller
 	// and the flag --name=my-controller to make only this controller process a node
@@ -506,9 +513,6 @@ func (c *Controller) ensureInstanceExistsForMachine(prov cloud.Provider, machine
 				return fmt.Errorf("failed to create bootstrap kubeconfig: %v", err)
 			}
 
-			if machine.Spec.Name == "" {
-				machine.Spec.Name = machine.Name
-			}
 			userdata, err := userdataProvider.UserData(machine.Spec, kubeconfig, prov, c.clusterDNSIPs)
 			if err != nil {
 				c.recorder.Eventf(machine, corev1.EventTypeWarning, "UserdataRenderingFailed", "Userdata rendering failed: %v", err)

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -335,6 +335,9 @@ func (c *Controller) syncHandler(key string) error {
 		machine, err = c.updateMachine(machine.Name, func(modifiedMachine *machinev1alpha1.Machine) {
 			modifiedMachine.Spec.Name = modifiedMachine.Name
 		})
+		if err != nil {
+			return fmt.Errorf("failed to default machine.Spec.Name to %s: %v", listerMachine.Name, err)
+		}
 		c.recorder.Eventf(machine, corev1.EventTypeNormal, "NodeName defaulted", "Defaulted nodename to %s", machine.Name)
 	}
 

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -144,7 +144,6 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 
 	scenarioParams := append([]string(nil), testParams...)
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< MACHINE_NAME >>=%s", kubernetesCompliantName))
-	scenarioParams = append(scenarioParams, fmt.Sprintf("<< NODE_NAME >>=%s", kubernetesCompliantName))
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< OS_NAME >>=%s", testCase.osName))
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< CONTAINER_RUNTIME >>=%s", testCase.containerRuntime))
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< KUBERNETES_VERSION >>=%s", testCase.kubernetesVersion))

--- a/test/e2e/provisioning/testdata/machine-aws.yaml
+++ b/test/e2e/provisioning/testdata/machine-aws.yaml
@@ -3,8 +3,6 @@ kind: Machine
 metadata:
   name: << MACHINE_NAME >>
 spec:
-  metadata:
-    name: << NODE_NAME >>
   providerConfig:
     sshPublicKeys:
       - "<< YOUR_PUBLIC_KEY >>"

--- a/test/e2e/provisioning/testdata/machine-azure.yaml
+++ b/test/e2e/provisioning/testdata/machine-azure.yaml
@@ -3,8 +3,6 @@ kind: Machine
 metadata:
   name: << MACHINE_NAME >>
 spec:
-  metadata:
-    name: << NODE_NAME >>
   providerConfig:
     sshPublicKeys:
       - "<< YOUR_PUBLIC_KEY >>"

--- a/test/e2e/provisioning/testdata/machine-digitalocean.yaml
+++ b/test/e2e/provisioning/testdata/machine-digitalocean.yaml
@@ -3,8 +3,6 @@ kind: Machine
 metadata:
   name: << MACHINE_NAME >>
 spec:
-  metadata:
-    name: << NODE_NAME >>
   providerConfig:
     sshPublicKeys:
       - "<< YOUR_PUBLIC_KEY >>"

--- a/test/e2e/provisioning/testdata/machine-hetzner.yaml
+++ b/test/e2e/provisioning/testdata/machine-hetzner.yaml
@@ -3,8 +3,6 @@ kind: Machine
 metadata:
   name: << MACHINE_NAME >>
 spec:
-  metadata:
-    name: << NODE_NAME >>
   providerConfig:
     sshPublicKeys:
       - "<< YOUR_PUBLIC_KEY >>"

--- a/test/e2e/provisioning/testdata/machine-openstack-upgrade.yml
+++ b/test/e2e/provisioning/testdata/machine-openstack-upgrade.yml
@@ -4,7 +4,6 @@ metadata:
   name: << MACHINE_NAME >>
 spec:
   metadata:
-    name: << NODE_NAME >>
     labels:
       foo: "bar"
   providerConfig:

--- a/test/e2e/provisioning/testdata/machine-openstack.yaml
+++ b/test/e2e/provisioning/testdata/machine-openstack.yaml
@@ -4,7 +4,6 @@ metadata:
   name: << MACHINE_NAME >>
 spec:
   metadata:
-    name: << NODE_NAME >>
     labels:
       foo: "bar"
   providerConfig:

--- a/test/e2e/provisioning/testdata/machine-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machine-vsphere-static-ip.yaml
@@ -4,7 +4,6 @@ metadata:
   name: << MACHINE_NAME >>
 spec:
   metadata:
-    name: << NODE_NAME >>
     labels:
       foo: "bar"
   providerConfig:

--- a/test/e2e/provisioning/testdata/machine-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machine-vsphere.yaml
@@ -4,7 +4,6 @@ metadata:
   name: << MACHINE_NAME >>
 spec:
   metadata:
-    name: << NODE_NAME >>
     labels:
       foo: "bar"
   providerConfig:

--- a/test/tools/integration/Makefile
+++ b/test/tools/integration/Makefile
@@ -10,13 +10,7 @@ else ifeq ($(MAKECMDGOALS),destroy)
 	EXTRA_ARG = -force
 endif
 
-.plugins/terraform-provider-hcloud:
-	mkdir -p $(dir $@)
-	curl -L https://github.com/hetznercloud/terraform-provider-hcloud/releases/download/v1.1.0/terraform-provider-hcloud_v1.1.0_linux_amd64.zip > /tmp/provider-hcloud.zip
-	unzip -n /tmp/provider-hcloud.zip terraform-provider-hcloud
-	mv terraform-provider-hcloud $@
-
-terraform: .plugins/terraform-provider-hcloud
+terraform:
 	@if ! which terraform; then \
 		curl https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_linux_amd64.zip > /tmp/terraform.zip && \
 		unzip -n /tmp/terraform.zip terraform; \

--- a/test/tools/integration/Makefile
+++ b/test/tools/integration/Makefile
@@ -17,7 +17,7 @@ terraform:
 	fi
 
 .terraform: terraform
-	terraform init -plugin-dir .plugins >/dev/null 2>&1
+	terraform init >/dev/null 2>&1
 
 .PHONY: plan apply destroy
 plan apply destroy: .terraform

--- a/test/tools/integration/Makefile
+++ b/test/tools/integration/Makefile
@@ -12,7 +12,7 @@ endif
 
 terraform:
 	@if ! which terraform; then \
-		curl https://releases.hashicorp.com/terraform/0.11.3/terraform_0.11.3_linux_amd64.zip > /tmp/terraform.zip && \
+		curl https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip > /tmp/terraform.zip && \
 		unzip -n /tmp/terraform.zip terraform; \
 	fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes it easier for higher-level controllers like the machineset controller to generate machines, as it doesn't have to set their name anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
