### PR TITLE
Update makefiles for migrating to prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ webhook: $(shell find cmd pkg -name '*.go') vendor
 		github.com/kubermatic/machine-controller/cmd/webhook
 
 lint:
+	./hack/verify-type-revision-annotation-const.sh
 	gometalinter --config gometalinter.json ./...
 
 docker-image: machine-controller webhook docker-image-nodep
@@ -105,3 +106,9 @@ deploy: examples/admission-cert.pem
 		|sed "s/__admission_cert__/$(shell cat examples/admission-cert.pem|base64 -w0)/g" \
 		|sed "s/__admission_key__/$(shell cat examples/admission-key.pem|base64 -w0)/g" \
 		|kubectl apply -f -
+
+check-dependencies:
+	# We need mercurial for bitbucket.org/ww/goautoneg, otherwise dep hangs forever
+	which hg >/dev/null 2>&1 || apt update && apt install -y mercurial
+	$$GOPATH/bin/dep version || (export DEP_RELEASE_TAG=v0.5.0; curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh)
+	dep status

--- a/hack/ci-e2e-test.sh
+++ b/hack/ci-e2e-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -e
+
+export BUILD_ID="${BUILD_ID:-$CIRCLE_BUILD_NUM}"
+
+# Install dependencies
+echo "Installing dependencies."
+apt update && apt install -y jq rsync unzip &&
+curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl &&
+chmod +x kubectl &&
+mv kubectl /usr/local/bin
+
+# Generate ssh keypair
+echo "Generating ssh keypairs."
+ssh-keygen -f $HOME/.ssh/id_rsa -P ''
+
+# Create environment at cloud provider
+echo "Creating environment at cloud provider."
+make -C test/tools/integration apply
+
+# Create kubeadm cluster and install machine-controller onto it
+echo "Creating kubeadm cluster and install machine-controller onto it."
+./test/tools/integration/provision_master.sh
+
+# Run e2e test
+echo "Running e2e test."
+export KUBECONFIG=$GOPATH/src/github.com/kubermatic/machine-controller/.kubeconfig &&
+go test -race -tags=e2e -parallel 240 -v -timeout 30m  ./test/e2e/... -identifier=$BUILD_ID
+
+function cleanup {
+    set +e
+
+    # Clean up machines
+    echo "Cleaning up machines."
+    ./test/tools/integration/cleanup_machines.sh
+
+    # Clean up master
+    echo "Clean up master."
+    make -C test/tools/integration destroy
+}
+trap cleanup EXIT

--- a/test/tools/integration/Makefile
+++ b/test/tools/integration/Makefile
@@ -1,3 +1,6 @@
+# prow uses BUILD_ID
+# TODO: remove CIRCLE_BUILD_NUM entirely after moving to prow
+CIRCLE_BUILD_NUM ?=$$BUILD_ID
 CIRCLE_BUILD_NUM ?= local
 
 USER ?= circleCI


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Makefiles and adds a script for the e2e test so that we can directly use them in prowjobs.

This is a first step for moving from CircleCI to Prowjobs: https://github.com/kubermatic/machine-controller/issues/400.

```release-note
NONE
```
