### PR TITLE
Fix MachineDeployment defaulting

### DIFF
--- a/pkg/admission/machinedeployments_test.go
+++ b/pkg/admission/machinedeployments_test.go
@@ -15,12 +15,12 @@ func TestMachineDeploymentDefaulting(t *testing.T) {
 		isValid           bool
 	}{
 		{
-			name:              "empty MachineDeployment validation should fail",
+			name:              "Empty MachineDeployment validation should fail",
 			machineDeployment: &clusterv1alpha1.MachineDeployment{},
 			isValid:           false,
 		},
 		{
-			name: "minimal MachineDeployment validation should suceed",
+			name: "Minimal MachineDeployment validation should succeed",
 			machineDeployment: &clusterv1alpha1.MachineDeployment{
 				Spec: clusterv1alpha1.MachineDeploymentSpec{
 					Selector: metav1.LabelSelector{

--- a/pkg/admission/machinedeployments_test.go
+++ b/pkg/admission/machinedeployments_test.go
@@ -1,0 +1,49 @@
+package admission
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	clusterv1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+)
+
+func TestMachineDeploymentDefaulting(t *testing.T) {
+	tests := []struct {
+		name              string
+		machineDeployment *clusterv1alpha1.MachineDeployment
+		isValid           bool
+	}{
+		{
+			name:              "empty MachineDeployment validation should fail",
+			machineDeployment: &clusterv1alpha1.MachineDeployment{},
+			isValid:           false,
+		},
+		{
+			name: "minimal MachineDeployment validation should suceed",
+			machineDeployment: &clusterv1alpha1.MachineDeployment{
+				Spec: clusterv1alpha1.MachineDeploymentSpec{
+					Selector: metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+					Template: clusterv1alpha1.MachineTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"foo": "bar"},
+						},
+					},
+				},
+			},
+			isValid: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			machineDeploymentDefaultingFunction(test.machineDeployment)
+			errs := validateMachineDeployment(*test.machineDeployment)
+			if test.isValid != (len(errs) == 0) {
+				t.Errorf("Expected machine to be valid: %t but got %d errors: %v", test.isValid, len(errs), errs)
+			}
+		})
+	}
+}

--- a/pkg/admission/machinedeployments_validation.go
+++ b/pkg/admission/machinedeployments_validation.go
@@ -109,6 +109,10 @@ func machineDeploymentDefaultingFunction(obj *v1alpha1.MachineDeployment) {
 		obj.Spec.ProgressDeadlineSeconds = new(int32)
 		*obj.Spec.ProgressDeadlineSeconds = 600
 	}
+	if obj.Spec.Strategy == nil {
+		obj.Spec.Strategy = &v1alpha1.MachineDeploymentStrategy{}
+	}
+
 	if obj.Spec.Strategy.Type == "" {
 		obj.Spec.Strategy.Type = common.RollingUpdateMachineDeploymentStrategyType
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Upstream by now has defaulting for this, once #416 is done I will change the Webhook to use the defaulting from upstream and add the tests to upstream.

```release-note
none
```


/assign @mrIncompetent 