### PR TITLE
Install docker 17.03 via binary and configure logs rotation on all systems via daemon.json

### DIFF
--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
@@ -57,8 +57,7 @@ write_files:
 
     
 
-    yum install -y docker-1.13.1 \
-      ebtables \
+    yum install -y ebtables \
       ethtool \
       nfs-utils \
       bash-completion \
@@ -66,6 +65,9 @@ write_files:
       socat \
       wget \
       curl \
+      libtool-ltdl \
+      libseccomp \
+      libcgroup \
       ipvsadm
 
     #setup some common directories
@@ -74,6 +76,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -89,10 +101,15 @@ write_files:
         curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/8b5b66e4910a6228dfaecccaa0a3b05ec4902f8e/pkg/userdata/scripts/health-monitor.sh
         chmod +x /opt/bin/health-monitor.sh
     fi
+    
+
+        # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -113,11 +130,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -145,11 +161,6 @@ write_files:
     
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |
@@ -230,6 +241,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -244,11 +256,50 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
@@ -57,8 +57,7 @@ write_files:
 
     
 
-    yum install -y docker-1.13.1 \
-      ebtables \
+    yum install -y ebtables \
       ethtool \
       nfs-utils \
       bash-completion \
@@ -66,6 +65,9 @@ write_files:
       socat \
       wget \
       curl \
+      libtool-ltdl \
+      libseccomp \
+      libcgroup \
       ipvsadm
 
     #setup some common directories
@@ -74,6 +76,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -89,10 +101,15 @@ write_files:
         curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/8b5b66e4910a6228dfaecccaa0a3b05ec4902f8e/pkg/userdata/scripts/health-monitor.sh
         chmod +x /opt/bin/health-monitor.sh
     fi
+    
+
+        # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -113,11 +130,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -145,11 +161,6 @@ write_files:
     
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |
@@ -230,6 +241,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -244,11 +256,50 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
@@ -57,8 +57,7 @@ write_files:
 
     
 
-    yum install -y docker-1.13.1 \
-      ebtables \
+    yum install -y ebtables \
       ethtool \
       nfs-utils \
       bash-completion \
@@ -66,6 +65,9 @@ write_files:
       socat \
       wget \
       curl \
+      libtool-ltdl \
+      libseccomp \
+      libcgroup \
       ipvsadm
 
     #setup some common directories
@@ -74,6 +76,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -89,10 +101,15 @@ write_files:
         curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/8b5b66e4910a6228dfaecccaa0a3b05ec4902f8e/pkg/userdata/scripts/health-monitor.sh
         chmod +x /opt/bin/health-monitor.sh
     fi
+    
+
+        # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -113,11 +130,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -144,11 +160,6 @@ write_files:
     
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |
@@ -229,6 +240,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -243,11 +255,50 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
@@ -64,8 +64,7 @@ write_files:
     hostnamectl set-hostname node1
     
 
-    yum install -y docker-1.13.1 \
-      ebtables \
+    yum install -y ebtables \
       ethtool \
       nfs-utils \
       bash-completion \
@@ -73,6 +72,9 @@ write_files:
       socat \
       wget \
       curl \
+      libtool-ltdl \
+      libseccomp \
+      libcgroup \
       ipvsadm \
       open-vm-tools
 
@@ -82,6 +84,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -98,11 +110,16 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+
+    
     systemctl enable --now vmtoolsd.service
+        # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -123,11 +140,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -155,11 +171,6 @@ write_files:
     
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |
@@ -240,6 +251,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -254,11 +266,50 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
@@ -57,8 +57,7 @@ write_files:
 
     
 
-    yum install -y docker-1.13.1 \
-      ebtables \
+    yum install -y ebtables \
       ethtool \
       nfs-utils \
       bash-completion \
@@ -66,6 +65,9 @@ write_files:
       socat \
       wget \
       curl \
+      libtool-ltdl \
+      libseccomp \
+      libcgroup \
       ipvsadm
 
     #setup some common directories
@@ -74,6 +76,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -89,10 +101,15 @@ write_files:
         curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/8b5b66e4910a6228dfaecccaa0a3b05ec4902f8e/pkg/userdata/scripts/health-monitor.sh
         chmod +x /opt/bin/health-monitor.sh
     fi
+    
+
+        # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -113,11 +130,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -145,11 +161,6 @@ write_files:
     
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |
@@ -230,6 +241,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -244,11 +256,50 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
@@ -9,10 +9,24 @@ passwd:
 
 systemd:
   units:
-    - name: docker.service
-      enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: docker.socket
+      mask: true
+
+    - name: download-binaries.service
+      enabled: false
+      contents: |
+        [Unit]
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        Type=oneshot
+        ExecStartPre=/opt/bin/download.sh
+        ExecStart=/usr/bin/echo Successfully downloaded all required binaries
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: setup-kubelet.service
       enabled: true
       contents: |
         [Unit]
@@ -20,24 +34,107 @@ systemd:
         After=network-online.target
         [Service]
         Type=oneshot
