### PR TITLE
Fix nullpointer dereference in openstack helper.go

### DIFF
--- a/pkg/cloudprovider/provider/openstack/helper.go
+++ b/pkg/cloudprovider/provider/openstack/helper.go
@@ -366,7 +366,7 @@ func assignFloatingIPToInstance(client *gophercloud.ProviderClient, instanceID, 
 		}
 	} else {
 		freeIP := freeFloatingIps[0]
-		ip, err := osfloatingips.Update(netClient, freeIP.ID, osfloatingips.UpdateOpts{
+		ip, err = osfloatingips.Update(netClient, freeIP.ID, osfloatingips.UpdateOpts{
 			PortID: &port.ID,
 		}).Extract()
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently https://github.com/kubermatic/machine-controller/blob/111a9df8af5475a84432ade9e5ed8f426d690065/pkg/cloudprovider/provider/openstack/helper.go#L390 runs into a nullpointer dereference, as the `ip` variable is only defined in the if-context.

**Special notes for your reviewer**:
The err variable is not (re-)defined, as its used above already.

```release-note
* Fix a nullpointer dereference in openstack IP assignment.
```