### PR TITLE
Remove deprecated changed return parameter on cloud provider implementations

### DIFF
--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -96,7 +96,7 @@ func (ad *admissionData) defaultAndValidateMachineSpec(spec *clusterv1alpha1.Mac
 		return fmt.Errorf("Kubelet version must be set")
 	}
 
-	defaultedSpec, _, err := prov.AddDefaults(*spec)
+	defaultedSpec, err := prov.AddDefaults(*spec)
 	if err != nil {
 		return fmt.Errorf("failed to default machineSpec: %v", err)
 	}

--- a/pkg/cloudprovider/cloud/provider.go
+++ b/pkg/cloudprovider/cloud/provider.go
@@ -11,7 +11,8 @@ import (
 
 // Provider exposed all required functions to interact with a cloud provider
 type Provider interface {
-	AddDefaults(spec clusterv1alpha1.MachineSpec) (clusterv1alpha1.MachineSpec, bool, error)
+	// AddDefaults will read the MachineSpec and apply defaults for provider specific fields
+	AddDefaults(spec clusterv1alpha1.MachineSpec) (clusterv1alpha1.MachineSpec, error)
 
 	// Validate validates the given machine's specification.
 	//
@@ -28,6 +29,7 @@ type Provider interface {
 	// In case the instance cannot be found, github.com/kubermatic/machine-controller/pkg/cloudprovider/errors/ErrInstanceNotFound will be returned
 	Get(machine *clusterv1alpha1.Machine) (instance.Instance, error)
 
+	// GetCloudConfig will return the cloud provider specific cloud-config, which gets consumed by the kubelet
 	GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config string, name string, err error)
 
 	// Create creates a cloud instance according to the given machine

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -279,8 +279,8 @@ func getEC2client(id, secret, region string) (*ec2.EC2, error) {
 	return ec2.New(sess), nil
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, bool, error) {
-	return spec, false, nil
+func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+	return spec, nil
 }
 
 func (p *provider) Validate(spec v1alpha1.MachineSpec) error {

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -315,8 +315,8 @@ func getIPAddressStrings(ctx context.Context, c *config, addrName string) ([]str
 	return ipAddresses, nil
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, bool, error) {
-	return spec, false, nil
+func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+	return spec, nil
 }
 
 func (p *provider) Create(machine *v1alpha1.Machine, data *cloud.MachineCreateDeleteData, userdata string) (instance.Instance, error) {

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -151,8 +151,8 @@ func (p *provider) getConfig(s v1alpha1.ProviderConfig) (*Config, *providerconfi
 	return &c, &pconfig, err
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, bool, error) {
-	return spec, false, nil
+func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+	return spec, nil
 }
 
 func (p *provider) Validate(spec v1alpha1.MachineSpec) error {

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -41,8 +41,8 @@ func New(_ *providerconfig.ConfigVarResolver) cloud.Provider {
 	return &provider{}
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, bool, error) {
-	return spec, false, nil
+func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+	return spec, nil
 }
 
 // Validate returns success or failure based according to its FakeCloudProviderConfig

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -256,8 +256,8 @@ func (p *provider) Delete(machine *v1alpha1.Machine, _ *cloud.MachineCreateDelet
 	return nil
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, bool, error) {
-	return spec, false, nil
+func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+	return spec, nil
 }
 
 func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -207,12 +207,10 @@ func getClient(c *Config) (*gophercloud.ProviderClient, error) {
 	return goopenstack.AuthenticatedClient(opts)
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, bool, error) {
-	var changed bool
-
+func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
 	c, _, rawConfig, err := p.getConfig(spec.ProviderConfig)
 	if err != nil {
-		return spec, changed, cloudprovidererrors.TerminalError{
+		return spec, cloudprovidererrors.TerminalError{
 			Reason:  common.InvalidConfigurationMachineError,
 			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
 		}
@@ -220,21 +218,20 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 
 	client, err := getClient(c)
 	if err != nil {
-		return spec, changed, osErrorToTerminalError(err, "failed to get a openstack client")
+		return spec, osErrorToTerminalError(err, "failed to get a openstack client")
 	}
 
 	if c.Region == "" {
 		glog.V(4).Infof("Trying to default region for machine '%s'...", spec.Name)
 		regions, err := getRegions(client)
 		if err != nil {
-			return spec, changed, osErrorToTerminalError(err, "failed to get regions")
+			return spec, osErrorToTerminalError(err, "failed to get regions")
 		}
 		if len(regions) == 1 {
 			glog.V(4).Infof("Defaulted region for machine '%s' to '%s'", spec.Name, regions[0].ID)
-			changed = true
 			rawConfig.Region.Value = regions[0].ID
 		} else {
-			return spec, changed, fmt.Errorf("could not default region because got '%v' results", len(regions))
+			return spec, fmt.Errorf("could not default region because got '%v' results", len(regions))
 		}
 	}
 
@@ -242,11 +239,10 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 		glog.V(4).Infof("Trying to default availability zone for machine '%s'...", spec.Name)
 		availabilityZones, err := getAvailabilityZones(client, c.Region)
 		if err != nil {
-			return spec, changed, osErrorToTerminalError(err, "failed to get availability zones")
+			return spec, osErrorToTerminalError(err, "failed to get availability zones")
 		}
 		if len(availabilityZones) == 1 {
 			glog.V(4).Infof("Defaulted availability zone for machine '%s' to '%s'", spec.Name, availabilityZones[0].ZoneName)
-			changed = true
 			rawConfig.AvailabilityZone.Value = availabilityZones[0].ZoneName
 		}
 	}
@@ -255,13 +251,12 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 		glog.V(4).Infof("Trying to default network for machine '%s'...", spec.Name)
 		net, err := getDefaultNetwork(client, c.Region)
 		if err != nil {
-			return spec, changed, osErrorToTerminalError(err, "failed to default network")
+			return spec, osErrorToTerminalError(err, "failed to default network")
 		}
 		if net != nil {
 			glog.V(4).Infof("Defaulted network for machine '%s' to '%s'", spec.Name, net.Name)
 			// Use the id as the name may not be unique
 			rawConfig.Network.Value = net.ID
-			changed = true
 		}
 	}
 
@@ -273,24 +268,23 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 
 		net, err := getNetwork(client, c.Region, networkID)
 		if err != nil {
-			return spec, changed, osErrorToTerminalError(err, fmt.Sprintf("failed to get network for subnet defaulting '%s", networkID))
+			return spec, osErrorToTerminalError(err, fmt.Sprintf("failed to get network for subnet defaulting '%s", networkID))
 		}
 		subnet, err := getDefaultSubnet(client, net, c.Region)
 		if err != nil {
-			return spec, changed, osErrorToTerminalError(err, "error defaulting subnet")
+			return spec, osErrorToTerminalError(err, "error defaulting subnet")
 		}
 		if subnet != nil {
 			glog.V(4).Infof("Defaulted subnet for machine '%s' to '%s'", spec.Name, *subnet)
 			rawConfig.Subnet.Value = *subnet
-			changed = true
 		}
 	}
 
 	spec.ProviderConfig.Value, err = setProviderConfig(*rawConfig, spec.ProviderConfig)
 	if err != nil {
-		return spec, changed, osErrorToTerminalError(err, "error marshaling providerconfig")
+		return spec, osErrorToTerminalError(err, "error marshaling providerconfig")
 	}
-	return spec, changed, nil
+	return spec, nil
 }
 
 func (p *provider) Validate(spec v1alpha1.MachineSpec) error {

--- a/test/e2e/provisioning/migrateuidscenario.go
+++ b/test/e2e/provisioning/migrateuidscenario.go
@@ -71,7 +71,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 		return fmt.Errorf("failed to get cloud provider %q: %v", providerConfig.CloudProvider, err)
 
 	}
-	defaultedSpec, _, err := prov.AddDefaults(machine.Spec)
+	defaultedSpec, err := prov.AddDefaults(machine.Spec)
 	if err != nil {
 		return fmt.Errorf("failed to add defaults: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove deprecated changed return parameter on cloud provider implementations.

```release-note
NONE
```