-        ExecStart=/opt/bin/download.sh
+        ExecStart=/opt/bin/setup.sh
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: containerd.service
+      enabled: false
+      dropins:
+      - name: override.conf
+        contents: |
+          [Unit]
+          Requires=download-binaries.service
+          After=download-binaries.service
+      contents: |
+        [Unit]
+        Description=containerd container runtime
+        Documentation=https://containerd.io
+        After=network.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Delegate=yes
+        ExecStart=/opt/bin/docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --metrics-interval=0 --start-timeout 2m --state-dir /var/run/docker/libcontainerd/containerd --shim /opt/bin/docker-containerd-shim --runtime /opt/bin/docker-runc
+        
+        KillMode=process
+        Restart=always
+        
+        # (lack of) limits from the upstream docker service unit
+        LimitNOFILE=1048576
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        
+        TasksMax=infinity
+        
+        
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: docker.service
+      dropins:
+      - name: containerd.conf
+        contents: |
+          [Unit]
+          After=containerd.service
+          Requires=containerd.service
+          [Service]
+          ExecStart= 
+          ExecStart=/opt/bin/dockerd --containerd=/var/run/docker/libcontainerd/docker-containerd.sock 
+
+      contents: |
+        [Unit]
+        Description=Docker Application Container Engine
+        Documentation=https://docs.docker.com
+        After=network-online.target
+        Wants=network-online.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Type=notify
+        # the default is not to use systemd for cgroups because the delegate issues still
+        # exists and systemd currently does not support the cgroup feature set required
+        # for containers run by docker
+        ExecStart=/opt/bin/dockerd
+        ExecReload=/bin/kill -s HUP $MAINPID
+        LimitNOFILE=1048576
+        # Having non-zero Limit*s causes performance problems due to accounting overhead
+        # in the kernel. We recommend using cgroups to do container-local accounting.
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        # Uncomment TasksMax if your systemd version supports it.
+        # Only systemd 226 and above support this version.
+        
+        TasksMax=infinity
+        
+        TimeoutStartSec=0
+        # set delegate yes so that systemd does not reset the cgroups of docker containers
+        Delegate=yes
+        # kill only the docker process, not all processes in the cgroup
+        KillMode=process
+        # restart the docker process if it exits prematurely
+        Restart=on-failure
+        StartLimitBurst=3
+        StartLimitInterval=60s
+        
         [Install]
         WantedBy=multi-user.target
 
     - name: docker-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service docker.service
+          After=download-binaries.service docker.service
       contents: |
           [Unit]
           Requires=docker.service
           After=docker.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh container-runtime
           
           [Install]
@@ -45,19 +142,20 @@ systemd:
           
 
     - name: kubelet-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service kubelet.service
+          After=download-binaries.service kubelet.service
       contents: |
           [Unit]
           Requires=kubelet.service
           After=kubelet.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh kubelet
           
           [Install]
@@ -65,12 +163,12 @@ systemd:
           
 
     - name: kubelet.service
-      enabled: true
+      enabled: false
       contents: |
         [Unit]
         Description=Kubernetes Kubelet
-        Requires=docker.service
-        After=docker.service
+        Requires=docker.service containerd.service
+        After=docker.service containerd.service
         [Service]
         TimeoutStartSec=5min
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
@@ -240,13 +338,6 @@ storage:
           sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-
 
 
     - path: /etc/hostname
@@ -274,14 +365,6 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
-    - path: /etc/systemd/system/docker.service.d/10-storage.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          Environment=DOCKER_OPTS=--storage-driver=overlay2
-
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755
@@ -296,6 +379,16 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           
+          # docker
+          if [ ! -f /opt/bin/docker ]; then
+              # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+              # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+              # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+              curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+              mv /opt/docker/* /opt/bin/
+              rm -rf /opt/docker
+          fi
+          
           # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
@@ -306,3 +399,45 @@ storage:
               chmod +x /opt/bin/health-monitor.sh
           fi
           
+
+    - path: /opt/bin/setup.sh
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -xeuo pipefail
+          # Make sure systemd is aware of the new units in /etc/systemd/system
+          systemctl daemon-reload
+          systemctl enable --now docker
+          systemctl enable --now kubelet
+          systemctl enable --now --no-block kubelet-healthcheck.service
+          systemctl enable --now --no-block docker-healthcheck.service
+          
+
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+            "default-runtime": "docker-runc",
+            "runtimes": {
+              "docker-runc": {
+                "path": "/opt/bin/docker-runc"
+              }
+            },
+            "storage-driver": "overlay2",
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "10m",
+              "max-file": "2"
+            }
+          }
+
+    - path: /etc/profile.d/opt-bin-path.sh
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          export PATH="/opt/bin:$PATH"

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
@@ -9,10 +9,24 @@ passwd:
 
 systemd:
   units:
-    - name: docker.service
-      enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: docker.socket
+      mask: true
+
+    - name: download-binaries.service
+      enabled: false
+      contents: |
+        [Unit]
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        Type=oneshot
+        ExecStartPre=/opt/bin/download.sh
+        ExecStart=/usr/bin/echo Successfully downloaded all required binaries
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: setup-kubelet.service
       enabled: true
       contents: |
         [Unit]
@@ -20,24 +34,107 @@ systemd:
         After=network-online.target
         [Service]
         Type=oneshot
