### PR TITLE
filter images by name when loading the image from the openstack api

### DIFF
--- a/pkg/cloudprovider/provider/openstack/helper.go
+++ b/pkg/cloudprovider/provider/openstack/helper.go
@@ -98,7 +98,7 @@ func getImageByName(client *gophercloud.ProviderClient, region, name string) (*o
 	}
 
 	var allImages []osimages.Image
-	pager := osimages.ListDetail(computeClient, osimages.ListOpts{})
+	pager := osimages.ListDetail(computeClient, osimages.ListOpts{Name: name})
 	err = pager.EachPage(func(page pagination.Page) (bool, error) {
 		images, err := osimages.ExtractImages(page)
 		if err != nil {

--- a/pkg/cloudprovider/provider/openstack/helper.go
+++ b/pkg/cloudprovider/provider/openstack/helper.go
@@ -111,13 +111,10 @@ func getImageByName(client *gophercloud.ProviderClient, region, name string) (*o
 		return nil, err
 	}
 
-	for _, i := range allImages {
-		if i.Name == name {
-			return &i, nil
-		}
+	if len(allImages) == 0 {
+		return nil, errNotFound
 	}
-
-	return nil, errNotFound
+	return &allImages[0], nil
 }
 
 func getFlavor(client *gophercloud.ProviderClient, region, name string) (*osflavors.Flavor, error) {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -58,7 +58,7 @@ type RawConfig struct {
 	FloatingIPPool   providerconfig.ConfigVarString   `json:"floatingIpPool"`
 	AvailabilityZone providerconfig.ConfigVarString   `json:"availabilityZone"`
 	// This tag is related to server metadata, not compute server's tag
-	Tags             map[string]string                `json:"tags"`
+	Tags map[string]string `json:"tags"`
 }
 
 type Config struct {
@@ -122,9 +122,9 @@ func (p *provider) getConfig(s v1alpha1.ProviderConfig) (*Config, *providerconfi
 	}
 	// Ignore Region not found as Region might not be found and we can default it later
 	c.Region, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Region, "OS_REGION_NAME")
-        if err != nil {
+	if err != nil {
 		glog.V(6).Infof("Region from configuration or environment variable not found")
-        }
+	}
 
 	// We ignore errors here because the OS domain is only required when using Identity API V3
 	c.DomainName, _ = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.DomainName, "OS_DOMAIN_NAME")


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will add the desired image name to the request so the API takes care of filtering.
This will avoid that the controller checks all existing images.

```release-note
NONE
```
