### PR TITLE
Move base Ubuntu provisioning into a dedicated script for reuse

### DIFF
--- a/pkg/userdata/helper/common_test.go
+++ b/pkg/userdata/helper/common_test.go
@@ -9,11 +9,12 @@ import (
 var update = flag.Bool("update", false, "update .golden files")
 
 var (
-	versions = []*semver.Version{
+	Versions = []*semver.Version{
 		semver.MustParse("v1.10.0"),
 		semver.MustParse("v1.11.0"),
 		semver.MustParse("v1.11.0-rc.2"),
 		semver.MustParse("v1.11.3"),
 		semver.MustParse("v1.12.0"),
+		semver.MustParse("v1.13.0"),
 	}
 )

--- a/pkg/userdata/helper/download_binaries_script_test.go
+++ b/pkg/userdata/helper/download_binaries_script_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDownloadBinariesScript(t *testing.T) {
-	for _, version := range versions {
+	for _, version := range Versions {
 		name := fmt.Sprintf("download_binaries_%s", version.Original())
 		t.Run(name, func(t *testing.T) {
 			script, err := DownloadBinariesScript(version.String(), true)

--- a/pkg/userdata/helper/kubelet_test.go
+++ b/pkg/userdata/helper/kubelet_test.go
@@ -20,7 +20,7 @@ type kubeletFlagTestCase struct {
 
 func TestKubeletSystemdUnit(t *testing.T) {
 	var tests []kubeletFlagTestCase
-	for _, version := range versions {
+	for _, version := range Versions {
 		tests = append(tests, kubeletFlagTestCase{
 			name:     fmt.Sprintf("version-%s", version.Original()),
 			version:  version,

--- a/pkg/userdata/helper/testdata/download_binaries_v1.13.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.13.0.golden
@@ -1,0 +1,31 @@
+#setup some common directories
+mkdir -p /opt/bin/
+mkdir -p /var/lib/calico
+mkdir -p /etc/kubernetes/manifests
+mkdir -p /etc/cni/net.d
+mkdir -p /opt/cni/bin
+
+# docker
+if [ ! -f /opt/bin/docker ]; then
+    # TODO: Support newer versions. Make sure to validate if the newer containerd version has configuration changes
+    # Newer versions of docker use containterd with a config file - containerd from 17.03 does not support that
+    # we maybe need to manage both ways(flags & config) or wait until we deprecate Kubernetes 1.11 
+    curl -L http://download.docker.com/linux/static/stable/x86_64/docker-17.03.2-ce.tgz | tar -xvzC /opt/ -f -
+    mv /opt/docker/* /opt/bin/
+    rm -rf /opt/docker
+fi
+
+# cni
+if [ ! -f /opt/cni/bin/loopback ]; then
+    curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
+fi
+# kubelet
+if [ ! -f /opt/bin/kubelet ]; then
+    curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubelet
+    chmod +x /opt/bin/kubelet
+fi
+
+if [[ ! -x /opt/bin/health-monitor.sh ]]; then
+    curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/8b5b66e4910a6228dfaecccaa0a3b05ec4902f8e/pkg/userdata/scripts/health-monitor.sh
+    chmod +x /opt/bin/health-monitor.sh
+fi

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.13.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.13.0.golden
@@ -1,0 +1,37 @@
+[Unit]
+After=docker.service
+Requires=docker.service
+
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/home/
+
+[Service]
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
+  --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
+  --kubeconfig=/etc/kubernetes/kubelet.conf \
+  --pod-manifest-path=/etc/kubernetes/manifests \
+  --allow-privileged=true \
+  --network-plugin=cni \
+  --cni-conf-dir=/etc/cni/net.d \
+  --cni-bin-dir=/opt/cni/bin \
+  --authorization-mode=Webhook \
+  --client-ca-file=/etc/kubernetes/pki/ca.crt \
+  --rotate-certificates=true \
+  --cert-dir=/etc/kubernetes/pki \
+  --authentication-token-webhook=true \
+  --hostname-override=some-test-node \
+  --read-only-port=0 \
+  --exit-on-lock-contention \
+  --lock-file=/tmp/kubelet.lock \
+  --anonymous-auth=false \
+  --protect-kernel-defaults=true \
+  --cluster-dns=10.10.10.10 \
+  --cluster-domain=cluster.local
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/userdata/ubuntu/base.go
+++ b/pkg/userdata/ubuntu/base.go
@@ -5,14 +5,12 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/Masterminds/semver"
-
 	"github.com/kubermatic/machine-controller/pkg/userdata/helper"
 )
 
 // GetBaseProvisioningScript will return a bash script which will prepare the Ubuntu 18.04 for Kubernetes.
 // All required binaries & services will be installed, but without cluster specifics like Kubeconfig, CA, etc.
-func GetBaseProvisioningScript(cloudProviderName string, kubeletVersion *semver.Version) (string, error) {
+func GetBaseProvisioningScript(cloudProviderName string, kubeletVersion string) (string, error) {
 	files := []File{
 		{
 			Filename: "/etc/systemd/journald.conf.d/max_disk_use.conf",
@@ -66,7 +64,7 @@ func GetBaseProvisioningScript(cloudProviderName string, kubeletVersion *semver.
 	}{
 		Files:          files,
 		CloudProvider:  cloudProviderName,
-		KubeletVersion: kubeletVersion.String(),
+		KubeletVersion: kubeletVersion,
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/pkg/userdata/ubuntu/base.go
+++ b/pkg/userdata/ubuntu/base.go
@@ -1,0 +1,137 @@
+package ubuntu
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/kubermatic/machine-controller/pkg/userdata/helper"
+)
+
+// GetBaseProvisioningScript will return a bash script which will prepare the Ubuntu 18.04 for Kubernetes.
+// All required binaries & services will be installed, but without cluster specifics like Kubeconfig, CA, etc.
+func GetBaseProvisioningScript(cloudProviderName string, kubeletVersion *semver.Version) (string, error) {
+	files := []File{
+		{
+			Filename: "/etc/systemd/journald.conf.d/max_disk_use.conf",
+			Content:  helper.JournalDConfig(),
+		},
+		{
+			Filename: "/etc/modules-load.d/k8s.conf",
+			Content:  helper.KernelModules(),
+		},
+		{
+			Filename: "/etc/sysctl.d/k8s.conf",
+			Content:  helper.KernelSettings(),
+		},
+		{
+			Filename: "/etc/profile.d/opt-bin-path.sh",
+			Content:  `export PATH="/opt/bin:$PATH"`,
+		},
+		{
+			Filename: "/etc/systemd/system/kubelet-healthcheck.service",
+			Content:  helper.KubeletHealthCheckSystemdUnit(),
+		},
+		{
+			Filename: "/etc/systemd/system/docker-healthcheck.service",
+			Content:  helper.ContainerRuntimeHealthCheckSystemdUnit(),
+		},
+		{
+			Filename: "/etc/docker/daemon.json",
+			Content:  helper.DockerDaemonConfig(),
+		},
+	}
+
+	dockerSystemdUnit, err := helper.DockerSystemdUnit(true)
+	if err != nil {
+		return "", fmt.Errorf("failed to create docker systemd unit: %v", err)
+	}
+
+	files = append(files, File{
+		Filename: "/etc/systemd/system/docker.service",
+		Content:  dockerSystemdUnit,
+	})
+
+	tmpl, err := template.New("base-setup").Funcs(helper.TxtFuncMap()).Parse(baseProvisioningTpl)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse base provisioning script template: %v", err)
+	}
+
+	data := struct {
+		CloudProvider  string
+		Files          []File
+		KubeletVersion string
+	}{
+		Files:          files,
+		CloudProvider:  cloudProviderName,
+		KubeletVersion: kubeletVersion.String(),
+	}
+	b := &bytes.Buffer{}
+	err = tmpl.Execute(b, data)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute base provisioning script template: %v", err)
+	}
+	return b.String(), nil
+}
+
+type File struct {
+	Filename string
+	Content  string
+	Mode     string
+}
+
+const (
+	baseProvisioningTpl = `#!/bin/bash
+set -xeuo pipefail
+
+{{ range .Files }}
+mkdir -p $(dirname {{ .Filename }})
+cat >{{ .Filename }} <<EOL
+{{ .Content  | replace "$" "\\$" }} 
+EOL
+{{ if .Mode -}}
+chmod {{ .Mode }} {{ .Filename }}
+{{ else -}}
+chmod 644 {{ .Filename -}}
+{{ end }}
+{{ end }}
+
+# As we added some modules and don't want to reboot, restart the service
+systemctl restart systemd-modules-load.service
+sysctl --system
+
+apt-get update
+
+# Make sure we always disable swap - Otherwise the kubelet won't start'.
+systemctl mask swap.target
+swapoff -a
+
+DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
+  curl \
+  ca-certificates \
+  ceph-common \
+  cifs-utils \
+  conntrack \
+  e2fsprogs \
+  ebtables \
+  ethtool \
+  glusterfs-client \
+  iptables \
+  jq \
+  kmod \
+  openssh-client \
+  nfs-common \
+  socat \
+  util-linux \
+  bridge-utils \
+  libapparmor1 \
+  libltdl7 \
+  perl \
+  ipvsadm{{ if eq .CloudProvider "vsphere" }} \
+  open-vm-tools{{ end }}
+
+{{ downloadBinariesScript .KubeletVersion true }}
+`
+)

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -144,11 +180,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade -y
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -181,6 +213,19 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade -y
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -309,99 +354,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -144,10 +180,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -180,6 +213,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -308,99 +353,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -144,10 +180,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -180,6 +213,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -308,99 +353,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
@@ -12,118 +12,154 @@ ssh_authorized_keys:
 - "ssh-rsa EEEFFF"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -146,10 +182,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -182,6 +215,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -310,99 +355,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -144,10 +180,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -180,6 +213,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -312,99 +357,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -144,10 +180,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -180,6 +213,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -310,99 +355,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -144,10 +180,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -180,6 +213,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -308,99 +353,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -144,10 +180,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -180,6 +213,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -308,99 +353,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -144,10 +180,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -180,6 +213,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -307,99 +352,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -144,10 +180,7 @@ write_files:
       libltdl7 \
       perl \
       ipvsadm
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -180,6 +213,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -308,99 +353,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere.golden
+++ b/pkg/userdata/ubuntu/testdata/vsphere.golden
@@ -10,118 +10,154 @@ ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    
+    
+    mkdir -p $(dirname /etc/systemd/journald.conf.d/max_disk_use.conf)
+    cat >/etc/systemd/journald.conf.d/max_disk_use.conf <<EOL
     [Journal]
     SystemMaxUse=5G
+     
+    EOL
+    chmod 644 /etc/systemd/journald.conf.d/max_disk_use.conf
     
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/modules-load.d/k8s.conf)
+    cat >/etc/modules-load.d/k8s.conf <<EOL
     ip_vs
     ip_vs_rr
     ip_vs_wrr
     ip_vs_sh
     nf_conntrack_ipv4
+     
+    EOL
+    chmod 644 /etc/modules-load.d/k8s.conf
     
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
+    mkdir -p $(dirname /etc/sysctl.d/k8s.conf)
+    cat >/etc/sysctl.d/k8s.conf <<EOL
     net.bridge.bridge-nf-call-ip6tables = 1
     net.bridge.bridge-nf-call-iptables = 1
     kernel.panic_on_oops = 1
     kernel.panic = 10
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
+     
+    EOL
+    chmod 644 /etc/sysctl.d/k8s.conf
     
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
-
-- path: "/opt/bin/setup"
-  permissions: "0755"
-  content: |
-    #!/bin/bash
-    set -xeuo pipefail
-
+    mkdir -p $(dirname /etc/profile.d/opt-bin-path.sh)
+    cat >/etc/profile.d/opt-bin-path.sh <<EOL
+    export PATH="/opt/bin:\$PATH" 
+    EOL
+    chmod 644 /etc/profile.d/opt-bin-path.sh
+    
+    mkdir -p $(dirname /etc/systemd/system/kubelet-healthcheck.service)
+    cat >/etc/systemd/system/kubelet-healthcheck.service <<EOL
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/kubelet-healthcheck.service
+    
+    mkdir -p $(dirname /etc/systemd/system/docker-healthcheck.service)
+    cat >/etc/systemd/system/docker-healthcheck.service <<EOL
+    [Unit]
+    Requires=docker.service
+    After=docker.service
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    ExecStart=/opt/bin/health-monitor.sh container-runtime
+    
+    [Install]
+    WantedBy=multi-user.target
+     
+    EOL
+    chmod 644 /etc/systemd/system/docker-healthcheck.service
+    
+    mkdir -p $(dirname /etc/docker/daemon.json)
+    cat >/etc/docker/daemon.json <<EOL
+    {
+      "default-runtime": "docker-runc",
+      "runtimes": {
+        "docker-runc": {
+          "path": "/opt/bin/docker-runc"
+        }
+      },
+      "storage-driver": "overlay2",
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "10m",
+        "max-file": "2"
+      }
+    } 
+    EOL
+    chmod 644 /etc/docker/daemon.json
+    
+    mkdir -p $(dirname /etc/systemd/system/docker.service)
+    cat >/etc/systemd/system/docker.service <<EOL
+    [Unit]
+    Description=Docker Application Container Engine
+    Documentation=https://docs.docker.com
+    After=network-online.target
+    Wants=network-online.target
+    
+    [Service]
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    Type=notify
+    # the default is not to use systemd for cgroups because the delegate issues still
+    # exists and systemd currently does not support the cgroup feature set required
+    # for containers run by docker
+    ExecStart=/opt/bin/dockerd
+    ExecReload=/bin/kill -s HUP \$MAINPID
+    LimitNOFILE=1048576
+    # Having non-zero Limit*s causes performance problems due to accounting overhead
+    # in the kernel. We recommend using cgroups to do container-local accounting.
+    LimitNPROC=infinity
+    LimitCORE=infinity
+    # Uncomment TasksMax if your systemd version supports it.
+    # Only systemd 226 and above support this version.
+    
+    TasksMax=infinity
+    
+    TimeoutStartSec=0
+    # set delegate yes so that systemd does not reset the cgroups of docker containers
+    Delegate=yes
+    # kill only the docker process, not all processes in the cgroup
+    KillMode=process
+    # restart the docker process if it exits prematurely
+    Restart=on-failure
+    StartLimitBurst=3
+    StartLimitInterval=60s
+    
+    [Install]
+    WantedBy=multi-user.target 
+    EOL
+    chmod 644 /etc/systemd/system/docker.service
+    
+    
     # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    apt-key add /opt/docker.asc
+    
     apt-get update
-
+    
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-
+    
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
@@ -145,10 +181,7 @@ write_files:
       perl \
       ipvsadm \
       open-vm-tools
-    if [[ -e /var/run/reboot-required ]]; then
-      reboot
-    fi
-
+    
     #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -181,6 +214,18 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
     
+    
+
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    /opt/bin/base-provisioning.sh
+    if [[ -e /var/run/reboot-required ]]; then
+      reboot
+    fi
+
     # Make sure systemd is aware of the new units in /etc/systemd/system
     systemctl daemon-reload
     systemctl enable --now docker
@@ -313,99 +358,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=kubelet.service
-    After=kubelet.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh kubelet
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Requires=docker.service
-    After=docker.service
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    ExecStart=/opt/bin/health-monitor.sh container-runtime
-    
-    [Install]
-    WantedBy=multi-user.target
-    
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-    {
-      "default-runtime": "docker-runc",
-      "runtimes": {
-        "docker-runc": {
-          "path": "/opt/bin/docker-runc"
-        }
-      },
-      "storage-driver": "overlay2",
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "10m",
-        "max-file": "2"
-      }
-    }
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-    [Unit]
-    Description=Docker Application Container Engine
-    Documentation=https://docs.docker.com
-    After=network-online.target
-    Wants=network-online.target
-    
-    [Service]
-    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-    Type=notify
-    # the default is not to use systemd for cgroups because the delegate issues still
-    # exists and systemd currently does not support the cgroup feature set required
-    # for containers run by docker
-    ExecStart=/opt/bin/dockerd
-    ExecReload=/bin/kill -s HUP $MAINPID
-    LimitNOFILE=1048576
-    # Having non-zero Limit*s causes performance problems due to accounting overhead
-    # in the kernel. We recommend using cgroups to do container-local accounting.
-    LimitNPROC=infinity
-    LimitCORE=infinity
-    # Uncomment TasksMax if your systemd version supports it.
-    # Only systemd 226 and above support this version.
-    
-    TasksMax=infinity
-    
-    TimeoutStartSec=0
-    # set delegate yes so that systemd does not reset the cgroups of docker containers
-    Delegate=yes
-    # kill only the docker process, not all processes in the cgroup
-    KillMode=process
-    # restart the docker process if it exits prematurely
-    Restart=on-failure
-    StartLimitBurst=3
-    StartLimitInterval=60s
-    
-    [Install]
-    WantedBy=multi-user.target
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/userdata.go
+++ b/pkg/userdata/ubuntu/userdata.go
@@ -95,28 +95,35 @@ func (p Provider) UserData(
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
+	baseProvisioningScript, err := GetBaseProvisioningScript(cpName, kubeletVersion)
+	if err != nil {
+		return "", fmt.Errorf("error generating base provisioning script: %v", err)
+	}
+
 	data := struct {
-		MachineSpec      clusterv1alpha1.MachineSpec
-		ProviderConfig   *providerconfig.Config
-		OSConfig         *Config
-		CloudProvider    string
-		CloudConfig      string
-		ClusterDNSIPs    []net.IP
-		ServerAddr       string
-		KubeletVersion   string
-		Kubeconfig       string
-		KubernetesCACert string
+		MachineSpec            clusterv1alpha1.MachineSpec
+		ProviderConfig         *providerconfig.Config
+		OSConfig               *Config
+		CloudProvider          string
+		CloudConfig            string
+		ClusterDNSIPs          []net.IP
+		ServerAddr             string
+		KubeletVersion         string
+		Kubeconfig             string
+		KubernetesCACert       string
+		BaseProvisioningScript string
 	}{
-		MachineSpec:      spec,
-		ProviderConfig:   pconfig,
-		OSConfig:         osConfig,
-		CloudProvider:    cpName,
-		CloudConfig:      cpConfig,
-		ClusterDNSIPs:    clusterDNSIPs,
-		ServerAddr:       serverAddr,
-		KubeletVersion:   kubeletVersion.String(),
-		Kubeconfig:       kubeconfigString,
-		KubernetesCACert: kubernetesCACert,
+		MachineSpec:            spec,
+		ProviderConfig:         pconfig,
+		OSConfig:               osConfig,
+		CloudProvider:          cpName,
+		CloudConfig:            cpConfig,
+		ClusterDNSIPs:          clusterDNSIPs,
+		ServerAddr:             serverAddr,
+		KubeletVersion:         kubeletVersion.String(),
+		Kubeconfig:             kubeconfigString,
+		KubernetesCACert:       kubernetesCACert,
+		BaseProvisioningScript: baseProvisioningScript,
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -141,128 +148,18 @@ ssh_authorized_keys:
 {{- end }}
 
 write_files:
-- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+
+- path: "/opt/bin/base-provisioning.sh"
+  permissions: "0755"
   content: |
-{{ journalDConfig | indent 4 }}
-
-- path: "/etc/modules-load.d/k8s.conf"
-  content: |
-{{ kernelModules | indent 4 }}
-
-- path: "/etc/sysctl.d/k8s.conf"
-  content: |
-{{ kernelSettings | indent 4 }}
-
-- path: "/etc/apt/sources.list.d/docker.list"
-  permissions: "0644"
-  content: deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable
-
-- path: "/opt/docker.asc"
-  permissions: "0400"
-  content: |
-    -----BEGIN PGP PUBLIC KEY BLOCK-----
-
-    mQINBFit2ioBEADhWpZ8/wvZ6hUTiXOwQHXMAlaFHcPH9hAtr4F1y2+OYdbtMuth
-    lqqwp028AqyY+PRfVMtSYMbjuQuu5byyKR01BbqYhuS3jtqQmljZ/bJvXqnmiVXh
-    38UuLa+z077PxyxQhu5BbqntTPQMfiyqEiU+BKbq2WmANUKQf+1AmZY/IruOXbnq
-    L4C1+gJ8vfmXQt99npCaxEjaNRVYfOS8QcixNzHUYnb6emjlANyEVlZzeqo7XKl7
-    UrwV5inawTSzWNvtjEjj4nJL8NsLwscpLPQUhTQ+7BbQXAwAmeHCUTQIvvWXqw0N
-    cmhh4HgeQscQHYgOJjjDVfoY5MucvglbIgCqfzAHW9jxmRL4qbMZj+b1XoePEtht
-    ku4bIQN1X5P07fNWzlgaRL5Z4POXDDZTlIQ/El58j9kp4bnWRCJW0lya+f8ocodo
-    vZZ+Doi+fy4D5ZGrL4XEcIQP/Lv5uFyf+kQtl/94VFYVJOleAv8W92KdgDkhTcTD
-    G7c0tIkVEKNUq48b3aQ64NOZQW7fVjfoKwEZdOqPE72Pa45jrZzvUFxSpdiNk2tZ
-    XYukHjlxxEgBdC/J3cMMNRE1F4NCA3ApfV1Y7/hTeOnmDuDYwr9/obA8t016Yljj
-    q5rdkywPf4JF8mXUW5eCN1vAFHxeg9ZWemhBtQmGxXnw9M+z6hWwc6ahmwARAQAB
-    tCtEb2NrZXIgUmVsZWFzZSAoQ0UgZGViKSA8ZG9ja2VyQGRvY2tlci5jb20+iQI3
-    BBMBCgAhBQJYrefAAhsvBQsJCAcDBRUKCQgLBRYCAwEAAh4BAheAAAoJEI2BgDwO
-    v82IsskP/iQZo68flDQmNvn8X5XTd6RRaUH33kXYXquT6NkHJciS7E2gTJmqvMqd
-    tI4mNYHCSEYxI5qrcYV5YqX9P6+Ko+vozo4nseUQLPH/ATQ4qL0Zok+1jkag3Lgk
-    jonyUf9bwtWxFp05HC3GMHPhhcUSexCxQLQvnFWXD2sWLKivHp2fT8QbRGeZ+d3m
-    6fqcd5Fu7pxsqm0EUDK5NL+nPIgYhN+auTrhgzhK1CShfGccM/wfRlei9Utz6p9P
-    XRKIlWnXtT4qNGZNTN0tR+NLG/6Bqd8OYBaFAUcue/w1VW6JQ2VGYZHnZu9S8LMc
-    FYBa5Ig9PxwGQOgq6RDKDbV+PqTQT5EFMeR1mrjckk4DQJjbxeMZbiNMG5kGECA8
-    g383P3elhn03WGbEEa4MNc3Z4+7c236QI3xWJfNPdUbXRaAwhy/6rTSFbzwKB0Jm
-    ebwzQfwjQY6f55MiI/RqDCyuPj3r3jyVRkK86pQKBAJwFHyqj9KaKXMZjfVnowLh
-    9svIGfNbGHpucATqREvUHuQbNnqkCx8VVhtYkhDb9fEP2xBu5VvHbR+3nfVhMut5
-    G34Ct5RS7Jt6LIfFdtcn8CaSas/l1HbiGeRgc70X/9aYx/V/CEJv0lIe8gP6uDoW
-    FPIZ7d6vH+Vro6xuWEGiuMaiznap2KhZmpkgfupyFmplh0s6knymuQINBFit2ioB
-    EADneL9S9m4vhU3blaRjVUUyJ7b/qTjcSylvCH5XUE6R2k+ckEZjfAMZPLpO+/tF
-    M2JIJMD4SifKuS3xck9KtZGCufGmcwiLQRzeHF7vJUKrLD5RTkNi23ydvWZgPjtx
-    Q+DTT1Zcn7BrQFY6FgnRoUVIxwtdw1bMY/89rsFgS5wwuMESd3Q2RYgb7EOFOpnu
-    w6da7WakWf4IhnF5nsNYGDVaIHzpiqCl+uTbf1epCjrOlIzkZ3Z3Yk5CM/TiFzPk
-    z2lLz89cpD8U+NtCsfagWWfjd2U3jDapgH+7nQnCEWpROtzaKHG6lA3pXdix5zG8
-    eRc6/0IbUSWvfjKxLLPfNeCS2pCL3IeEI5nothEEYdQH6szpLog79xB9dVnJyKJb
-    VfxXnseoYqVrRz2VVbUI5Blwm6B40E3eGVfUQWiux54DspyVMMk41Mx7QJ3iynIa
-    1N4ZAqVMAEruyXTRTxc9XW0tYhDMA/1GYvz0EmFpm8LzTHA6sFVtPm/ZlNCX6P1X
-    zJwrv7DSQKD6GGlBQUX+OeEJ8tTkkf8QTJSPUdh8P8YxDFS5EOGAvhhpMBYD42kQ
-    pqXjEC+XcycTvGI7impgv9PDY1RCC1zkBjKPa120rNhv/hkVk/YhuGoajoHyy4h7
-    ZQopdcMtpN2dgmhEegny9JCSwxfQmQ0zK0g7m6SHiKMwjwARAQABiQQ+BBgBCAAJ
-    BQJYrdoqAhsCAikJEI2BgDwOv82IwV0gBBkBCAAGBQJYrdoqAAoJEH6gqcPyc/zY
-    1WAP/2wJ+R0gE6qsce3rjaIz58PJmc8goKrir5hnElWhPgbq7cYIsW5qiFyLhkdp
-    YcMmhD9mRiPpQn6Ya2w3e3B8zfIVKipbMBnke/ytZ9M7qHmDCcjoiSmwEXN3wKYI
-    mD9VHONsl/CG1rU9Isw1jtB5g1YxuBA7M/m36XN6x2u+NtNMDB9P56yc4gfsZVES
-    KA9v+yY2/l45L8d/WUkUi0YXomn6hyBGI7JrBLq0CX37GEYP6O9rrKipfz73XfO7
-    JIGzOKZlljb/D9RX/g7nRbCn+3EtH7xnk+TK/50euEKw8SMUg147sJTcpQmv6UzZ
-    cM4JgL0HbHVCojV4C/plELwMddALOFeYQzTif6sMRPf+3DSj8frbInjChC3yOLy0
-    6br92KFom17EIj2CAcoeq7UPhi2oouYBwPxh5ytdehJkoo+sN7RIWua6P2WSmon5
-    U888cSylXC0+ADFdgLX9K2zrDVYUG1vo8CX0vzxFBaHwN6Px26fhIT1/hYUHQR1z
-    VfNDcyQmXqkOnZvvoMfz/Q0s9BhFJ/zU6AgQbIZE/hm1spsfgvtsD1frZfygXJ9f
-    irP+MSAI80xHSf91qSRZOj4Pl3ZJNbq4yYxv0b1pkMqeGdjdCYhLU+LZ4wbQmpCk
-    SVe2prlLureigXtmZfkqevRz7FrIZiu9ky8wnCAPwC7/zmS18rgP/17bOtL4/iIz
-    QhxAAoAMWVrGyJivSkjhSGx1uCojsWfsTAm11P7jsruIL61ZzMUVE2aM3Pmj5G+W
-    9AcZ58Em+1WsVnAXdUR//bMmhyr8wL/G1YO1V3JEJTRdxsSxdYa4deGBBY/Adpsw
-    24jxhOJR+lsJpqIUeb999+R8euDhRHG9eFO7DRu6weatUJ6suupoDTRWtr/4yGqe
-    dKxV3qQhNLSnaAzqW/1nA3iUB4k7kCaKZxhdhDbClf9P37qaRW467BLCVO/coL3y
-    Vm50dwdrNtKpMBh3ZpbB1uJvgi9mXtyBOMJ3v8RZeDzFiG8HdCtg9RvIt/AIFoHR
-    H3S+U79NT6i0KPzLImDfs8T7RlpyuMc4Ufs8ggyg9v3Ae6cN3eQyxcK3w0cbBwsh
-    /nQNfsA6uu+9H7NhbehBMhYnpNZyrHzCmzyXkauwRAqoCbGCNykTRwsur9gS41TQ
-    M8ssD1jFheOJf3hODnkKU+HKjvMROl1DK7zdmLdNzA1cvtZH/nCC9KPj1z8QC47S
-    xx+dTZSx4ONAhwbS/LN3PoKtn8LPjY9NP9uDWI+TWYquS2U+KHDrBDlsgozDbs/O
-    jCxcpDzNmXpWQHEtHU7649OXHP7UeNST1mCUCH5qdank0V1iejF6/CfTFU4MfcrG
-    YT90qFF93M3v01BbxP+EIY2/9tiIPbrd
-    =0YYh
-    -----END PGP PUBLIC KEY BLOCK-----
+{{ .BaseProvisioningScript | indent 4 }}
 
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
-    systemctl restart systemd-modules-load.service
-    sysctl --system
-
-    apt-key add /opt/docker.asc
-    apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
-    swapoff -a
-
-    DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
-      curl \
-      ca-certificates \
-      ceph-common \
-      cifs-utils \
-      conntrack \
-      e2fsprogs \
-      ebtables \
-      ethtool \
-      glusterfs-client \
-      iptables \
-      jq \
-      kmod \
-      openssh-client \
-      nfs-common \
-      socat \
-      util-linux \
-      bridge-utils \
-      libapparmor1 \
-      libltdl7 \
-      perl \
-      ipvsadm{{ if eq .CloudProvider "vsphere" }} \
-      open-vm-tools{{ end }}
+    /opt/bin/base-provisioning.sh
 
     {{- if .OSConfig.DistUpgradeOnBoot }}
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade -y
@@ -271,7 +168,6 @@ write_files:
       reboot
     fi
 
-{{ downloadBinariesScript .KubeletVersion true | indent 4 }}
 {{ startAllUnits | indent 4 }}
 
 - path: "/opt/bin/supervise.sh"
@@ -318,31 +214,6 @@ write_files:
     Type=oneshot
     RemainAfterExit=true
     ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-- path: "/etc/profile.d/opt-bin-path.sh"
-  permissions: "0644"
-  content: |
-    export PATH="/opt/bin:$PATH"
-
-- path: /etc/systemd/system/kubelet-healthcheck.service
-  permissions: "0644"
-  content: |
-{{ kubeletHealthCheckSystemdUnit | indent 4 }}
-
-- path: /etc/systemd/system/docker-healthcheck.service
-  permissions: "0644"
-  content: |
-{{ containerRuntimeHealthCheckSystemdUnit | indent 4 }}
-
-- path: /etc/docker/daemon.json
-  permissions: "0644"
-  content: |
-{{ dockerDaemonConfig | indent 4 }}
-
-- path: /etc/systemd/system/docker.service
-  permissions: "0644"
-  content: |
-{{ dockerSystemdUnit true | indent 4 }}
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/userdata.go
+++ b/pkg/userdata/ubuntu/userdata.go
@@ -95,7 +95,7 @@ func (p Provider) UserData(
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
-	baseProvisioningScript, err := GetBaseProvisioningScript(cpName, kubeletVersion)
+	baseProvisioningScript, err := GetBaseProvisioningScript(cpName, kubeletVersion.String())
 	if err != nil {
 		return "", fmt.Errorf("error generating base provisioning script: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This moves the general Ubuntu provisioning into a dedicated script.
It allows reuse of the provisioning either by using cloud-init or by using SSH.

```release-note
NONE
```