-        ExecStart=/opt/bin/download.sh
+        ExecStart=/opt/bin/setup.sh
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: containerd.service
+      enabled: false
+      dropins:
+      - name: override.conf
+        contents: |
+          [Unit]
+          Requires=download-binaries.service
+          After=download-binaries.service
+      contents: |
+        [Unit]
+        Description=containerd container runtime
+        Documentation=https://containerd.io
+        After=network.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Delegate=yes
+        ExecStart=/opt/bin/docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --metrics-interval=0 --start-timeout 2m --state-dir /var/run/docker/libcontainerd/containerd --shim /opt/bin/docker-containerd-shim --runtime /opt/bin/docker-runc
+        
+        KillMode=process
+        Restart=always
+        
+        # (lack of) limits from the upstream docker service unit
+        LimitNOFILE=1048576
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        
+        TasksMax=infinity
+        
+        
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: docker.service
+      dropins:
+      - name: containerd.conf
+        contents: |
+          [Unit]
+          After=containerd.service
+          Requires=containerd.service
+          [Service]
+          ExecStart= 
+          ExecStart=/opt/bin/dockerd --containerd=/var/run/docker/libcontainerd/docker-containerd.sock 
+
+      contents: |
+        [Unit]
+        Description=Docker Application Container Engine
+        Documentation=https://docs.docker.com
+        After=network-online.target
+        Wants=network-online.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Type=notify
+        # the default is not to use systemd for cgroups because the delegate issues still
+        # exists and systemd currently does not support the cgroup feature set required
+        # for containers run by docker
+        ExecStart=/opt/bin/dockerd
+        ExecReload=/bin/kill -s HUP $MAINPID
+        LimitNOFILE=1048576
+        # Having non-zero Limit*s causes performance problems due to accounting overhead
+        # in the kernel. We recommend using cgroups to do container-local accounting.
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        # Uncomment TasksMax if your systemd version supports it.
+        # Only systemd 226 and above support this version.
+        
+        TasksMax=infinity
+        
+        TimeoutStartSec=0
+        # set delegate yes so that systemd does not reset the cgroups of docker containers
+        Delegate=yes
+        # kill only the docker process, not all processes in the cgroup
+        KillMode=process
+        # restart the docker process if it exits prematurely
+        Restart=on-failure
+        StartLimitBurst=3
+        StartLimitInterval=60s
+        
         [Install]
         WantedBy=multi-user.target
 
     - name: docker-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service docker.service
+          After=download-binaries.service docker.service
       contents: |
           [Unit]
           Requires=docker.service
           After=docker.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh container-runtime
           
           [Install]
@@ -45,19 +142,20 @@ systemd:
           
 
     - name: kubelet-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service kubelet.service
+          After=download-binaries.service kubelet.service
       contents: |
           [Unit]
           Requires=kubelet.service
           After=kubelet.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh kubelet
           
           [Install]
@@ -65,12 +163,12 @@ systemd:
           
 
     - name: kubelet.service
-      enabled: true
+      enabled: false
       contents: |
         [Unit]
         Description=Kubernetes Kubelet
-        Requires=docker.service
-        After=docker.service
+        Requires=docker.service containerd.service
+        After=docker.service containerd.service
         [Service]
         TimeoutStartSec=5min
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.10.3
@@ -240,13 +338,6 @@ storage:
           sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-
 
 
     - path: /etc/hostname
@@ -274,14 +365,6 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
-    - path: /etc/systemd/system/docker.service.d/10-storage.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          Environment=DOCKER_OPTS=--storage-driver=overlay2
-
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755
@@ -296,6 +379,16 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           
+          # docker
+          if [ ! -f /opt/bin/docker ]; then
+              # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+              # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+              # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+              curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+              mv /opt/docker/* /opt/bin/
+              rm -rf /opt/docker
+          fi
+          
           # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
@@ -306,3 +399,45 @@ storage:
               chmod +x /opt/bin/health-monitor.sh
           fi
           
+
+    - path: /opt/bin/setup.sh
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -xeuo pipefail
+          # Make sure systemd is aware of the new units in /etc/systemd/system
+          systemctl daemon-reload
+          systemctl enable --now docker
+          systemctl enable --now kubelet
+          systemctl enable --now --no-block kubelet-healthcheck.service
+          systemctl enable --now --no-block docker-healthcheck.service
+          
+
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+            "default-runtime": "docker-runc",
+            "runtimes": {
+              "docker-runc": {
+                "path": "/opt/bin/docker-runc"
+              }
+            },
+            "storage-driver": "overlay2",
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "10m",
+              "max-file": "2"
+            }
+          }
+
+    - path: /etc/profile.d/opt-bin-path.sh
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          export PATH="/opt/bin:$PATH"

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
@@ -30,10 +30,24 @@ systemd:
     - name: locksmithd.service
       mask: true
 
-    - name: docker.service
-      enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: docker.socket
+      mask: true
+
+    - name: download-binaries.service
+      enabled: false
+      contents: |
+        [Unit]
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        Type=oneshot
+        ExecStartPre=/opt/bin/download.sh
+        ExecStart=/usr/bin/echo Successfully downloaded all required binaries
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: setup-kubelet.service
       enabled: true
       contents: |
         [Unit]
@@ -41,24 +55,107 @@ systemd:
         After=network-online.target
         [Service]
         Type=oneshot
