### PR TITLE
Remove subnet concept in opensatck(Fix #404)

### DIFF
--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -94,8 +94,6 @@ spec:
             region: ""
             # Only required if there is more than one network available
             network: ""
-            # Only required if the network has more than one subnet
-            subnet: ""
             # the list of metadata you would like to attach to the instance
             tags:
               tagKey: tagValue

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/machinesv1alpha1machine/openstack.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/machinesv1alpha1machine/openstack.yaml
@@ -56,8 +56,6 @@ spec:
       region: ""
       # Only required if there is more than one network available
       network: ""
-      # Only required if the network has more than one subnet
-      subnet: ""
       # the list of tags you would like to attach to the instance
       tags:
         tagKey: tagValue

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/openstack.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/openstack.yaml
@@ -39,7 +39,6 @@ spec:
             key: securityGroup
             name: machine-controller
             namespace: kube-system
-        subnet: ""
         tags:
           tagKey: tagValue
         tenantName:


### PR DESCRIPTION
Per Bug indicated, the subnet need to be provided inside
network through fixed ip param, not subnet...

**What this PR does / why we need it**:
Per bug indicated, the subnet concept is not suitable to openstack
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 404

**Special notes for your reviewer**:

```release-note
Subnet concept has been removed from openstack, follow up patch will reorg network into dict and make fixed_ip to replace subnet selection
```
