### PR TITLE
Never override the hostname on AWS nodes

### DIFF
--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
@@ -1,5 +1,5 @@
 #cloud-config
-hostname: node1
+
 
 ssh_pwauth: no
 
@@ -55,9 +55,7 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
-    # The normal way of setting it via cloud-init is broken:
-    # https://bugs.launchpad.net/cloud-init/+bug/1662542
-    hostnamectl set-hostname node1
+    
 
     yum install -y docker-1.13.1 \
       ebtables \
@@ -137,7 +135,6 @@ write_files:
       --authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --hostname-override=node1 \
       --read-only-port=0 \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
@@ -1,5 +1,5 @@
 #cloud-config
-hostname: node1
+
 
 ssh_pwauth: no
 
@@ -55,9 +55,7 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
-    # The normal way of setting it via cloud-init is broken:
-    # https://bugs.launchpad.net/cloud-init/+bug/1662542
-    hostnamectl set-hostname node1
+    
 
     yum install -y docker-1.13.1 \
       ebtables \
@@ -137,7 +135,6 @@ write_files:
       --authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --hostname-override=node1 \
       --read-only-port=0 \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
@@ -1,5 +1,5 @@
 #cloud-config
-hostname: node1
+
 
 ssh_pwauth: no
 
@@ -55,9 +55,7 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
-    # The normal way of setting it via cloud-init is broken:
-    # https://bugs.launchpad.net/cloud-init/+bug/1662542
-    hostnamectl set-hostname node1
+    
 
     yum install -y docker-1.13.1 \
       ebtables \
@@ -136,7 +134,6 @@ write_files:
       --authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --hostname-override=node1 \
       --read-only-port=0 \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 
@@ -55,9 +58,11 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
+     
     # The normal way of setting it via cloud-init is broken:
     # https://bugs.launchpad.net/cloud-init/+bug/1662542
     hostnamectl set-hostname node1
+    
 
     yum install -y docker-1.13.1 \
       ebtables \

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
@@ -1,5 +1,5 @@
 #cloud-config
-hostname: node1
+
 
 ssh_pwauth: no
 
@@ -55,9 +55,7 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
-    # The normal way of setting it via cloud-init is broken:
-    # https://bugs.launchpad.net/cloud-init/+bug/1662542
-    hostnamectl set-hostname node1
+    
 
     yum install -y docker-1.13.1 \
       ebtables \
@@ -137,7 +135,6 @@ write_files:
       --authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --hostname-override=node1 \
       --read-only-port=0 \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