-        ExecStart=/opt/bin/download.sh
+        ExecStart=/opt/bin/setup.sh
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: containerd.service
+      enabled: false
+      dropins:
+      - name: override.conf
+        contents: |
+          [Unit]
+          Requires=download-binaries.service
+          After=download-binaries.service
+      contents: |
+        [Unit]
+        Description=containerd container runtime
+        Documentation=https://containerd.io
+        After=network.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Delegate=yes
+        ExecStart=/opt/bin/docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --metrics-interval=0 --start-timeout 2m --state-dir /var/run/docker/libcontainerd/containerd --shim /opt/bin/docker-containerd-shim --runtime /opt/bin/docker-runc
+        
+        KillMode=process
+        Restart=always
+        
+        # (lack of) limits from the upstream docker service unit
+        LimitNOFILE=1048576
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        
+        TasksMax=infinity
+        
+        
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: docker.service
+      dropins:
+      - name: containerd.conf
+        contents: |
+          [Unit]
+          After=containerd.service
+          Requires=containerd.service
+          [Service]
+          ExecStart= 
+          ExecStart=/opt/bin/dockerd --containerd=/var/run/docker/libcontainerd/docker-containerd.sock 
+
+      contents: |
+        [Unit]
+        Description=Docker Application Container Engine
+        Documentation=https://docs.docker.com
+        After=network-online.target
+        Wants=network-online.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Type=notify
+        # the default is not to use systemd for cgroups because the delegate issues still
+        # exists and systemd currently does not support the cgroup feature set required
+        # for containers run by docker
+        ExecStart=/opt/bin/dockerd
+        ExecReload=/bin/kill -s HUP $MAINPID
+        LimitNOFILE=1048576
+        # Having non-zero Limit*s causes performance problems due to accounting overhead
+        # in the kernel. We recommend using cgroups to do container-local accounting.
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        # Uncomment TasksMax if your systemd version supports it.
+        # Only systemd 226 and above support this version.
+        
+        TasksMax=infinity
+        
+        TimeoutStartSec=0
+        # set delegate yes so that systemd does not reset the cgroups of docker containers
+        Delegate=yes
+        # kill only the docker process, not all processes in the cgroup
+        KillMode=process
+        # restart the docker process if it exits prematurely
+        Restart=on-failure
+        StartLimitBurst=3
+        StartLimitInterval=60s
+        
         [Install]
         WantedBy=multi-user.target
 
     - name: docker-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service docker.service
+          After=download-binaries.service docker.service
       contents: |
           [Unit]
           Requires=docker.service
           After=docker.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh container-runtime
           
           [Install]
@@ -66,19 +163,20 @@ systemd:
           
 
     - name: kubelet-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service kubelet.service
+          After=download-binaries.service kubelet.service
       contents: |
           [Unit]
           Requires=kubelet.service
           After=kubelet.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh kubelet
           
           [Install]
@@ -86,12 +184,12 @@ systemd:
           
 
     - name: kubelet.service
-      enabled: true
+      enabled: false
       contents: |
         [Unit]
         Description=Kubernetes Kubelet
-        Requires=docker.service
-        After=docker.service
+        Requires=docker.service containerd.service
+        After=docker.service containerd.service
         [Service]
         TimeoutStartSec=5min
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.11.2
@@ -261,13 +359,6 @@ storage:
           sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-
 
 
     - path: /etc/hostname
@@ -295,14 +386,6 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
-    - path: /etc/systemd/system/docker.service.d/10-storage.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          Environment=DOCKER_OPTS=--storage-driver=overlay2
-
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755
@@ -317,6 +400,16 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           
+          # docker
+          if [ ! -f /opt/bin/docker ]; then
+              # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+              # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+              # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+              curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+              mv /opt/docker/* /opt/bin/
+              rm -rf /opt/docker
+          fi
+          
           # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
@@ -327,3 +420,45 @@ storage:
               chmod +x /opt/bin/health-monitor.sh
           fi
           
+
+    - path: /opt/bin/setup.sh
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -xeuo pipefail
+          # Make sure systemd is aware of the new units in /etc/systemd/system
+          systemctl daemon-reload
+          systemctl enable --now docker
+          systemctl enable --now kubelet
+          systemctl enable --now --no-block kubelet-healthcheck.service
+          systemctl enable --now --no-block docker-healthcheck.service
+          
+
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+            "default-runtime": "docker-runc",
+            "runtimes": {
+              "docker-runc": {
+                "path": "/opt/bin/docker-runc"
+              }
+            },
+            "storage-driver": "overlay2",
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "10m",
+              "max-file": "2"
+            }
+          }
+
+    - path: /etc/profile.d/opt-bin-path.sh
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          export PATH="/opt/bin:$PATH"

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.golden
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.golden
@@ -30,10 +30,24 @@ systemd:
     - name: locksmithd.service
       mask: true
 
-    - name: docker.service
-      enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: docker.socket
+      mask: true
+
+    - name: download-binaries.service
+      enabled: false
+      contents: |
+        [Unit]
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        Type=oneshot
+        ExecStartPre=/opt/bin/download.sh
+        ExecStart=/usr/bin/echo Successfully downloaded all required binaries
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: setup-kubelet.service
       enabled: true
       contents: |
         [Unit]
@@ -41,24 +55,107 @@ systemd:
         After=network-online.target
         [Service]
         Type=oneshot
