### PR TITLE
Cache cloudprovider validation

### DIFF
--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -19,6 +19,10 @@ spec:
   - name: Address
     type: string
     JSONPath: .status.addresses[0].address
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -44,6 +48,9 @@ spec:
   - name: OS
     type: string
     JSONPath: .spec.template.spec.providerConfig.value.operatingSystem
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -69,6 +76,9 @@ spec:
   - name: OS
     type: string
     JSONPath: .spec.template.spec.providerConfig.value.operatingSystem
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -212,7 +222,7 @@ spec:
           command:
             - /usr/local/bin/webhook
             - -logtostderr
-            - -v=4
+            - -v=6
             - -listen-address=0.0.0.0:9876
           volumeMounts:
             - name: machine-controller-admission-cert

--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -57,16 +57,9 @@ func (ad *admissionData) mutateMachines(ar admissionv1beta1.AdmissionReview) (*a
 		machine.Spec.Name = machine.Name
 	}
 
-	var isMachineSetOwned bool
-	for _, ownerRef := range machine.OwnerReferences {
-		if ownerRef.Kind == "MachineSet" {
-			isMachineSetOwned = true
-			break
-		}
-	}
 	// Default and verify .Spec on CREATE only, its expensive and not required to do it on UPDATE
 	// as we disallow .Spec changes anyways
