### PR TITLE
Limit node CPUs on VSphere

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -278,7 +278,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	}
 
 	if config.CPUs > 8 {
-		return errors.New("number of CPUs could not be greater than 8")
+		return errors.New("number of CPUs must not be greater than 8")
 	}
 
 	client, err := getClient(config.Username, config.Password, config.VSphereURL, config.AllowInsecure)

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -277,6 +277,10 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 		return errors.New("specified target network (VMNetName) in cluster, but no source network (TemplateNetName) in machine")
 	}
 
+	if config.CPUs > 8 {
+		return errors.New("number of CPUs could not be greater than 8")
+	}
+
 	client, err := getClient(config.Username, config.Password, config.VSphereURL, config.AllowInsecure)
 	if err != nil {
 		return fmt.Errorf("failed to get vsphere client: '%v'", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Limit the amount of CPUs per node to a maximum of 8 on VSphere.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/kubermatic/kubermatic/issues/2139

**Special notes for your reviewer**:
/

```release-note
Limit amount of CPUs per node to a maximum of 8 on VSphere
```
