### PR TITLE
Remove finalizers when instance is gone

### DIFF
--- a/pkg/cloudprovider/cloud/provider.go
+++ b/pkg/cloudprovider/cloud/provider.go
@@ -21,6 +21,8 @@ type Provider interface {
 	// Note that this method can return what we call a "terminal" error,
 	// which indicates that a manual interaction is required to recover from this state.
 	// See v1alpha1.MachineStatus for more info and TerminalError type
+	//
+	// In case the instance cannot be found, github.com/kubermatic/machine-controller/pkg/cloudprovider/errors/ErrInstanceNotFound will be returned
 	Get(machine *clusterv1alpha1.Machine) (instance.Instance, error)
 
 	GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config string, name string, err error)
@@ -31,6 +33,7 @@ type Provider interface {
 	// Delete deletes the instance and all associated ressources
 	// This will always be called on machine deletion, the implemention must check if there is actually
 	// something to delete and just do nothing if there isn't
+	// In case the instance is already gone, nil will be returned
 	Delete(machine *clusterv1alpha1.Machine, update MachineUpdater) error
 
 	// MachineMetricsLabels returns labels used for the Prometheus metrics

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -461,18 +461,13 @@ func (c *Controller) ensureMachineHasNodeReadyCondition(machine *clusterv1alpha1
 
 // deleteMachine makes sure that an instance has gone in a series of steps.
 func (c *Controller) deleteMachine(prov cloud.Provider, machine *clusterv1alpha1.Machine) error {
-	if err := c.deleteCloudProviderInstance(prov, machine); err != nil {
-		c.recorder.Eventf(machine, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete instance at cloud provider: %v", err)
+	if err := c.deleteNodeForMachine(machine); err != nil {
+		c.recorder.Eventf(machine, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete node: %v", err)
 		return err
 	}
 
-	// Delete the node object after the instance is gone
-	if sets.NewString(machine.Finalizers...).Has(finalizerDeleteInstance) {
-		return nil
-	}
-
-	if err := c.deleteNodeForMachine(machine); err != nil {
-		c.recorder.Eventf(machine, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete node: %v", err)
+	if err := c.deleteCloudProviderInstance(prov, machine); err != nil {
+		c.recorder.Eventf(machine, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete instance at cloud provider: %v", err)
 		return err
 	}
 

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -461,13 +461,18 @@ func (c *Controller) ensureMachineHasNodeReadyCondition(machine *clusterv1alpha1
 
 // deleteMachine makes sure that an instance has gone in a series of steps.
 func (c *Controller) deleteMachine(prov cloud.Provider, machine *clusterv1alpha1.Machine) error {
-	if err := c.deleteNodeForMachine(machine); err != nil {
-		c.recorder.Eventf(machine, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete node: %v", err)
+	if err := c.deleteCloudProviderInstance(prov, machine); err != nil {
+		c.recorder.Eventf(machine, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete instance at cloud provider: %v", err)
 		return err
 	}
 
-	if err := c.deleteCloudProviderInstance(prov, machine); err != nil {
-		c.recorder.Eventf(machine, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete instance at cloud provider: %v", err)
+	// Delete the node object after the instance is gone
+	if sets.NewString(machine.Finalizers...).Has(finalizerDeleteInstance) {
+		return nil
+	}
+
+	if err := c.deleteNodeForMachine(machine); err != nil {
+		c.recorder.Eventf(machine, corev1.EventTypeWarning, "DeletionFailed", "Failed to delete node: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will ensure that we remove the finalizers only when we know that all actions have been successful.
Being more specific:
- Only when the instances at the cloud provider cannot be found anymore*, the deletion will be considered successful and the finalizer will be removed.
*For AWS the instance state `terminated` is considered deleted as well.
- The node object will only be removed in case the cloud provider instance is gone - this will ensure that the kubelet does not restart & registers again before the instance got shutdown.

Fixes #345