### PR TITLE
replace delete with cleanup to ensure proper deletion of all cloud provider resources

### DIFF
--- a/pkg/cloudprovider/cloud/provider.go
+++ b/pkg/cloudprovider/cloud/provider.go
@@ -35,11 +35,11 @@ type Provider interface {
 	// Create creates a cloud instance according to the given machine
 	Create(machine *clusterv1alpha1.Machine, data *MachineCreateDeleteData, userdata string) (instance.Instance, error)
 
-	// Delete deletes the instance and all associated ressources
-	// This will always be called on machine deletion, the implemention must check if there is actually
-	// something to delete and just do nothing if there isn't
-	// In case the instance is already gone, nil will be returned
-	Delete(machine *clusterv1alpha1.Machine, data *MachineCreateDeleteData) error
+	// Cleanup will delete the instance associated with the machine and all associated resources.
+	// If all resources have been cleaned up, true will be returned.
+	// In case the cleanup involves ansynchronous deletion of resources & those resources are not gone yet,
+	// false should be returned. This is to indicate that the cleanup is not done, but needs to be called again at a later point
+	Cleanup(machine *clusterv1alpha1.Machine, data *MachineCreateDeleteData) (bool, error)
 
 	// MachineMetricsLabels returns labels used for the Prometheus metrics
 	// about created machines, e.g. instance type, instance size, region

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -472,9 +472,11 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloud.MachineCreateDe
 		Groups:     aws.StringSlice(config.SecurityGroupIDs),
 	})
 	if err != nil {
-		delErr := p.Delete(machine, data)
-		if delErr != nil {
-			return nil, awsErrorToTerminalError(err, fmt.Sprintf("failed to attach instance %s to security groups %v & delete the created instance", aws.StringValue(runOut.Instances[0].InstanceId), config.SecurityGroupIDs))
+		_, err := ec2Client.TerminateInstances(&ec2.TerminateInstancesInput{
+			InstanceIds: []*string{runOut.Instances[0].InstanceId},
+		})
+		if err != nil {
+			return nil, awsErrorToTerminalError(err, fmt.Sprintf("failed to attach instance %s to security group id's %v & delete the created instance", aws.StringValue(runOut.Instances[0].InstanceId), config.SecurityGroupIDs))
 		}
 		return nil, awsErrorToTerminalError(err, fmt.Sprintf("failed to attach instance %s to security group %v", aws.StringValue(runOut.Instances[0].InstanceId), config.SecurityGroupIDs))
 	}
@@ -482,18 +484,18 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloud.MachineCreateDe
 	return awsInstance, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) error {
+func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) (bool, error) {
 	instance, err := p.Get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
-			return nil
+			return true, nil
 		}
-		return err
+		return false, err
 	}
 
 	config, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