-        ExecStart=/opt/bin/download.sh
+        ExecStart=/opt/bin/setup.sh
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: containerd.service
+      enabled: false
+      dropins:
+      - name: override.conf
+        contents: |
+          [Unit]
+          Requires=download-binaries.service
+          After=download-binaries.service
+      contents: |
+        [Unit]
+        Description=containerd container runtime
+        Documentation=https://containerd.io
+        After=network.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Delegate=yes
+        ExecStart=/opt/bin/docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --metrics-interval=0 --start-timeout 2m --state-dir /var/run/docker/libcontainerd/containerd --shim /opt/bin/docker-containerd-shim --runtime /opt/bin/docker-runc
+        
+        KillMode=process
+        Restart=always
+        
+        # (lack of) limits from the upstream docker service unit
+        LimitNOFILE=1048576
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        
+        TasksMax=infinity
+        
+        
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: docker.service
+      dropins:
+      - name: containerd.conf
+        contents: |
+          [Unit]
+          After=containerd.service
+          Requires=containerd.service
+          [Service]
+          ExecStart= 
+          ExecStart=/opt/bin/dockerd --containerd=/var/run/docker/libcontainerd/docker-containerd.sock 
+
+      contents: |
+        [Unit]
+        Description=Docker Application Container Engine
+        Documentation=https://docs.docker.com
+        After=network-online.target
+        Wants=network-online.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Type=notify
+        # the default is not to use systemd for cgroups because the delegate issues still
+        # exists and systemd currently does not support the cgroup feature set required
+        # for containers run by docker
+        ExecStart=/opt/bin/dockerd
+        ExecReload=/bin/kill -s HUP $MAINPID
+        LimitNOFILE=1048576
+        # Having non-zero Limit*s causes performance problems due to accounting overhead
+        # in the kernel. We recommend using cgroups to do container-local accounting.
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        # Uncomment TasksMax if your systemd version supports it.
+        # Only systemd 226 and above support this version.
+        
+        TasksMax=infinity
+        
+        TimeoutStartSec=0
+        # set delegate yes so that systemd does not reset the cgroups of docker containers
+        Delegate=yes
+        # kill only the docker process, not all processes in the cgroup
+        KillMode=process
+        # restart the docker process if it exits prematurely
+        Restart=on-failure
+        StartLimitBurst=3
+        StartLimitInterval=60s
+        
         [Install]
         WantedBy=multi-user.target
 
     - name: docker-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service docker.service
+          After=download-binaries.service docker.service
       contents: |
           [Unit]
           Requires=docker.service
           After=docker.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh container-runtime
           
           [Install]
@@ -66,19 +163,20 @@ systemd:
           
 
     - name: kubelet-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service kubelet.service
+          After=download-binaries.service kubelet.service
       contents: |
           [Unit]
           Requires=kubelet.service
           After=kubelet.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh kubelet
           
           [Install]
@@ -86,12 +184,12 @@ systemd:
           
 
     - name: kubelet.service
-      enabled: true
+      enabled: false
       contents: |
         [Unit]
         Description=Kubernetes Kubelet
-        Requires=docker.service
-        After=docker.service
+        Requires=docker.service containerd.service
+        After=docker.service containerd.service
         [Service]
         TimeoutStartSec=5min
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.12.0
@@ -289,14 +387,6 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
-    - path: /etc/systemd/system/docker.service.d/10-storage.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          Environment=DOCKER_OPTS=--storage-driver=overlay2
-
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755
@@ -311,6 +401,16 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           
+          # docker
+          if [ ! -f /opt/bin/docker ]; then
+              # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+              # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+              # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+              curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+              mv /opt/docker/* /opt/bin/
+              rm -rf /opt/docker
+          fi
+          
           # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
@@ -321,3 +421,45 @@ storage:
               chmod +x /opt/bin/health-monitor.sh
           fi
           
+
+    - path: /opt/bin/setup.sh
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -xeuo pipefail
+          # Make sure systemd is aware of the new units in /etc/systemd/system
+          systemctl daemon-reload
+          systemctl enable --now docker
+          systemctl enable --now kubelet
+          systemctl enable --now --no-block kubelet-healthcheck.service
+          systemctl enable --now --no-block docker-healthcheck.service
+          
+
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+            "default-runtime": "docker-runc",
+            "runtimes": {
+              "docker-runc": {
+                "path": "/opt/bin/docker-runc"
+              }
+            },
+            "storage-driver": "overlay2",
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "10m",
+              "max-file": "2"
+            }
+          }
+
+    - path: /etc/profile.d/opt-bin-path.sh
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          export PATH="/opt/bin:$PATH"

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
@@ -14,10 +14,24 @@ systemd:
     - name: locksmithd.service
       mask: true
 
-    - name: docker.service
-      enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: docker.socket
+      mask: true
+
+    - name: download-binaries.service
+      enabled: false
+      contents: |
+        [Unit]
+        Requires=network-online.target
+        After=network-online.target
+        [Service]
+        Type=oneshot
+        ExecStartPre=/opt/bin/download.sh
+        ExecStart=/usr/bin/echo Successfully downloaded all required binaries
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: setup-kubelet.service
       enabled: true
       contents: |
         [Unit]
@@ -25,24 +39,107 @@ systemd:
         After=network-online.target
         [Service]
         Type=oneshot
