### PR TITLE
use ubuntu 18.04 image on openstack

### DIFF
--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -13,7 +13,7 @@ size: "2gb"
 # enable backups for the droplet
 backups: false
 # enable ipv6 for the droplet
-ipv6: false- Add operating system config 
+ipv6: false- Add operating system config
 # enable private networking for the droplet
 private_networking: true
 # enable monitoring for the droplet
@@ -47,15 +47,15 @@ diskSize: 50
 diskType: "gp2"
 # optional! the ami id to use. Needs to fit to the specified operating system
 ami: ""
-# optional! The security group ids for the instance. 
+# optional! The security group ids for the instance.
 # When not set a 'kubernetes-v1' security gruop will get created
 securityGroupIDs:
 - ""
 # name of the instance profile to use.
-# When not set a 'kubernetes-v1' instance profile will get created 
+# When not set a 'kubernetes-v1' instance profile will get created
 instanceProfile : ""
 
-# instance tags ("KubernetesCluster": "my-cluster" is a required tag. 
+# instance tags ("KubernetesCluster": "my-cluster" is a required tag.
 # If not set, the kubernetes controller-manager will delete the nodes)
 tags:
   "KubernetesCluster": "my-cluster"
@@ -76,7 +76,7 @@ domainName: "default"
 # tenant name
 tenantName: ""
 # image to use (currently only ubuntu & coreos are supported)
-image: "Ubuntu 16.04 amd64"
+image: "Ubuntu 18.04 amd64"
 # instance flavor
 flavor: ""
 # additional security groups.

--- a/examples/machine-openstack.yaml
+++ b/examples/machine-openstack.yaml
@@ -64,7 +64,7 @@ spec:
           namespace: kube-system
           name: machine-controller-openstack
           key: tenantName
-      image: "Ubuntu 16.04 amd64"
+      image: "Ubuntu 18.04 amd64"
       flavor: "m1.small"
       securityGroups:
         - configMapKeyRef:

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -27,6 +27,12 @@ var (
 		providerconfig.OperatingSystemCoreos,
 		providerconfig.OperatingSystemCentOS,
 	}
+
+	openStackImages = map[string]string{
+		string(providerconfig.OperatingSystemUbuntu): "Ubuntu 18.04 LTS - 2018-08-10",
+		string(providerconfig.OperatingSystemCoreos): "coreos",
+		string(providerconfig.OperatingSystemCentOS): "centos",
+	}
 )
 
 type scenario struct {
@@ -92,6 +98,9 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< CONTAINER_RUNTIME >>=%s", testCase.containerRuntime))
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< KUBERNETES_VERSION >>=%s", testCase.kubernetesVersion))
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< YOUR_PUBLIC_KEY >>=%s", os.Getenv("E2E_SSH_PUBKEY")))
+
+	// only used by OpenStack scenarios
+	scenarioParams = append(scenarioParams, fmt.Sprintf("<< OS_IMAGE >>=%s", openStackImages[testCase.osName]))
 
 	gopath := os.Getenv("GOPATH")
 	projectDir := filepath.Join(gopath, "src/github.com/kubermatic/machine-controller")

--- a/test/e2e/provisioning/testdata/machine-openstack-upgrade.yml
+++ b/test/e2e/provisioning/testdata/machine-openstack-upgrade.yml
@@ -15,9 +15,7 @@ spec:
       username: "<< USERNAME >>"
       password: "<< PASSWORD >>"
       tenantName: "<< TENANT_NAME >>"
-      # Image link:
-      # https://cloud-images.ubuntu.com/releases/16.04/release-20160420.3/ubuntu-16.04-server-cloudimg-amd64-disk1.img
-      image: "Ubuntu 1604 2016-april-20"
+      image: "Ubuntu 18.04 LTS - 2018-08-10"
       flavor: "m1.small"
       floatingIpPool: ""
       domainName: "<< DOMAIN_NAME >>"

--- a/test/e2e/provisioning/testdata/machine-openstack.yaml
+++ b/test/e2e/provisioning/testdata/machine-openstack.yaml
@@ -15,7 +15,7 @@ spec:
       username: "<< USERNAME >>"
       password: "<< PASSWORD >>"
       tenantName: "<< TENANT_NAME >>"
-      image: "<< OS_NAME >>"
+      image: "<< OS_IMAGE >>"
       flavor: "m1.small"
       floatingIpPool: ""
       domainName: "<< DOMAIN_NAME >>"

--- a/test/tools/integration/hetzner.tf
+++ b/test/tools/integration/hetzner.tf
@@ -9,7 +9,7 @@ resource "hcloud_ssh_key" "default" {
 
 resource "hcloud_server" "machine-controller-test" {
   name = "${var.hcloud_test_server_name}"
-  image = "ubuntu-16.04"
+  image = "ubuntu-18.04"
   server_type = "cx41"
   ssh_keys = ["${hcloud_ssh_key.default.id}"]
 }

--- a/test/tools/integration/provision_master.sh
+++ b/test/tools/integration/provision_master.sh
@@ -28,9 +28,14 @@ if ! grep -q kubectl /root/.bashrc; then
   echo 'source <(kubectl completion bash)' >> /root/.bashrc
 fi
 
+# Hetzner's Ubuntu Bionic comes with swap pre-configured, so we force it off.
+systemctl mask swap.target
+swapoff -a
+
 if ! which docker; then
   apt update
   apt install -y docker.io
+  systemctl enable docker.service
   systemctl start docker
   systemctl status docker
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
The image to be used in e2e tests on OpenStack was configured to be `ubuntu`. This forced using the same image in all configurations, including branches using both Ubuntu Xenial and Bionic. With this change, specific version image is named.

```release-note
NONE
```