@@ -130,17 +130,6 @@
       },
       {
         "filesystem": "root",
-        "group": {},
-        "path": "/etc/hostname",
-        "user": {},
-        "contents": {
-          "source": "data:,node1",
-          "verification": {}
-        },
-        "mode": 384
-      },
-      {
-        "filesystem": "root",
         "group": {
           "id": 0
         },
@@ -220,7 +209,7 @@
         "name": "kubelet-healthcheck.service"
       },
       {
-        "contents": "[Unit]\nDescription=Kubernetes Kubelet\nRequires=docker.service\nAfter=docker.service\n[Service]\nTimeoutStartSec=5min\nEnvironment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2\nEnvironment=\"RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \\\n  --insecure-options=image \\\n  --volume=resolv,kind=host,source=/etc/resolv.conf \\\n  --mount volume=resolv,target=/etc/resolv.conf \\\n  --volume cni-bin,kind=host,source=/opt/cni/bin \\\n  --mount volume=cni-bin,target=/opt/cni/bin \\\n  --volume cni-conf,kind=host,source=/etc/cni/net.d \\\n  --mount volume=cni-conf,target=/etc/cni/net.d \\\n  --volume etc-kubernetes,kind=host,source=/etc/kubernetes \\\n  --mount volume=etc-kubernetes,target=/etc/kubernetes \\\n  --volume var-log,kind=host,source=/var/log \\\n  --mount volume=var-log,target=/var/log \\\n  --volume var-lib-calico,kind=host,source=/var/lib/calico \\\n  --mount volume=var-lib-calico,target=/var/lib/calico\"\nExecStartPre=/bin/mkdir -p /var/lib/calico\nExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests\nExecStartPre=/bin/mkdir -p /etc/cni/net.d\nExecStartPre=/bin/mkdir -p /opt/cni/bin\nExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid\nExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/\nExecStart=/usr/lib/coreos/kubelet-wrapper \\\n  --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \\\n  --kubeconfig=/etc/kubernetes/kubelet.conf \\\n  --pod-manifest-path=/etc/kubernetes/manifests \\\n  --allow-privileged=true \\\n  --network-plugin=cni \\\n  --cni-conf-dir=/etc/cni/net.d \\\n  --cni-bin-dir=/opt/cni/bin \\\n  --authorization-mode=Webhook \\\n  --client-ca-file=/etc/kubernetes/pki/ca.crt \\\n  --cadvisor-port=0 \\\n  --rotate-certificates=true \\\n  --cert-dir=/etc/kubernetes/pki \\\n  --authentication-token-webhook=true \\\n  --cloud-provider=aws \\\n  --cloud-config=/etc/kubernetes/cloud-config \\\n  --hostname-override=node1 \\\n  --read-only-port=0 \\\n  --exit-on-lock-contention \\\n  --lock-file=/tmp/kubelet.lock \\\n  --anonymous-auth=false \\\n  --protect-kernel-defaults=true \\\n  --cluster-dns=10.10.10.10 \\\n  --cluster-domain=cluster.local\nExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid\nRestart=always\nRestartSec=10\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=Kubernetes Kubelet\nRequires=docker.service\nAfter=docker.service\n[Service]\nTimeoutStartSec=5min\nEnvironment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2\nEnvironment=\"RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \\\n  --insecure-options=image \\\n  --volume=resolv,kind=host,source=/etc/resolv.conf \\\n  --mount volume=resolv,target=/etc/resolv.conf \\\n  --volume cni-bin,kind=host,source=/opt/cni/bin \\\n  --mount volume=cni-bin,target=/opt/cni/bin \\\n  --volume cni-conf,kind=host,source=/etc/cni/net.d \\\n  --mount volume=cni-conf,target=/etc/cni/net.d \\\n  --volume etc-kubernetes,kind=host,source=/etc/kubernetes \\\n  --mount volume=etc-kubernetes,target=/etc/kubernetes \\\n  --volume var-log,kind=host,source=/var/log \\\n  --mount volume=var-log,target=/var/log \\\n  --volume var-lib-calico,kind=host,source=/var/lib/calico \\\n  --mount volume=var-lib-calico,target=/var/lib/calico\"\nExecStartPre=/bin/mkdir -p /var/lib/calico\nExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests\nExecStartPre=/bin/mkdir -p /etc/cni/net.d\nExecStartPre=/bin/mkdir -p /opt/cni/bin\nExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid\nExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/\nExecStart=/usr/lib/coreos/kubelet-wrapper \\\n  --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \\\n  --kubeconfig=/etc/kubernetes/kubelet.conf \\\n  --pod-manifest-path=/etc/kubernetes/manifests \\\n  --allow-privileged=true \\\n  --network-plugin=cni \\\n  --cni-conf-dir=/etc/cni/net.d \\\n  --cni-bin-dir=/opt/cni/bin \\\n  --authorization-mode=Webhook \\\n  --client-ca-file=/etc/kubernetes/pki/ca.crt \\\n  --cadvisor-port=0 \\\n  --rotate-certificates=true \\\n  --cert-dir=/etc/kubernetes/pki \\\n  --authentication-token-webhook=true \\\n  --cloud-provider=aws \\\n  --cloud-config=/etc/kubernetes/cloud-config \\\n  --read-only-port=0 \\\n  --exit-on-lock-contention \\\n  --lock-file=/tmp/kubelet.lock \\\n  --anonymous-auth=false \\\n  --protect-kernel-defaults=true \\\n  --cluster-dns=10.10.10.10 \\\n  --cluster-domain=cluster.local\nExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid\nRestart=always\nRestartSec=10\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "kubelet.service"
       }

--- a/pkg/userdata/coreos/userdata.go
+++ b/pkg/userdata/coreos/userdata.go
@@ -318,11 +318,13 @@ storage:
           yes
 {{ end }}
 
+{{ if ne .CloudProvider "aws" }}
     - path: /etc/hostname
       filesystem: root
       mode: 0600
       contents:
         inline: '{{ .MachineSpec.Name }}'
+{{- end }}
 
     - path: /etc/ssh/sshd_config
       filesystem: root

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -27,7 +27,7 @@ const (
 --cloud-provider={{ .CloudProvider }} \
 --cloud-config=/etc/kubernetes/cloud-config \
 {{- end }}
-{{- if .Hostname }}
+{{- if and (.Hostname) (ne .CloudProvider "aws") }}
 --hostname-override={{ .Hostname }} \
 {{- end }}
 --read-only-port=0 \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -28,7 +28,6 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --authentication-token-webhook=true \
   --cloud-provider=aws \
   --cloud-config=/etc/kubernetes/cloud-config \
-  --hostname-override=some-test-node \
   --read-only-port=0 \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/openstack.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/testdata/vsphere.golden
+++ b/pkg/userdata/ubuntu/testdata/vsphere.golden
@@ -1,5 +1,8 @@
 #cloud-config
+
 hostname: node1
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+
 
 ssh_pwauth: no
 

--- a/pkg/userdata/ubuntu/userdata.go
+++ b/pkg/userdata/ubuntu/userdata.go
@@ -128,7 +128,10 @@ func (p Provider) UserData(
 }
 
 const ctTemplate = `#cloud-config
+{{ if ne .CloudProvider "aws" }}
 hostname: {{ .MachineSpec.Name }}
+# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+{{ end }}
 
 ssh_pwauth: no
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Never override the hostname on AWS nodes.
Kube-Proxy uses the `hostname= to lookup the `corev1.Node` object its running on.
On AWS nodes, the name of the `corev1.Node` is always the private dns name in AWS.
This is a requirement of the AWS code in kubernetes. Thus, manually overriding the hostname in the OS is not useful.
Instead if leads to the error messages: 
```
W1023 13:23:23.835678       5 server.go:601] Failed to retrieve node info: nodes "aws-coreos-1-10-8-node-2" not found
W1023 13:23:23.835871       5 proxier.go:306] invalid nodeIP, initializing kube-proxy with 127.0.0.1 as nodeIP
```

```release-note
NONE
```