-        ExecStart=/opt/bin/download.sh
+        ExecStart=/opt/bin/setup.sh
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: containerd.service
+      enabled: false
+      dropins:
+      - name: override.conf
+        contents: |
+          [Unit]
+          Requires=download-binaries.service
+          After=download-binaries.service
+      contents: |
+        [Unit]
+        Description=containerd container runtime
+        Documentation=https://containerd.io
+        After=network.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Delegate=yes
+        ExecStart=/opt/bin/docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --metrics-interval=0 --start-timeout 2m --state-dir /var/run/docker/libcontainerd/containerd --shim /opt/bin/docker-containerd-shim --runtime /opt/bin/docker-runc
+        
+        KillMode=process
+        Restart=always
+        
+        # (lack of) limits from the upstream docker service unit
+        LimitNOFILE=1048576
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        
+        TasksMax=infinity
+        
+        
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: docker.service
+      dropins:
+      - name: containerd.conf
+        contents: |
+          [Unit]
+          After=containerd.service
+          Requires=containerd.service
+          [Service]
+          ExecStart= 
+          ExecStart=/opt/bin/dockerd --containerd=/var/run/docker/libcontainerd/docker-containerd.sock 
+
+      contents: |
+        [Unit]
+        Description=Docker Application Container Engine
+        Documentation=https://docs.docker.com
+        After=network-online.target
+        Wants=network-online.target
+        
+        [Service]
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+        Type=notify
+        # the default is not to use systemd for cgroups because the delegate issues still
+        # exists and systemd currently does not support the cgroup feature set required
+        # for containers run by docker
+        ExecStart=/opt/bin/dockerd
+        ExecReload=/bin/kill -s HUP $MAINPID
+        LimitNOFILE=1048576
+        # Having non-zero Limit*s causes performance problems due to accounting overhead
+        # in the kernel. We recommend using cgroups to do container-local accounting.
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        # Uncomment TasksMax if your systemd version supports it.
+        # Only systemd 226 and above support this version.
+        
+        TasksMax=infinity
+        
+        TimeoutStartSec=0
+        # set delegate yes so that systemd does not reset the cgroups of docker containers
+        Delegate=yes
+        # kill only the docker process, not all processes in the cgroup
+        KillMode=process
+        # restart the docker process if it exits prematurely
+        Restart=on-failure
+        StartLimitBurst=3
+        StartLimitInterval=60s
+        
         [Install]
         WantedBy=multi-user.target
 
     - name: docker-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service docker.service
+          After=download-binaries.service docker.service
       contents: |
           [Unit]
           Requires=docker.service
           After=docker.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh container-runtime
           
           [Install]
@@ -50,19 +147,20 @@ systemd:
           
 
     - name: kubelet-healthcheck.service
-      enabled: true
+      enabled: false
       dropins:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries.service kubelet.service
+          After=download-binaries.service kubelet.service
       contents: |
           [Unit]
           Requires=kubelet.service
           After=kubelet.service
           
           [Service]
+          Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
           ExecStart=/opt/bin/health-monitor.sh kubelet
           
           [Install]
@@ -70,12 +168,12 @@ systemd:
           
 
     - name: kubelet.service
-      enabled: true
+      enabled: false
       contents: |
         [Unit]
         Description=Kubernetes Kubelet
-        Requires=docker.service
-        After=docker.service
+        Requires=docker.service containerd.service
+        After=docker.service containerd.service
         [Service]
         TimeoutStartSec=5min
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
@@ -244,13 +342,6 @@ storage:
           sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-
 
 
 
@@ -273,14 +364,6 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
-    - path: /etc/systemd/system/docker.service.d/10-storage.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          Environment=DOCKER_OPTS=--storage-driver=overlay2
-
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755
@@ -295,6 +378,16 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           
+          # docker
+          if [ ! -f /opt/bin/docker ]; then
+              # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+              # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+              # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+              curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+              mv /opt/docker/* /opt/bin/
+              rm -rf /opt/docker
+          fi
+          
           # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
@@ -305,3 +398,45 @@ storage:
               chmod +x /opt/bin/health-monitor.sh
           fi
           
+
+    - path: /opt/bin/setup.sh
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          set -xeuo pipefail
+          # Make sure systemd is aware of the new units in /etc/systemd/system
+          systemctl daemon-reload
+          systemctl enable --now docker
+          systemctl enable --now kubelet
+          systemctl enable --now --no-block kubelet-healthcheck.service
+          systemctl enable --now --no-block docker-healthcheck.service
+          
+
+    - path: /etc/docker/daemon.json
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          {
+            "default-runtime": "docker-runc",
+            "runtimes": {
+              "docker-runc": {
+                "path": "/opt/bin/docker-runc"
+              }
+            },
+            "storage-driver": "overlay2",
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "10m",
+              "max-file": "2"
+            }
+          }
+
+    - path: /etc/profile.d/opt-bin-path.sh
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          export PATH="/opt/bin:$PATH"

--- a/pkg/userdata/helper/container_runtime.go
+++ b/pkg/userdata/helper/container_runtime.go
@@ -1,0 +1,133 @@
+package helper
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+// DockerDaemonConfig returns the docker daemon.json with preferred settings
+func DockerDaemonConfig() string {
+	// We need to specify a custom default runtime, as docker does not allow to specify a path for runc (Which is a reserved key - which cannot be overwritten)
+	// This is needed to make sure we only use the binaries we downloaded. On CoreOS the same binaries already exist on the OS, but in different versions.
+	// We must only use our binaries to avoid versions conflicts
+	return `{
+  "default-runtime": "docker-runc",
+  "runtimes": {
+    "docker-runc": {
+      "path": "/opt/bin/docker-runc"
+    }
+  },
+  "storage-driver": "overlay2",
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "2"
+  }
+}`
+}
+
+const dockerSystemdUnitTpl = `[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/opt/bin/dockerd
+ExecReload=/bin/kill -s HUP $MAINPID
+LimitNOFILE=1048576
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this version.
+{{ if .SetTasksMax }}
+TasksMax=infinity
+{{ end }}
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+# restart the docker process if it exits prematurely
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
+[Install]
+WantedBy=multi-user.target`
+
+// DockerSystemdUnit returns the systemd unit for docker. setTasksMax should be set if the consumer uses systemd > 226 (Ubuntu & CoreoS - NOT CentOS)
+func DockerSystemdUnit(setTasksMax bool) (string, error) {
+	tmpl, err := template.New("docker-systemd-unit").Funcs(TxtFuncMap()).Parse(dockerSystemdUnitTpl)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse docker-systemd-unit template: %v", err)
+	}
+
+	data := struct {
+		SetTasksMax bool
+	}{
+		SetTasksMax: setTasksMax,
+	}
+	b := &bytes.Buffer{}
+	err = tmpl.Execute(b, data)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute docker-systemd-unit template: %v", err)
+	}
+
+	return b.String(), nil
+}
+
+const (
+	containerdSystemdUnit = `[Unit]
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target
+
+[Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+Delegate=yes
+ExecStart=/opt/bin/docker-containerd -l unix:///var/run/docker/libcontainerd/docker-containerd.sock --metrics-interval=0 --start-timeout 2m --state-dir /var/run/docker/libcontainerd/containerd --shim /opt/bin/docker-containerd-shim --runtime /opt/bin/docker-runc
+
+KillMode=process
+Restart=always
+
+# (lack of) limits from the upstream docker service unit
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+{{ if .SetTasksMax }}
+TasksMax=infinity
+{{ end }}
+
+[Install]
+WantedBy=multi-user.target`
+)
+
+// ContainerdSystemdUnit returns the systemd unit for containerd
+func ContainerdSystemdUnit(setTasksMax bool) (string, error) {
+	tmpl, err := template.New("containerd-systemd-unit").Funcs(TxtFuncMap()).Parse(containerdSystemdUnit)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse containerd-systemd-unit template: %v", err)
+	}
+
+	data := struct {
+		SetTasksMax bool
+	}{
+		SetTasksMax: setTasksMax,
+	}
+	b := &bytes.Buffer{}
+	err = tmpl.Execute(b, data)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute containerd-systemd-unit template: %v", err)
+	}
+
+	return b.String(), nil
+}

