### PR TITLE
remove kubeadm specific RBAC manifests

### DIFF
--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -133,43 +133,6 @@ subjects:
   kind: Group
   name: system:bootstrappers:machine-controller:default-node-token
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: machine-controller:kubelet-config
-  namespace: kube-system
-  labels:
-    local-testing: "true"
-rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - kubelet-config-1.11
-  - kubelet-config-1.12
-  resources:
-  - configmaps
-  verbs:
-  - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: machine-controller:kubelet-config
-  namespace: kube-system
-  labels:
-    local-testing: "true"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: machine-controller:kubelet-config
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:nodes
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:bootstrappers:machine-controller:default-node-token
----
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove kubeadm specific RBAC manifests. Kubeadm does not get used anymore.

```release-note
NONE
```
