### PR TITLE
Improve FloatingIP allocation on OpenStack

### DIFF
--- a/pkg/cloudprovider/provider/openstack/helper.go
+++ b/pkg/cloudprovider/provider/openstack/helper.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
+
+	"github.com/golang/glog"
 
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
@@ -25,7 +28,11 @@ var (
 	securityGroupCreationLock = sync.Mutex{}
 )
 
-const openstackFloatingIPErrorStatusName = "ERROR"
+const (
+	openstackFloatingIPErrorStatusName = "ERROR"
+
+	floatingReassignIPCheckPeriod = 3 * time.Second
+)
 
 func getRegion(client *gophercloud.ProviderClient, name string) (*osregions.Region, error) {
 	idClient, err := goopenstack.NewIdentityV3(client, gophercloud.EndpointOpts{})
@@ -324,21 +331,65 @@ func getFreeFloatingIPs(client *gophercloud.ProviderClient, region string, float
 	return freeFIPs, nil
 }
 
-func assignFloatingIP(client *gophercloud.ProviderClient, region, ipID, instanceID, networkID string) error {
+func assignFloatingIPToInstance(client *gophercloud.ProviderClient, instanceID, floatingIPPoolName, region string, network *osnetworks.Network) error {
+	port, err := getInstancePort(client, region, instanceID, network.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get instance port for network %s in region %s: %v", network.ID, region, err)
+	}
+
 	netClient, err := goopenstack.NewNetworkV2(client, gophercloud.EndpointOpts{Region: region})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create the networkv2 client for region %s: %v", region, err)
 	}
 
-	port, err := getInstancePort(client, region, instanceID, networkID)
+	floatingIPPool, err := getNetwork(client, region, floatingIPPoolName)
 	if err != nil {
-		return err
+		return osErrorToTerminalError(err, fmt.Sprintf("failed to get floating ip pool %q", floatingIPPoolName))
 	}
-	_, err = osfloatingips.Update(netClient, ipID, osfloatingips.UpdateOpts{
+
+	// We're only interested in the part which is vulnerable to concurrent access
+	started := time.Now()
+	glog.V(2).Infof("Assigning a floating IP to instance %s", instanceID)
+
+	floatingIPAssignLock.Lock()
+	defer floatingIPAssignLock.Unlock()
+
+	freeFloatingIps, err := getFreeFloatingIPs(client, region, floatingIPPool)
+	if err != nil {
+		return osErrorToTerminalError(err, "failed to get free floating ips")
+	}
+
+	var ip *osfloatingips.FloatingIP
+	if len(freeFloatingIps) < 1 {
+		if ip, err = createFloatingIP(client, region, floatingIPPool); err != nil {
+			return osErrorToTerminalError(err, "failed to allocate a floating ip")
+		}
+	} else {
+		ip = &freeFloatingIps[0]
+	}
+
+	_, err = osfloatingips.Update(netClient, ip.ID, osfloatingips.UpdateOpts{
 		PortID: &port.ID,
 	}).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to update FloatingIP %s: %v", ip.ID, err)
+	}
+	secondsTook := time.Since(started).Seconds()
 
-	return err
+	// We're now going to wait 3 seconds and check if the IP is still ours. If not, we're going to fail
+	// On our reference system it took ~3 seconds for a full FloatingIP allocation (Including creating a new one). It took ~600ms just for assigning one.
+	time.Sleep(floatingReassignIPCheckPeriod)
+	currentIP, err := osfloatingips.Get(netClient, ip.ID).Extract()
+	if err != nil {
+		return fmt.Errorf("failed to load FloatingIP %s after assignment has been done: %v", ip.FloatingIP, err)
+	}
+	// Verify if the port is still the one we set it to
+	if currentIP.PortID != port.ID {
+		return fmt.Errorf("FloatingIP %s got reassigned", currentIP.FloatingIP)
+	}
+
+	glog.V(2).Infof("Successfully assigned the FloatingIP %s to instance %s. Took %f seconds(without the recheck wait period %f seconds). ", ip.FloatingIP, instanceID, secondsTook, floatingReassignIPCheckPeriod.Seconds())
+	return nil
 }
 
 func createFloatingIP(client *gophercloud.ProviderClient, region string, floatingIPPool *osnetworks.Network) (*osfloatingips.FloatingIP, error) {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/golang/glog"
@@ -16,7 +17,6 @@ import (
 	osextendedstatus "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/extendedstatus"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	osservers "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	"github.com/gophercloud/gophercloud/pagination"
 
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/cloud"
@@ -371,30 +371,6 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, use
 		return nil, osErrorToTerminalError(err, fmt.Sprintf("failed to get network %s", c.Network))
 	}
 
-	var ip *floatingips.FloatingIP
-	if c.FloatingIPPool != "" {
-		floatingIPAssignLock.Lock()
-		defer floatingIPAssignLock.Unlock()
-		floatingIPPool, err := getNetwork(client, c.Region, c.FloatingIPPool)
-		if err != nil {
-			return nil, osErrorToTerminalError(err, fmt.Sprintf("failed to get floating ip pool %q", c.FloatingIPPool))
-		}
-
-		freeFloatingIps, err := getFreeFloatingIPs(client, c.Region, floatingIPPool)
-		if err != nil {
-			return nil, osErrorToTerminalError(err, "failed to get free floating ips")
-		}
-
-		if len(freeFloatingIps) < 1 {
-			ip, err = createFloatingIP(client, c.Region, floatingIPPool)
-			if err != nil {
-				return nil, osErrorToTerminalError(err, "failed to allocate a floating ip")
-			}
-		} else {
-			ip = &freeFloatingIps[0]
-		}
-	}
-
 	securityGroups := c.SecurityGroups
 	if len(securityGroups) == 0 {
 		glog.V(2).Infof("creating security group %s for worker nodes", securityGroupName)
@@ -433,36 +409,63 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, use
 		return nil, osErrorToTerminalError(err, "failed to create server")
 	}
 
-	if ip != nil {
-		// if we want to assign a floating ip to the instance, we have to wait until it is running
-		// otherwise the instance has no port in the desired network
-		instanceIsReady := func() (bool, error) {
-			currentServer, err := osservers.Get(computeClient, server.ID).Extract()
-			if err != nil {
-				tErr := osErrorToTerminalError(err, fmt.Sprintf("failed to get current instance %s", server.ID))
-				if isTerminalErr, _, _ := cloudprovidererrors.IsTerminalError(tErr); isTerminalErr {
-					return true, tErr
-				}
-				// Only log the error but don't exit. in case of a network failure we want to retry
-				glog.V(2).Infof("failed to get current instance %s: %v", server.ID, err)
-				return false, nil
-			}
-			if currentServer.Status == "ACTIVE" {
-				return true, nil
-			}
-			return false, nil
-		}
+	if err := waitUntilInstanceIsActive(computeClient, server.ID); err != nil {
+		defer deleteInstanceDueToFatalLogged(computeClient, server.ID)
+		return nil, fmt.Errorf("instance %s became not active: %v", server.ID, err)
+	}
 
-		if err := wait.Poll(instanceReadyCheckPeriod, instanceReadyCheckTimeout, instanceIsReady); err != nil {
-			return nil, fmt.Errorf("failed to wait for instance to be running. unable to proceed. %v", err)
-		}
-
-		if err := assignFloatingIP(client, c.Region, ip.ID, server.ID, network.ID); err != nil {
-			return nil, fmt.Errorf("failed to assign a floating ip: %v", err)
+	// Find a free FloatingIP or allocate a new one
+	if c.FloatingIPPool != "" {
+		if err := assignFloatingIPToInstance(client, server.ID, c.FloatingIPPool, c.Region, network); err != nil {
+			defer deleteInstanceDueToFatalLogged(computeClient, server.ID)
+			return nil, fmt.Errorf("failed to assign a floating ip to instance %s: %v", server.ID, err)
 		}
 	}
 
 	return &osInstance{server: &server}, nil
+}
+
+func waitUntilInstanceIsActive(computeClient *gophercloud.ServiceClient, serverID string) error {
+	started := time.Now()
+	glog.V(2).Infof("Waiting for the instance %s to become active...", serverID)
+
+	instanceIsReady := func() (bool, error) {
+		currentServer, err := osservers.Get(computeClient, serverID).Extract()
+		if err != nil {
+			tErr := osErrorToTerminalError(err, fmt.Sprintf("failed to get current instance %s", serverID))
+			if isTerminalErr, _, _ := cloudprovidererrors.IsTerminalError(tErr); isTerminalErr {
+				return true, tErr
+			}
+			// Only log the error but don't exit. in case of a network failure we want to retry
+			glog.V(2).Infof("failed to get current instance %s: %v", serverID, err)
+			return false, nil
+		}
+		if currentServer.Status == "ACTIVE" {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	if err := wait.Poll(instanceReadyCheckPeriod, instanceReadyCheckTimeout, instanceIsReady); err != nil {
+		if err == wait.ErrWaitTimeout {
+			// In case we have a timeout, include the timeout details
+			return fmt.Errorf("instance became not active after %f seconds", instanceReadyCheckTimeout.Seconds())
+		}
+		// Some terminal error happened
+		return fmt.Errorf("failed to wait for instance to become active: %v", err)
+	}
+
+	glog.V(2).Infof("Instance %s became active after %f seconds", serverID, time.Since(started).Seconds())
+	return nil
+}
+
+func deleteInstanceDueToFatalLogged(computeClient *gophercloud.ServiceClient, serverID string) {
+	glog.V(0).Infof("Deleting instance %s due to fatal error during machine creation...", serverID)
+	if err := osservers.Delete(computeClient, serverID).ExtractErr(); err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to delete the instance %s. Please take care of manually deleting the instance: %v", serverID, err))
+		return
+	}
+	glog.V(0).Infof("Instance %s got deleted", serverID)
 }
 
 func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will reduce the critical time, in which a concurrent machine-controller can steal an already assigned FloatingIP.
As a cheap additional hack, a check was added to verify that the assigned FloatingIP is still assigned after 3 seconds.

**Which issue(s) this PR fixes**
Fixes #313
