### PR TITLE
Add default prometheus process and go metrics

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -234,6 +234,8 @@ func main() {
 	ctx, ctxDone := context.WithCancel(context.Background())
 	var g run.Group
 	{
+		prometheusRegistry.MustRegister(prometheus.NewProcessCollector(os.Getpid(), ""))
+		prometheusRegistry.MustRegister(prometheus.NewGoCollector())
 		prometheusRegistry.MustRegister(machinecontroller.NewMachineCollector(
 			clusterInformerFactory.Cluster().V1alpha1().Machines().Lister(),
 			kubeClient,


### PR DESCRIPTION
This adds the same Prometheus process and go metrics as the default
Registry[0] uses

Resolves #324

[0] https://github.com/prometheus/client_golang/blob/v0.8.0/prometheus/registry.go#L51-L53

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