-		return cloudprovidererrors.TerminalError{
+		return false, cloudprovidererrors.TerminalError{
 			Reason:  common.InvalidConfigurationMachineError,
 			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
 		}
@@ -501,21 +503,21 @@ func (p *provider) Delete(machine *v1alpha1.Machine, _ *cloud.MachineCreateDelet
 
 	ec2Client, err := getEC2client(config.AccessKeyID, config.SecretAccessKey, config.Region)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	tOut, err := ec2Client.TerminateInstances(&ec2.TerminateInstancesInput{
 		InstanceIds: aws.StringSlice([]string{instance.ID()}),
 	})
 	if err != nil {
-		return awsErrorToTerminalError(err, "failed to terminate instance")
+		return false, awsErrorToTerminalError(err, "failed to terminate instance")
 	}
 
 	if *tOut.TerminatingInstances[0].PreviousState.Name != *tOut.TerminatingInstances[0].CurrentState.Name {
 		glog.V(4).Infof("successfully triggered termination of instance %s at aws", instance.ID())
 	}
 
-	return nil
+	return false, nil
 }
 
 func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -80,8 +80,8 @@ func (p *provider) Create(_ *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData,
 	return CloudProviderInstance{}, nil
 }
 
-func (p *provider) Delete(_ *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) error {
-	return nil
+func (p *provider) Cleanup(_ *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) (bool, error) {
+	return true, nil
 }
 
 func (p *provider) MigrateUID(machine *v1alpha1.Machine, new types.UID) error {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -475,18 +475,18 @@ func deleteInstanceDueToFatalLogged(computeClient *gophercloud.ServiceClient, se
 	glog.V(0).Infof("Instance %s got deleted", serverID)
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) error {
+func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) (bool, error) {
 	instance, err := p.Get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
-			return nil
+			return true, nil
 		}
-		return err
+		return false, err
 	}
 
 	c, _, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
-		return cloudprovidererrors.TerminalError{
+		return false, cloudprovidererrors.TerminalError{
 			Reason:  common.InvalidConfigurationMachineError,
 			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
 		}
@@ -494,19 +494,19 @@ func (p *provider) Delete(machine *v1alpha1.Machine, _ *cloud.MachineCreateDelet
 
 	client, err := getClient(c)
 	if err != nil {
-		return osErrorToTerminalError(err, "failed to get a openstack client")
+		return false, osErrorToTerminalError(err, "failed to get a openstack client")
 	}
 
 	computeClient, err := goopenstack.NewComputeV2(client, gophercloud.EndpointOpts{Availability: gophercloud.AvailabilityPublic, Region: c.Region})
 	if err != nil {
-		return osErrorToTerminalError(err, "failed to get compute client")
+		return false, osErrorToTerminalError(err, "failed to get compute client")
 	}
 
 	if err := osservers.Delete(computeClient, instance.ID()).ExtractErr(); err != nil {
-		return osErrorToTerminalError(err, "failed to delete instance")
+		return false, osErrorToTerminalError(err, "failed to delete instance")
 	}
 
-	return nil
+	return false, nil
 }
 
 func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {

--- a/pkg/cloudprovider/validationwrapper.go
+++ b/pkg/cloudprovider/validationwrapper.go
@@ -63,8 +63,8 @@ func (w *cachingValidationWrapper) Create(m *v1alpha1.Machine, mcd *cloud.Machin
 }
 
 // Delete just calls the underlying cloudproviders Delete
-func (w *cachingValidationWrapper) Delete(m *v1alpha1.Machine, mcd *cloud.MachineCreateDeleteData) error {
-	return w.actualProvider.Delete(m, mcd)
+func (w *cachingValidationWrapper) Cleanup(m *v1alpha1.Machine, mcd *cloud.MachineCreateDeleteData) (bool, error) {
+	return w.actualProvider.Cleanup(m, mcd)
 }
 
 // MigrateUID just calls the underlying cloudproviders MigrateUID

--- a/pkg/cloudprovider/validationwrapper.go
+++ b/pkg/cloudprovider/validationwrapper.go
@@ -62,7 +62,7 @@ func (w *cachingValidationWrapper) Create(m *v1alpha1.Machine, mcd *cloud.Machin
 	return w.actualProvider.Create(m, mcd, cloudConfig)
 }
 
-// Delete just calls the underlying cloudproviders Delete
+// Cleanup just calls the underlying cloudproviders Cleanup
 func (w *cachingValidationWrapper) Cleanup(m *v1alpha1.Machine, mcd *cloud.MachineCreateDeleteData) (bool, error) {
 	return w.actualProvider.Cleanup(m, mcd)
 }

--- a/test/e2e/provisioning/migrateuidscenario.go
+++ b/test/e2e/provisioning/migrateuidscenario.go
@@ -157,8 +157,8 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 			return fmt.Errorf("failed to delete machine %s: %v", machine.Name, err)
 		}
 		if !done {
-			// Resources are not gone yet, check in a few seconds again
-			time.Sleep(30 * time.Second)
+			// The deletion is async, thus we wait 10 seconds to recheck if its done
+			time.Sleep(10 * time.Second)
 			continue
 		}
 

--- a/test/e2e/provisioning/migrateuidscenario.go
+++ b/test/e2e/provisioning/migrateuidscenario.go
@@ -145,14 +145,21 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 
 	// Step 4: Delete the instance and then verify instance is gone
 	for i := 0; i < maxTries; i++ {
+
 		// Deletion part 0: Delete and continue on err if there are tries left
-		if err := prov.Delete(machine, machineCreateDeleteData); err != nil {
+		done, err := prov.Cleanup(machine, machineCreateDeleteData)
+		if err != nil {
 			if i < maxTries-1 {
 				glog.V(4).Infof("Failed to delete machine %s on try %v with err=%v, will retry", machine.Name, i, err)
 				time.Sleep(10 * time.Second)
 				continue
 			}
 			return fmt.Errorf("failed to delete machine %s: %v", machine.Name, err)
+		}
+		if !done {
+			// Resources are not gone yet, check in a few seconds again
+			time.Sleep(30 * time.Second)
+			continue
 		}
 
 		// Deletion part 1: Get and continue if err != cloudprovidererrors.ErrInstanceNotFound if there are tries left


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the way we delete cloud provider resources.
Instead of doing a one-shot delete call, the controller will now continuously call `Cleanup` on the cloud provider implementation until it returns `true` - stating that all resources are gone.

Fixes #383

```release-note
NONE
```
