### PR TITLE
Make ValidateMachineDeployment public

### DIFF
--- a/pkg/admission/machinedeployments.go
+++ b/pkg/admission/machinedeployments.go
@@ -19,7 +19,7 @@ func (ad *admissionData) mutateMachineDeployments(ar admissionv1beta1.AdmissionR
 	machineDeploymentOriginal := machineDeployment.DeepCopy()
 
 	machineDeploymentDefaultingFunction(&machineDeployment)
-	if errs := validateMachineDeployment(machineDeployment); len(errs) > 0 {
+	if errs := ValidateMachineDeployment(machineDeployment); len(errs) > 0 {
 		return nil, fmt.Errorf("validation failed: %v", errs)
 	}
 

--- a/pkg/admission/machinedeployments_validation.go
+++ b/pkg/admission/machinedeployments_validation.go
@@ -1,18 +1,20 @@
 package admission
 
 import (
+	"log"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"log"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/common"
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-func validateMachineDeployment(md v1alpha1.MachineDeployment) field.ErrorList {
+// ValidateMachineDeployment validates the given MachineDeployment object by checking for logical or syntax errors
+func ValidateMachineDeployment(md v1alpha1.MachineDeployment) field.ErrorList {
 	log.Printf("Validating fields for MachineDeployment %s\n", md.Name)
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateMachineDeploymentSpec(&md.Spec, field.NewPath("spec"))...)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the ValidateMachineDeployment public, so it can be used in other projects when importing the cluster API objects from the machine controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
NONE
```
