### PR TITLE
Fix escaping in cloud-config

### DIFF
--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -639,21 +639,22 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 	config = fmt.Sprintf(`
 {
   "cloud": "AZUREPUBLICCLOUD",
-  "tenantId": "%s",
-  "subscriptionId": "%s",
-  "aadClientId": "%s",
-  "aadClientSecret": "%s",
+  "tenantId": "%q",
+  "subscriptionId": "%q",
+  "aadClientId": "%q",
+  "aadClientSecret": "%q",
 
-  "resourceGroup": "%s",
-  "location": "%s",
-  "vnetName": "%s",
-  "vnetResourceGroup": "%s",
-  "subnetName": "%s",
-  "routeTableName": "%s",
+  "resourceGroup": "%q",
+  "location": "%q",
+  "vnetName": "%q",
+  "vnetResourceGroup": "%q",
+  "subnetName": "%q",
+  "routeTableName": "%q",
 
   "useInstanceMetadata": true
 }`, c.TenantID, c.SubscriptionID, c.ClientID, c.ClientSecret,
-		c.ResourceGroup, c.Location, c.VNetName, c.ResourceGroup, c.SubnetName, c.RouteTableName)
+		c.ResourceGroup, c.Location, c.VNetName, c.ResourceGroup,
+		c.SubnetName, c.RouteTableName)
 
 	return config, "azure", nil
 }

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -547,13 +547,15 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 
 	config = fmt.Sprintf(`
 [Global]
-auth-url = "%s"
-username = "%s"
-password = "%s"
-domain-name="%s"
-tenant-name = "%s"
-region = "%s"
-`, c.IdentityEndpoint, c.Username, c.Password, c.DomainName, c.TenantName, c.Region)
+auth-url = "%q"
+username = "%q"
+password = "%q"
+domain-name="%q"
+tenant-name = "%q"
+region = "%q"
+`, c.IdentityEndpoint, c.Username, c.Password, c.DomainName,
+		c.TenantName, c.Region)
+
 	return config, "openstack", nil
 }
 


### PR DESCRIPTION
As quotation marks may be part of the password in the cloud config,
these must be escaped in order to let the quoted string be correct.
Also backslashes are interpreted as special characters and must be
escaped likewise.
For convenience every field of the cloud-config gets replaced,
regardless of whether or not its (currently) a valid character.

**What this PR does / why we need it**:

When a customer uses a " in the password, the quotation of the password breaks (ending at the ") and e.g. the controller-manager has troubles connecting to the cluster. This PR addresses this issue.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #304

**Special notes for your reviewer**:

Currently changed in Azure and OpenStack. As far as I can tell, those should be the only ones affected.