### PR TITLE
Pass PVLister down to providers Create/Delete

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -111,8 +111,11 @@ type controllerRunOptions struct {
 	// nodeLister holds a lister that knows how to list Nodes from a cache
 	nodeLister listerscorev1.NodeLister
 
-	// secreSystemNstLister knows hot to list Secrects that are inside kube-system namespace from a cache
+	// secretSystemNsLister knows hot to list Secrects that are inside kube-system namespace from a cache
 	secretSystemNsLister listerscorev1.SecretLister
+
+	// pvLister knows how to list PersistentVolumes
+	pvLister listerscorev1.PersistentVolumeLister
 
 	// machineInformer holds a shared informer for Machines
 	machineInformer cache.SharedIndexInformer
@@ -218,6 +221,7 @@ func main() {
 		nodeInformer:         kubeInformerFactory.Core().V1().Nodes().Informer(),
 		nodeLister:           kubeInformerFactory.Core().V1().Nodes().Lister(),
 		secretSystemNsLister: kubeSystemInformerFactory.Core().V1().Secrets().Lister(),
+		pvLister:             kubeInformerFactory.Core().V1().PersistentVolumes().Lister(),
 		machineInformer:      clusterInformerFactory.Cluster().V1alpha1().Machines().Informer(),
 		machineLister:        clusterInformerFactory.Cluster().V1alpha1().Machines().Lister(),
 		kubeconfigProvider:   kubeconfigProvider,
@@ -380,6 +384,7 @@ func startControllerViaLeaderElection(runOptions controllerRunOptions) error {
 			runOptions.machineInformer,
 			runOptions.machineLister,
 			runOptions.secretSystemNsLister,
+			runOptions.pvLister,
 			runOptions.clusterDNSIPs,
 			runOptions.metrics,
 			runOptions.prometheusRegisterer,

--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -447,11 +447,13 @@ rules:
   - "nodes"
   verbs:
   - "*"
-# Required for draining
+# Pods are required for draining
+# PVs are required for vsphere to detach them prior to deleting the instance
 - apiGroups:
   - ""
   resources:
   - "pods"
+  - "persistentvolumes"
   verbs:
   - "list"
   - "get"

--- a/pkg/cloudprovider/cloud/provider.go
+++ b/pkg/cloudprovider/cloud/provider.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
 
 	"k8s.io/apimachinery/pkg/types"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
 
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
@@ -30,13 +31,13 @@ type Provider interface {
 	GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config string, name string, err error)
 
 	// Create creates a cloud instance according to the given machine
-	Create(machine *clusterv1alpha1.Machine, update MachineUpdater, userdata string) (instance.Instance, error)
+	Create(machine *clusterv1alpha1.Machine, data *MachineCreateDeleteData, userdata string) (instance.Instance, error)
 
 	// Delete deletes the instance and all associated ressources
 	// This will always be called on machine deletion, the implemention must check if there is actually
 	// something to delete and just do nothing if there isn't
 	// In case the instance is already gone, nil will be returned
-	Delete(machine *clusterv1alpha1.Machine, update MachineUpdater) error
+	Delete(machine *clusterv1alpha1.Machine, data *MachineCreateDeleteData) error
 
 	// MachineMetricsLabels returns labels used for the Prometheus metrics
 	// about created machines, e.g. instance type, instance size, region
@@ -51,3 +52,9 @@ type Provider interface {
 
 // MachineUpdater defines a function to persist an update to a machine
 type MachineUpdater func(*clusterv1alpha1.Machine, func(*clusterv1alpha1.Machine)) (*clusterv1alpha1.Machine, error)
+
+// MachineCreateDeleteData is the struct the cloud providers get when creating or deleting an instance
+type MachineCreateDeleteData struct {
+	Updater  MachineUpdater
+	PVLister listerscorev1.PersistentVolumeLister
+}

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -503,7 +503,7 @@ func ensureDefaultInstanceProfileExists(client *iam.IAM) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, data *cloud.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
 	config, pc, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -630,7 +630,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 		Groups:     aws.StringSlice(securityGroupIDs),
 	})
 	if err != nil {
-		delErr := p.Delete(machine, update)
+		delErr := p.Delete(machine, data)
 		if delErr != nil {
 			return nil, awsErrorToTerminalError(err, fmt.Sprintf("failed to attach instance %s to security group %s & delete the created instance", aws.StringValue(runOut.Instances[0].InstanceId), defaultSecurityGroupName))
 		}
@@ -640,7 +640,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	return awsInstance, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) error {
 	instance, err := p.Get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -319,7 +319,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	return spec, false, nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, data *cloud.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
 	config, providerCfg, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -349,7 +349,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	var publicIP *network.PublicIPAddress
 	if config.AssignPublicIP {
 		if !kuberneteshelper.HasFinalizer(machine, finalizerPublicIP) {
-			if machine, err = update(machine, func(updatedMachine *v1alpha1.Machine) {
+			if machine, err = data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
 				updatedMachine.Finalizers = append(updatedMachine.Finalizers, finalizerPublicIP)
 			}); err != nil {
 				return nil, err
@@ -362,7 +362,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	}
 
 	if !kuberneteshelper.HasFinalizer(machine, finalizerNIC) {
-		if machine, err = update(machine, func(updatedMachine *v1alpha1.Machine) {
+		if machine, err = data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
 			updatedMachine.Finalizers = append(updatedMachine.Finalizers, finalizerNIC)
 		}); err != nil {
 			return nil, err
@@ -420,14 +420,14 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 
 	glog.Infof("Creating machine %q", machine.Spec.Name)
 	if !kuberneteshelper.HasFinalizer(machine, finalizerDisks) {
-		if machine, err = update(machine, func(updatedMachine *v1alpha1.Machine) {
+		if machine, err = data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
 			updatedMachine.Finalizers = append(updatedMachine.Finalizers, finalizerDisks)
 		}); err != nil {
 			return nil, err
 		}
 	}
 	if !kuberneteshelper.HasFinalizer(machine, finalizerVM) {
-		if machine, err = update(machine, func(updatedMachine *v1alpha1.Machine) {
+		if machine, err = data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
 			updatedMachine.Finalizers = append(updatedMachine.Finalizers, finalizerVM)
 		}); err != nil {
 			return nil, err
@@ -467,7 +467,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	return &azureVM{vm: &vm, ipAddresses: ipAddresses, status: status}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, data *cloud.MachineCreateDeleteData) error {
 	config, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return fmt.Errorf("failed to parse MachineSpec: %v", err)
@@ -483,7 +483,7 @@ func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater
 		}
 	}
 
-	if machine, err = update(machine, func(updatedMachine *v1alpha1.Machine) {
+	if machine, err = data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
 		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerVM)
 	}); err != nil {
 		return err
@@ -493,7 +493,7 @@ func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	if err = deleteDisksByMachineUID(context.TODO(), config, machine.UID); err != nil {
 		return fmt.Errorf("failed to remove disks of machine %q: %v", machine.Name, err)
 	}
-	if machine, err = update(machine, func(updatedMachine *v1alpha1.Machine) {
+	if machine, err = data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
 		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerDisks)
 	}); err != nil {
 		return err
@@ -503,7 +503,7 @@ func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	if err = deleteInterfacesByMachineUID(context.TODO(), config, machine.UID); err != nil {
 		return fmt.Errorf("failed to remove network interfaces of machine %q: %v", machine.Name, err)
 	}
-	if machine, err = update(machine, func(updatedMachine *v1alpha1.Machine) {
+	if machine, err = data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
 		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerNIC)
 	}); err != nil {
 		return err
@@ -513,7 +513,7 @@ func (p *provider) Delete(machine *v1alpha1.Machine, update cloud.MachineUpdater
 	if err = deleteIPAddressesByMachineUID(context.TODO(), config, machine.UID); err != nil {
 		return fmt.Errorf("failed to remove public IP addresses of machine %q: %v", machine.Name, err)
 	}
-	if machine, err = update(machine, func(updatedMachine *v1alpha1.Machine) {
+	if machine, err = data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
 		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerPublicIP)
 	}); err != nil {
 		return err

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -255,7 +255,7 @@ func uploadRandomSSHPublicKey(ctx context.Context, service godo.KeysService) (st
 	return newDoKey.Fingerprint, nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -327,7 +327,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, use
 	return &doInstance{droplet: droplet}, err
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) error {
 	instance, err := p.Get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -76,11 +76,11 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (string, string, er
 }
 
 // Create creates a cloud instance according to the given machine
-func (p *provider) Create(_ *v1alpha1.Machine, _ cloud.MachineUpdater, _ string) (instance.Instance, error) {
+func (p *provider) Create(_ *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData, _ string) (instance.Instance, error) {
 	return CloudProviderInstance{}, nil
 }
 
-func (p *provider) Delete(_ *v1alpha1.Machine, _ cloud.MachineUpdater) error {
+func (p *provider) Delete(_ *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) error {
 	return nil
 }
 

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -140,7 +140,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -226,7 +226,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, use
 	return &hetznerServer{server: serverCreateRes.Server}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) error {
 	instance, err := p.Get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -352,7 +352,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
 	c, _, _, err := p.getConfig(machine.Spec.ProviderConfig)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -478,7 +478,7 @@ func deleteInstanceDueToFatalLogged(computeClient *gophercloud.ServiceClient, se
 	glog.V(0).Infof("Instance %s got deleted", serverID)
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData) error {
 	instance, err := p.Get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -311,7 +311,7 @@ func machineInvalidConfigurationTerminalError(err error) error {
 	}
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloud.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -382,7 +382,15 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ cloud.MachineUpdater, use
 	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value}, nil
 }
 
-func (p *provider) Delete(machine *v1alpha1.Machine, _ cloud.MachineUpdater) error {
+func (p *provider) Delete(machine *v1alpha1.Machine, data *cloud.MachineCreateDeleteData) error {
+	pvs, err := data.PVLister.List(nil)
+	if err != nil {
+		return fmt.Errorf("failed to list PVs: %v", err)
+	}
+	for _, pv := range pvs {
+		_ = pv
+	}
+
 	if _, err := p.Get(machine); err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return nil

--- a/test/e2e/provisioning/verify.go
+++ b/test/e2e/provisioning/verify.go
@@ -354,14 +354,18 @@ func getInt32Ptr(i int32) *int32 {
 }
 
 func updateMachineDeployment(md *v1alpha1.MachineDeployment, clusterClient clientset.Interface, modify func(*v1alpha1.MachineDeployment)) error {
+	// Store Namespace and Name here because after an error md will be nil
+	name := md.Name
+	namespace := md.Namespace
+
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		var err error
-		md, err = clusterClient.ClusterV1alpha1().MachineDeployments(md.Namespace).Get(md.Name, metav1.GetOptions{})
+		md, err = clusterClient.ClusterV1alpha1().MachineDeployments(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 		modify(md)
-		md, err = clusterClient.ClusterV1alpha1().MachineDeployments(md.Namespace).Update(md)
+		md, err = clusterClient.ClusterV1alpha1().MachineDeployments(namespace).Update(md)
 		return err
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Initially I started off by passing down a new struct with all required info into the cloudproviders `New()`. This poses a problem thought, as both the `MachineControllerMetrics` and the `AdmissionWebhook` call that `New()`, hence the change would result in being forced to have a `MachineUpdater` and a `PVLister` to be available in the metrics and webhook even thought its not used at all. 

```release-note
NONE
```