--- a/pkg/userdata/helper/download_binaries_script.go
+++ b/pkg/userdata/helper/download_binaries_script.go
@@ -14,6 +14,16 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 
+# docker
+if [ ! -f /opt/bin/docker ]; then
+    # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+    # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+    # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+    curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+    mv /opt/docker/* /opt/bin/
+    rm -rf /opt/docker
+fi
+
 # cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -

--- a/pkg/userdata/helper/helper.go
+++ b/pkg/userdata/helper/helper.go
@@ -72,3 +72,14 @@ func JournalDConfig() string {
 SystemMaxUse=5G
 `
 }
+
+// StartAllUnits returns the shell commands to start all required units
+func StartAllUnits() string {
+	return `# Make sure systemd is aware of the new units in /etc/systemd/system
+systemctl daemon-reload
+systemctl enable --now docker
+systemctl enable --now kubelet
+systemctl enable --now --no-block kubelet-healthcheck.service
+systemctl enable --now --no-block docker-healthcheck.service
+`
+}

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -46,11 +46,10 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=https://kubernetes.io/docs/home/
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 Restart=always
 StartLimitInterval=0
 RestartSec=10
-
-Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
 {{ kubeletFlags .KubeletVersion .CloudProvider .Hostname .ClusterDNSIPs | indent 2 }}
@@ -119,6 +118,7 @@ Requires=kubelet.service
 After=kubelet.service
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 ExecStart=/opt/bin/health-monitor.sh kubelet
 
 [Install]
@@ -132,6 +132,7 @@ Requires=docker.service
 After=docker.service
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 ExecStart=/opt/bin/health-monitor.sh container-runtime
 
 [Install]

--- a/pkg/userdata/helper/template_functions.go
+++ b/pkg/userdata/helper/template_functions.go
@@ -16,8 +16,12 @@ func TxtFuncMap() template.FuncMap {
 	funcMap["kernelModules"] = KernelModules
 	funcMap["kernelSettings"] = KernelSettings
 	funcMap["journalDConfig"] = JournalDConfig
+	funcMap["dockerDaemonConfig"] = DockerDaemonConfig
 	funcMap["kubeletHealthCheckSystemdUnit"] = KubeletHealthCheckSystemdUnit
 	funcMap["containerRuntimeHealthCheckSystemdUnit"] = ContainerRuntimeHealthCheckSystemdUnit
+	funcMap["dockerSystemdUnit"] = DockerSystemdUnit
+	funcMap["containerdSystemdUnit"] = ContainerdSystemdUnit
+	funcMap["startAllUnits"] = StartAllUnits
 
 	return funcMap
 }

--- a/pkg/userdata/helper/testdata/download_binaries_v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.10.0.golden
@@ -5,6 +5,16 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 
+# docker
+if [ ! -f /opt/bin/docker ]; then
+    # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+    # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+    # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+    curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+    mv /opt/docker/* /opt/bin/
+    rm -rf /opt/docker
+fi
+
 # cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -

--- a/pkg/userdata/helper/testdata/download_binaries_v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.11.0-rc.2.golden
@@ -5,6 +5,16 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 
+# docker
+if [ ! -f /opt/bin/docker ]; then
+    # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+    # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+    # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+    curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+    mv /opt/docker/* /opt/bin/
+    rm -rf /opt/docker
+fi
+
 # cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -

--- a/pkg/userdata/helper/testdata/download_binaries_v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.11.0.golden
@@ -5,6 +5,16 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 
+# docker
+if [ ! -f /opt/bin/docker ]; then
+    # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+    # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+    # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+    curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+    mv /opt/docker/* /opt/bin/
+    rm -rf /opt/docker
+fi
+
 # cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -

--- a/pkg/userdata/helper/testdata/download_binaries_v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.11.3.golden
@@ -5,6 +5,16 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 
+# docker
+if [ ! -f /opt/bin/docker ]; then
+    # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+    # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+    # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+    curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+    mv /opt/docker/* /opt/bin/
+    rm -rf /opt/docker
+fi
+
 # cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -

--- a/pkg/userdata/helper/testdata/download_binaries_v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.12.0.golden
@@ -5,6 +5,16 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 
+# docker
+if [ ! -f /opt/bin/docker ]; then
+    # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+    # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+    # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+    curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+    mv /opt/docker/* /opt/bin/
+    rm -rf /opt/docker
+fi
+
 # cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -6,11 +6,10 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=https://kubernetes.io/docs/home/
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 Restart=always
 StartLimitInterval=0
 RestartSec=10
-
-Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
@@ -6,11 +6,10 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=https://kubernetes.io/docs/home/
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 Restart=always
 StartLimitInterval=0
 RestartSec=10
-
-Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
@@ -6,11 +6,10 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=https://kubernetes.io/docs/home/
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 Restart=always
 StartLimitInterval=0
 RestartSec=10
-
-Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
@@ -6,11 +6,10 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=https://kubernetes.io/docs/home/
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 Restart=always
 StartLimitInterval=0
 RestartSec=10
-
-Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
@@ -6,11 +6,10 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=https://kubernetes.io/docs/home/
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 Restart=always
 StartLimitInterval=0
 RestartSec=10
-
-Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
@@ -6,11 +6,10 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=https://kubernetes.io/docs/home/
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 Restart=always
 StartLimitInterval=0
 RestartSec=10
-
-Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
@@ -6,11 +6,10 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=https://kubernetes.io/docs/home/
 
 [Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 Restart=always
 StartLimitInterval=0
 RestartSec=10
-
-Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,12 +139,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade -y
     if [[ -e /var/run/reboot-required ]]; then
       reboot
@@ -157,6 +155,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -173,11 +181,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -198,11 +208,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -306,13 +315,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -321,6 +323,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -335,11 +338,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,12 +139,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -156,6 +154,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -172,11 +180,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -197,11 +207,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -305,13 +314,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -320,6 +322,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -334,11 +337,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,12 +139,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -156,6 +154,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -172,11 +180,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -197,11 +207,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -305,13 +314,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -320,6 +322,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -334,11 +337,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
@@ -123,7 +123,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -142,12 +141,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -158,6 +156,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -174,11 +182,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -199,11 +209,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -307,13 +316,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -322,6 +324,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -336,11 +339,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,12 +139,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -156,6 +154,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -172,11 +180,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -197,11 +207,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -309,13 +318,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -324,6 +326,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -338,11 +341,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,12 +139,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -156,6 +154,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -172,11 +180,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -197,11 +207,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -307,13 +316,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -322,6 +324,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -336,11 +339,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,12 +139,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -156,6 +154,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -172,11 +180,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -197,11 +207,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -305,13 +314,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -320,6 +322,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -334,11 +337,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,12 +139,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -156,6 +154,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -172,11 +180,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -197,11 +207,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -305,13 +314,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -320,6 +322,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -334,11 +337,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker-ce=18.06.0~ce~3-0~ubuntu'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,12 +139,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -156,6 +154,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -172,11 +180,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -197,11 +207,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -304,13 +313,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -319,6 +321,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -333,11 +336,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,12 +139,11 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -156,6 +154,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -172,11 +180,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -197,11 +207,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -305,13 +314,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -320,6 +322,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -334,11 +337,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere.golden
+++ b/pkg/userdata/ubuntu/testdata/vsphere.golden
@@ -121,7 +121,6 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -140,13 +139,12 @@ write_files:
       nfs-common \
       socat \
       util-linux \
-      ${CR_PKG} \
+      bridge-utils \
+      libapparmor1 \
+      libltdl7 \
+      perl \
       ipvsadm \
       open-vm-tools
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
-    apt-mark hold docker.io || true
-    apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
@@ -157,6 +155,16 @@ write_files:
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
+    
+    # docker
+    if [ ! -f /opt/bin/docker ]; then
+        # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+        # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+        # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+        curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+        mv /opt/docker/* /opt/bin/
+        rm -rf /opt/docker
+    fi
     
     # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
@@ -173,11 +181,13 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
-
+    # Make sure systemd is aware of the new units in /etc/systemd/system
+    systemctl daemon-reload
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -198,11 +208,10 @@ write_files:
     Documentation=https://kubernetes.io/docs/home/
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
@@ -310,13 +319,6 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
-- path: /etc/systemd/system/docker.service.d/10-storage.conf
-  permissions: "0644"
-  content: |
-    [Service]
-    ExecStart=
-    ExecStart=/usr/bin/dockerd -H fd:// --storage-driver=overlay2
-
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"
   content: |
@@ -325,6 +327,7 @@ write_files:
     After=kubelet.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh kubelet
     
     [Install]
@@ -339,11 +342,70 @@ write_files:
     After=docker.service
     
     [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     ExecStart=/opt/bin/health-monitor.sh container-runtime
     
     [Install]
     WantedBy=multi-user.target
     
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    }
+
+- path: /etc/systemd/system/docker.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP $MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will unify the docker installation on all operating systems.
Instead of installing the best(Or close to best) version via the individual OS repositories, docker will now be installed by simply downloading the release binary & creating the systemdunit.
This ensures that we always install the same version across all operating systems.

Additionally - and this was actually the initial idea - all operating systems now use the docker log-rotation via `daemon.json`

Fixes #292 

```release-note
Install docker 17.03 via binary and configure logs rotation on all systems via daemon.json
```
