### PR TITLE
Move region into secret of openstack

### DIFF
--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -12,6 +12,7 @@ stringData:
   password: << OS_PASSWORD >>
   domainName: << OS_DOMAIN_NAME >>
   tenantName: << OS_TENANT_NAME >>
+  region: << OS_REGION_NAME >>
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -79,6 +80,12 @@ spec:
                 namespace: kube-system
                 name: machine-controller-openstack
                 key: tenantName
+            # Only required if there is more than one region to choose from
+            region:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: region
             image: "Ubuntu 18.04 amd64"
             flavor: "m1.small"
             securityGroups:
@@ -90,8 +97,6 @@ spec:
             floatingIpPool: "ext-net"
             # Only required if there is more than one AZ to choose from
             availabilityZone: ""
-            # Only required if there is more than one region to choose from
-            region: ""
             # Only required if there is more than one network available
             network: ""
             # Only required if the network has more than one subnet


### PR DESCRIPTION
Openstack Region should be put into secret..

**What this PR does / why we need it**:
'Region' is secret in openrc file (params to link to keystone of openstack)
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```
Region should be a secret , not a common user settings
```