-	if ar.Request.Operation == admissionv1beta1.Create && !isMachineSetOwned {
+	if ar.Request.Operation == admissionv1beta1.Create {
 		if err := ad.defaultAndValidateMachineSpec(&machine.Spec); err != nil {
 			return nil, err
 		}

--- a/pkg/cloudprovider/cache/cloudprovidercache.go
+++ b/pkg/cloudprovider/cache/cloudprovidercache.go
@@ -8,8 +8,6 @@ import (
 
 	gocache "github.com/patrickmn/go-cache"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
@@ -58,11 +56,7 @@ func (c *CloudproviderCache) Set(machineSpec clusterv1alpha1.MachineSpec, val er
 }
 
 func getID(machineSpec clusterv1alpha1.MachineSpec) (string, error) {
-	// We clear these two fields as they are irrelevant for the cloudprovider validation
-	machineSpec.ObjectMeta = metav1.ObjectMeta{}
-	machineSpec.Taints = nil
-
-	b, err := json.Marshal(machineSpec)
+	b, err := json.Marshal(machineSpec.ProviderConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal MachineSpec: %v", err)
 	}

--- a/pkg/cloudprovider/cache/cloudprovidercache.go
+++ b/pkg/cloudprovider/cache/cloudprovidercache.go
@@ -1,0 +1,76 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+type CloudproviderCache struct {
+	cache *gocache.Cache
+}
+
+// New returns a new cloudproviderCache
+func New() *CloudproviderCache {
+	return &CloudproviderCache{cache: gocache.New(5*time.Minute, 5*time.Minute)}
+}
+
+// Get returns an error indicating the result of the validation and a boolean indicating if
+// it got a cache hit or miss
+func (c *CloudproviderCache) Get(machineSpec clusterv1alpha1.MachineSpec) (error, bool, error) {
+	id, err := getID(machineSpec)
+	if err != nil {
+		return nil, false, err
+	}
+
+	val, found := c.cache.Get(id)
+	if !found {
+		return nil, false, nil
+	}
+
+	if val == nil {
+		return nil, true, nil
+	}
+
+	errVal, castable := val.(error)
+	if !castable {
+		return nil, false, fmt.Errorf("failed to cast val to err: %v", err)
+	}
+	return errVal, true, nil
+}
+
+// Set sets the passed value for the given machineSpec
+func (c *CloudproviderCache) Set(machineSpec clusterv1alpha1.MachineSpec, val error) error {
+	id, err := getID(machineSpec)
+	if err != nil {
+		return err
+	}
+
+	c.cache.Set(id, val, gocache.DefaultExpiration)
+	return nil
+}
+
+func getID(machineSpec clusterv1alpha1.MachineSpec) (string, error) {
+	// We clear these two fields as they are irrelevant for the cloudprovider validation
+	machineSpec.ObjectMeta = metav1.ObjectMeta{}
+	machineSpec.Taints = nil
+
+	b, err := json.Marshal(machineSpec)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal MachineSpec: %v", err)
+	}
+
+	sum := sha256.Sum256(b)
+	var sumSlice []byte
+	for _, b := range sum {
+		sumSlice = append(sumSlice, b)
+	}
+	return string(sumSlice), nil
+}

--- a/pkg/cloudprovider/cache/cloudprovidercache_test.go
+++ b/pkg/cloudprovider/cache/cloudprovidercache_test.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+func TestCloudproviderCache(t *testing.T) {
+	cache := New()
+
+	m1 := clusterv1alpha1.MachineSpec{}
+	m1.ProviderConfig.Value = &runtime.RawExtension{Raw: []byte(`{"key":"m1"}`)}
+	m1.Name = "hans"
+
+	if err := cache.Set(m1, nil); err != nil {
+		t.Fatalf("Error setting cache value for m1: %v", err)
+	}
+	val, exists, err := cache.Get(m1)
+	if err != nil {
+		t.Fatalf("Error when getting m1 from cache: %v", err)
+	}
+	if !exists {
+		t.Error("Expected val to exist when getting m1 from cache")
+	}
+	if val != nil {
+		t.Errorf("Expected m1 val to be nil but was %v", val)
+	}
+
+	m1.Name = "wurst"
+	val, exists, err = cache.Get(m1)
+	if err != nil {
+		t.Fatalf("Error getting m1 from cache after changing name: %v", err)
+	}
+	if !exists {
+		t.Error("Expected val to exist when getting m1 from cache after chaning name")
+	}
+	if val != nil {
+		t.Errorf("Expected m1 val to be nil after changing name but was %v", val)
+	}
+
+	m1.Taints = []corev1.Taint{{Key: "hello", Value: "world"}}
+	val, exists, err = cache.Get(m1)
+	if err != nil {
+		t.Fatalf("Error getting m1 from cache after adding taint: %v", err)
+	}
+	if !exists {
+		t.Error("Expected val to exist when getting m1 from cache after adding taints")
+	}
+	if val != nil {
+		t.Errorf("Expected m1 val to be nil after adding taint but was %s", val)
+	}
+
+	m2 := clusterv1alpha1.MachineSpec{}
+	m2.ProviderConfig.Value = &runtime.RawExtension{Raw: []byte(`{"key":"m2"}`)}
+	val, exists, err = cache.Get(m2)
+	if err != nil {
+		t.Fatalf("Error getting m2 from cache: %v", err)
+	}
+	if exists {
+		t.Error("Expected val to not exist when getting m2 from cache")
+	}
+	if val != nil {
+		t.Errorf("Expected val for m2 to be nil but was %v", val)
+	}
+
+	m3 := clusterv1alpha1.MachineSpec{}
+	m3.ProviderConfig.Value = &runtime.RawExtension{Raw: []byte(`{"key":"m3"}`)}
+	errMsg := "Thou shall not pass"
+	if err := cache.Set(m3, errors.New(errMsg)); err != nil {
+		t.Fatalf("Error setting cache value for m3: %v", err)
+	}
+	val, exists, err = cache.Get(m3)
+	if err != nil {
+		t.Fatalf("Error getting m3 from cache: %v", err)
+	}
+	if !exists {
+		t.Error("Expected val to exist when getting m3 from cache")
+	}
+	if val.Error() != errMsg {
+		t.Errorf("Expected val for m3 to be %s but was %v", errMsg, val)
+	}
+}

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -3,6 +3,7 @@ package cloudprovider
 import (
 	"errors"
 
+	cloudprovidercache "github.com/kubermatic/machine-controller/pkg/cloudprovider/cache"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/cloud"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure"
@@ -15,6 +16,8 @@ import (
 )
 
 var (
+	cache = cloudprovidercache.New()
+
 	// ErrProviderNotFound tells that the requested cloud provider was not found
 	ErrProviderNotFound = errors.New("cloudprovider not found")
 
@@ -46,7 +49,7 @@ var (
 // ForProvider returns a CloudProvider actuator for the requested provider
 func ForProvider(p providerconfig.CloudProvider, cvr *providerconfig.ConfigVarResolver) (cloud.Provider, error) {
 	if p, found := providers[p]; found {
-		return p(cvr), nil
+		return NewValidationCacheWrappingCloudProvider(p(cvr)), nil
 	}
 	return nil, ErrProviderNotFound
 }

--- a/pkg/cloudprovider/validationwrapper.go
+++ b/pkg/cloudprovider/validationwrapper.go
@@ -1,0 +1,78 @@
+package cloudprovider
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/cloud"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+type cachingValidationWrapper struct {
+	actualProvider cloud.Provider
+}
+
+// NewValidationCacheWrappingCloudProvider returns a wrapped cloudprovider
+func NewValidationCacheWrappingCloudProvider(actualProvider cloud.Provider) cloud.Provider {
+	return &cachingValidationWrapper{actualProvider: actualProvider}
+}
+
+// AddDefaults just calls the underlying cloudproviders AddDefaults
+func (w *cachingValidationWrapper) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+	return w.actualProvider.AddDefaults(spec)
+}
+
+// Validate tries to get the validation result from the cache and if not found, calls the
+// cloudproviders Validate and saves that to the cache
+func (w *cachingValidationWrapper) Validate(spec v1alpha1.MachineSpec) error {
+	result, exists, err := cache.Get(spec)
+	if err != nil {
+		return fmt.Errorf("error getting validation result from cache: %v", err)
+	}
+	if exists {
+		glog.V(6).Infof("Got cache hit for validation")
+		return result
+	}
+
+	glog.V(6).Infof("Got cache miss for validation")
+	err = w.actualProvider.Validate(spec)
+	if err := cache.Set(spec, err); err != nil {
+		return fmt.Errorf("failed to set cache after validation: %v", err)
+	}
+
+	return err
+}
+
+// Get just calls the underlying cloudproviders Get
+func (w *cachingValidationWrapper) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+	return w.actualProvider.Get(machine)
+}
+
+// GetCloudConfig just calls the underlying cloudproviders GetCloudConfig
+func (w *cachingValidationWrapper) GetCloudConfig(spec v1alpha1.MachineSpec) (string, string, error) {
+	return w.actualProvider.GetCloudConfig(spec)
+}
+
+// Create just calls the underlying cloudproviders Create
+func (w *cachingValidationWrapper) Create(m *v1alpha1.Machine, mcd *cloud.MachineCreateDeleteData, cloudConfig string) (instance.Instance, error) {
+	return w.actualProvider.Create(m, mcd, cloudConfig)
+}
+
+// Delete just calls the underlying cloudproviders Delete
+func (w *cachingValidationWrapper) Delete(m *v1alpha1.Machine, mcd *cloud.MachineCreateDeleteData) error {
+	return w.actualProvider.Delete(m, mcd)
+}
+
+// MigrateUID just calls the underlying cloudproviders MigrateUID
+func (w *cachingValidationWrapper) MigrateUID(m *v1alpha1.Machine, new types.UID) error {
+	return w.actualProvider.MigrateUID(m, new)
+}
+
+// MachineMetricsLabels just calls the underlying cloudproviders MachineMetricsLabels
+func (w *cachingValidationWrapper) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]string, error) {
+	return w.actualProvider.MachineMetricsLabels(machine)
+}


### PR DESCRIPTION
Fixes #397

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Log from the webhook, first eight lines are on the first run of tests, second eight lines on the second run:

```
$ k logs machine-controller-webhook-854d6d9959-ms6tx -f |grep 'validationwrapper.go'
I1108 17:02:03.779021       1 validationwrapper.go:41] Got cache miss for validation
I1108 17:02:03.797608       1 validationwrapper.go:41] Got cache miss for validation
I1108 17:02:03.799101       1 validationwrapper.go:41] Got cache miss for validation
I1108 17:02:03.799295       1 validationwrapper.go:41] Got cache miss for validation
I1108 17:02:03.799943       1 validationwrapper.go:41] Got cache miss for validation
I1108 17:02:03.826444       1 validationwrapper.go:41] Got cache miss for validation
I1108 17:02:03.829624       1 validationwrapper.go:41] Got cache miss for validation
I1108 17:02:03.830230       1 validationwrapper.go:41] Got cache miss for validation
I1108 17:03:26.033274       1 validationwrapper.go:37] Got cache hit for validation
I1108 17:03:26.039542       1 validationwrapper.go:37] Got cache hit for validation
I1108 17:03:26.064090       1 validationwrapper.go:37] Got cache hit for validation
I1108 17:03:26.064985       1 validationwrapper.go:37] Got cache hit for validation
I1108 17:03:26.065049       1 validationwrapper.go:37] Got cache hit for validation
I1108 17:03:26.065670       1 validationwrapper.go:37] Got cache hit for validation
I1108 17:03:26.066815       1 validationwrapper.go:37] Got cache hit for validation
I1108 17:03:26.075409       1 validationwrapper.go:37] Got cache hit for validation
```

```release-note
NONE
```
