### PR TITLE
backport cloud-config escaping

### DIFF
--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -639,17 +639,17 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 	config = fmt.Sprintf(`
 {
   "cloud": "AZUREPUBLICCLOUD",
-  "tenantId": "%s",
-  "subscriptionId": "%s",
-  "aadClientId": "%s",
-  "aadClientSecret": "%s",
+  "tenantId": %q,
+  "subscriptionId": %q,
+  "aadClientId": %q,
+  "aadClientSecret": %q,
 
-  "resourceGroup": "%s",
-  "location": "%s",
-  "vnetName": "%s",
-  "vnetResourceGroup": "%s",
-  "subnetName": "%s",
-  "routeTableName": "%s",
+  "resourceGroup": %q,
+  "location": %q,
+  "vnetName": %q,
+  "vnetResourceGroup": %q,
+  "subnetName": %q,
+  "routeTableName": %q,
 
   "useInstanceMetadata": true
 }`, c.TenantID, c.SubscriptionID, c.ClientID, c.ClientSecret,

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -545,15 +545,15 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 		return "", "", fmt.Errorf("failed to parse config: %v", err)
 	}
 
-	config = fmt.Sprintf(`
-[Global]
-auth-url = "%s"
-username = "%s"
-password = "%s"
-domain-name="%s"
-tenant-name = "%s"
-region = "%s"
+	config = fmt.Sprintf(`[Global]
+auth-url = %q
+username = %q
+password = %q
+domain-name = %q
+tenant-name = %q
+region = %q
 `, c.IdentityEndpoint, c.Username, c.Password, c.DomainName, c.TenantName, c.Region)
+
 	return config, "openstack", nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Cheap backport of the cloud-config escaping. This does not catch all escaping issues, but the most common ones. This change will work with v1.8

```release-note
Fixed escaping of values in cloud-config on Azure and Openstack
```