### PR TITLE
Bring back node metrics

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -232,7 +232,8 @@ func main() {
 	var g run.Group
 	{
 		prometheusRegistry.MustRegister(machinecontroller.NewMachineCollector(
-			machineInformerFactory.Machine().V1alpha1().Machines().Lister(),
+			runOptions.machineLister,
+			runOptions.nodeLister,
 			kubeClient,
 		))
 

--- a/pkg/controller/machine/metrics.go
+++ b/pkg/controller/machine/metrics.go
@@ -56,8 +56,8 @@ type machineMetricLabels struct {
 	ProviderLabels  map[string]string
 }
 
-// Counter turns a label collection into a Prometheus counter.
-func (l *machineMetricLabels) Counter(value uint) prometheus.Counter {
+// Gauge turns a label collection into a Prometheus gauge.
+func (l *machineMetricLabels) Gauge(value uint) prometheus.Gauge {
 	labels := make(map[string]string)
 	labelNames := make([]string, 0)
 
@@ -81,14 +81,14 @@ func (l *machineMetricLabels) Counter(value uint) prometheus.Counter {
 		labelNames = append(labelNames, k)
 	}
 
-	counterVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+	gaugeVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: metricsPrefix + "machines",
 	}, labelNames)
 
-	counter := counterVec.With(labels)
-	counter.Set(float64(value))
+	gauge := gaugeVec.With(labels)
+	gauge.Set(float64(value))
 
-	return counter
+	return gauge
 }
 
 type nodeMetricLabels struct {
@@ -99,8 +99,8 @@ type nodeMetricLabels struct {
 	Architecture     string
 }
 
-// Counter turns a label collection into a Prometheus counter.
-func (l *nodeMetricLabels) Counter(value uint) prometheus.Counter {
+// Gauge turns a label collection into a Prometheus gauge.
+func (l *nodeMetricLabels) Gauge(value uint) prometheus.Gauge {
 	labels := make(map[string]string)
 	labelNames := make([]string, 0)
 
@@ -128,14 +128,14 @@ func (l *nodeMetricLabels) Counter(value uint) prometheus.Counter {
 		labelNames = append(labelNames, k)
 	}
 
-	counterVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+	gaugeVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: metricsPrefix + "nodes",
 	}, labelNames)
 
-	counter := counterVec.With(labels)
-	counter.Set(float64(value))
+	gauge := gaugeVec.With(labels)
+	gauge.Set(float64(value))
 
-	return counter
+	return gauge
 }
 
 // NewMachineCollector creates a new machine metrics collector.
@@ -251,7 +251,7 @@ func (mc MachineCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	for info, count := range machineCountByLabels {
-		ch <- info.Counter(count)
+		ch <- info.Gauge(count)
 	}
 
 	// Gather the same kind of information in much the same
@@ -297,6 +297,6 @@ func (mc MachineCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	for info, count := range nodeCountByLabels {
-		ch <- info.Counter(count)
+		ch <- info.Gauge(count)
 	}
 }

--- a/pkg/controller/machine/metrics.go
+++ b/pkg/controller/machine/metrics.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
 )
 
 const metricsPrefix = "machine_controller_"
@@ -36,13 +37,16 @@ func NewMachineControllerMetrics() *MetricsCollection {
 	return cm
 }
 
+// MachineCollector is a Prometheus metrics collector.
 type MachineCollector struct {
-	lister     v1alpha1.MachineLister
-	kubeClient kubernetes.Interface
+	machineLister v1alpha1.MachineLister
+	nodeLister    listerscorev1.NodeLister
+	kubeClient    kubernetes.Interface
 
 	machines       *prometheus.Desc
 	machineCreated *prometheus.Desc
 	machineDeleted *prometheus.Desc
+	nodes          *prometheus.Desc
 }
 
 type machineMetricLabels struct {
@@ -87,10 +91,59 @@ func (l *machineMetricLabels) Counter(value uint) prometheus.Counter {
 	return counter
 }
 
-func NewMachineCollector(lister v1alpha1.MachineLister, kubeClient kubernetes.Interface) *MachineCollector {
+type nodeMetricLabels struct {
+	ContainerRuntime string
+	KubeletVersion   string
+	OperatingSystem  string
+	OSImage          string
+	Architecture     string
+}
+
+// Counter turns a label collection into a Prometheus counter.
+func (l *nodeMetricLabels) Counter(value uint) prometheus.Counter {
+	labels := make(map[string]string)
+	labelNames := make([]string, 0)
+
+	if len(l.KubeletVersion) > 0 {
+		labels["kubelet_version"] = l.KubeletVersion
+	}
+
+	if len(l.ContainerRuntime) > 0 {
+		labels["runtime"] = string(l.ContainerRuntime)
+	}
+
+	if len(l.OperatingSystem) > 0 {
+		labels["os"] = string(l.OperatingSystem)
+	}
+
+	if len(l.Architecture) > 0 {
+		labels["architecture"] = string(l.Architecture)
+	}
+
+	if len(l.OSImage) > 0 {
+		labels["osimage"] = string(l.OSImage)
+	}
+
+	for k := range labels {
+		labelNames = append(labelNames, k)
+	}
+
+	counterVec := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: metricsPrefix + "nodes",
+	}, labelNames)
+
+	counter := counterVec.With(labels)
+	counter.Set(float64(value))
+
+	return counter
+}
+
+// NewMachineCollector creates a new machine metrics collector.
+func NewMachineCollector(machineLister v1alpha1.MachineLister, nodeLister listerscorev1.NodeLister, kubeClient kubernetes.Interface) *MachineCollector {
 	return &MachineCollector{
-		lister:     lister,
-		kubeClient: kubeClient,
+		machineLister: machineLister,
+		nodeLister:    nodeLister,
+		kubeClient:    kubeClient,
 
 		machines: prometheus.NewDesc(
 			metricsPrefix+"machines",
@@ -107,6 +160,11 @@ func NewMachineCollector(lister v1alpha1.MachineLister, kubeClient kubernetes.In
 			"Timestamp of the machine's deletion time",
 			[]string{"machine"}, nil,
 		),
+		nodes: prometheus.NewDesc(
+			metricsPrefix+"nodes",
+			"The number of actually existing Kubernetes nodes",
+			[]string{}, nil,
+		),
 	}
 }
 
@@ -115,12 +173,14 @@ func (mc MachineCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- mc.machines
 	ch <- mc.machineCreated
 	ch <- mc.machineDeleted
+	ch <- mc.nodes
 }
 
 // Collect implements the prometheus.Collector interface.
 func (mc MachineCollector) Collect(ch chan<- prometheus.Metric) {
-	machines, err := mc.lister.List(labels.Everything())
+	machines, err := mc.machineLister.List(labels.Everything())
 	if err != nil {
+		runtime.HandleError(fmt.Errorf("failed to list machines for machines metric: %v", err))
 		return
 	}
 
@@ -191,6 +251,52 @@ func (mc MachineCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	for info, count := range machineCountByLabels {
+		ch <- info.Counter(count)
+	}
+
+	// Gather the same kind of information in much the same
+	// way for nodes instead of machines.
+
+	nodes, err := mc.nodeLister.List(labels.Everything())
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("failed to list nodes for machines metric: %v", err))
+		return
+	}
+
+	nodeCountByLabels := make(map[*nodeMetricLabels]uint)
+	for _, node := range nodes {
+		nodeInfo := node.Status.NodeInfo
+
+		metricsLabels := nodeMetricLabels{
+			ContainerRuntime: nodeInfo.ContainerRuntimeVersion,
+			KubeletVersion:   nodeInfo.KubeletVersion,
+			OperatingSystem:  nodeInfo.OperatingSystem,
+			OSImage:          nodeInfo.OSImage,
+			Architecture:     nodeInfo.Architecture,
+		}
+
+		var key *nodeMetricLabels
+
+		for p := range nodeCountByLabels {
+			if equality.Semantic.DeepEqual(*p, metricsLabels) {
+				key = p
+				break
+			}
+		}
+
+		if key == nil {
+			key = &metricsLabels
+		}
+
+		nodeCountByLabels[key]++
+	}
+
+	// ensure that we always report at least a nodes=0
+	if len(nodeCountByLabels) == 0 {
+		nodeCountByLabels[&nodeMetricLabels{}] = 0
+	}
+
+	for info, count := range nodeCountByLabels {
 		ch <- info.Counter(count)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Node metrics (count of how many nodes currently exist) have been removed in #270 for no (to me) apparent reason. Since kubermatic/kubermatic#868 calls for a dashboard (and maybe alerts) that shows the difference between machines and nodes, we need the old node metric back.

The implementation is practically identical to the one for machine metrics, it's just using slightly different labels. I again chose to put a bunch of labels on the metric to provide data just in case we want to run analytics on it later. In a sample cluster with three nodes, the metrics look something like this:

```
# HELP machine_controller_machines
# TYPE machine_controller_machines gauge
machine_controller_machines{kubelet_version="1.10.6",os="centos",provider="digitalocean",region="fra1",size="s-1vcpu-1gb"} 1
machine_controller_machines{kubelet_version="1.10.6",os="ubuntu",provider="digitalocean",region="fra1",size="s-1vcpu-1gb"} 2

# HELP machine_controller_nodes
# TYPE machine_controller_nodes gauge
machine_controller_nodes{architecture="amd64",kubelet_version="v1.10.6",os="linux",osimage="CentOS Linux 7 (Core)",runtime="docker://1.13.1"} 1
machine_controller_nodes{architecture="amd64",kubelet_version="v1.10.6",os="linux",osimage="Ubuntu 16.04.5 LTS",runtime="docker://17.3.2"} 2
```