### PR TITLE
Improve local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ GO_VERSION = 1.10.1
 
 export CGO_ENABLED := 0
 
+export E2E_SSH_PUBKEY ?= $(shell cat ~/.ssh/id_rsa.pub)
+
 REGISTRY ?= docker.io
 REGISTRY_NAMESPACE ?= kubermatic
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test-unit: vendor
 	@#The `-race` flag requires CGO
 	CGO_ENABLED=1 go test -race ./...
 
-e2e-cluster:
+e2e-cluster: machine-controller webhook
 	make -C test/tools/integration apply
 	./test/tools/integration/provision_master.sh do-not-deploy-machine-controller
 

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ test-unit: vendor
 e2e-cluster: machine-controller webhook
 	make -C test/tools/integration apply
 	./test/tools/integration/provision_master.sh do-not-deploy-machine-controller
+	KUBECONFIG=$(shell pwd)/.kubeconfig kubectl apply -f examples/machine-controller.yaml -l local-testing="true"
 
 e2e-destroy:
 	./test/tools/integration/cleanup_machines.sh

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Simply run `make test-unit`
 This project provides easy to use e2e testing using Hetzner cloud. To run the e2e tests
 locally, the following steps are required:
 
-* Populate the environment variable `HZ_TOKEN` with a valid Hetzner cloud token
+* Populate the environment variable `HZ_E2E_TOKEN` with a valid Hetzner cloud token
 * Run `make e2e-cluster` to get a simple kubeadm cluster on Hetzner
 * Run `hack/run-machine-controller.sh` to locally run the machine-controller for your freshly created cluster
 

--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: machines.cluster.k8s.io
+  labels:
+    local-testing: "true"
 spec:
   group: cluster.k8s.io
   version: v1alpha1
@@ -28,6 +30,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: machinesets.cluster.k8s.io
+  labels:
+    local-testing: "true"
 spec:
   group: cluster.k8s.io
   version: v1alpha1
@@ -56,6 +60,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: machinedeployments.cluster.k8s.io
+  labels:
+    local-testing: "true"
 spec:
   group: cluster.k8s.io
   version: v1alpha1
@@ -84,6 +90,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusters.cluster.k8s.io
+  labels:
+    local-testing: "true"
 spec:
   group: cluster.k8s.io
   version: v1alpha1
@@ -99,6 +107,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: machine-controller:kubelet-bootstrap
+  labels:
+    local-testing: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -112,6 +122,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-controller:node-autoapprove-bootstrap
+  labels:
+    local-testing: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -126,6 +138,8 @@ kind: Role
 metadata:
   name: machine-controller:kubelet-config
   namespace: kube-system
+  labels:
+    local-testing: "true"
 rules:
 - apiGroups:
   - ""
@@ -142,6 +156,8 @@ kind: RoleBinding
 metadata:
   name: machine-controller:kubelet-config
   namespace: kube-system
+  labels:
+    local-testing: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -274,12 +290,16 @@ kind: ServiceAccount
 metadata:
   name: machine-controller
   namespace: kube-system
+  labels:
+    local-testing: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: machine-controller
   namespace: kube-system
+  labels:
+    local-testing: "true"
 rules:
 - apiGroups:
   - ""
@@ -331,6 +351,8 @@ kind: Role
 metadata:
   name: machine-controller
   namespace: kube-public
+  labels:
+    local-testing: "true"
 rules:
 - apiGroups:
   - ""
@@ -346,6 +368,8 @@ kind: Role
 metadata:
   name: machine-controller
   namespace: default
+  labels:
+    local-testing: "true"
 rules:
 - apiGroups:
   - ""
@@ -361,6 +385,8 @@ kind: RoleBinding
 metadata:
   name: machine-controller
   namespace: kube-system
+  labels:
+    local-testing: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -375,6 +401,8 @@ kind: RoleBinding
 metadata:
   name: machine-controller
   namespace: kube-public
+  labels:
+    local-testing: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -389,6 +417,8 @@ kind: RoleBinding
 metadata:
   name: machine-controller
   namespace: default
+  labels:
+    local-testing: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -402,6 +432,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: machine-controller
+  labels:
+    local-testing: "true"
 rules:
 - apiGroups:
   - "apiextensions.k8s.io"
@@ -485,6 +517,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: machine-controller
+  labels:
+    local-testing: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/test/tools/integration/Makefile
+++ b/test/tools/integration/Makefile
@@ -1,7 +1,7 @@
 # prow uses BUILD_ID
 # TODO: remove CIRCLE_BUILD_NUM entirely after moving to prow
-CIRCLE_BUILD_NUM ?=$$BUILD_ID
-CIRCLE_BUILD_NUM ?= local
+BUILD_ID ?= $(USER)-local
+CIRCLE_BUILD_NUM ?=$(BUILD_ID)
 
 USER ?= circleCI
 

--- a/test/tools/integration/hetzner.tf
+++ b/test/tools/integration/hetzner.tf
@@ -3,13 +3,14 @@ provider "hcloud" {
 }
 
 resource "hcloud_ssh_key" "default" {
-  name = "${var.hcloud_sshkey_name}"
+  name       = "${var.hcloud_sshkey_name}"
   public_key = "${var.hcloud_sshkey_content}"
 }
 
 resource "hcloud_server" "machine-controller-test" {
-  name = "${var.hcloud_test_server_name}"
-  image = "ubuntu-18.04"
+  name        = "${var.hcloud_test_server_name}"
+  image       = "ubuntu-18.04"
   server_type = "cx41"
-  ssh_keys = ["${hcloud_ssh_key.default.id}"]
+  ssh_keys    = ["${hcloud_ssh_key.default.id}"]
+  location    = "hel1"
 }

--- a/test/tools/integration/provision_master.sh
+++ b/test/tools/integration/provision_master.sh
@@ -15,9 +15,11 @@ for try in {1..100}; do
   sleep 1;
 done
 
+if [[ "${1:-deploy_machine_controller}"  != "do-not-deploy-machine-controller" ]]; then
 rsync -avR  -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" \
     ../../.././{Makefile,examples/machine-controller.yaml,machine-controller,Dockerfile,webhook} \
     root@$ADDR:/root/
+fi
 
 cat <<EOEXEC |ssh_exec
 set -ex


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes various issues with the local test env:

* HZ token env var name in README was wrong
* Missing default for the `E2E_SSH_PUBKEY` env var caused the provisioning script to fail
* Manifests were not applied automatically
* The `e2e-cluster` Make target was missing the `machine-controller` and `webhook` dependencies
* The defaulting for the `BUILD_ID` was broken
* The defaulting for `BUILD_ID` was hardcoded to `local`, allowing only one person to use this at a time due to Hetzner server name restriction
* The binaries for `machine-controller` and `webhook` were always synced to the kubeadm controller even thought they weren't used locally

**Special notes for your reviewer**:

```release-note
NONE
```

CC @lindtdev 