### PR TITLE
Set a terminal error if AMI terms were not accepted

### DIFF
--- a/hack/ci-e2e-test.sh
+++ b/hack/ci-e2e-test.sh
@@ -49,7 +49,7 @@ for try in {1..20}; do
   set +e
   # Create environment at cloud provider
   echo "Creating environment at cloud provider."
-  terraform import hcloud_ssh_key.default 265119
+  terraform import hcloud_ssh_key.default 355488
   terraform apply -auto-approve
   TF_RC=$?
   if [[ $TF_RC == 0 ]]; then break; fi

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -732,6 +732,12 @@ func awsErrorToTerminalError(err error, msg string) error {
 				Reason:  common.InvalidConfigurationMachineError,
 				Message: "A request has been rejected due to invalid credentials which were taken from the MachineSpec",
 			}
+		case "OptInRequired":
+			// User has to accept the terms of the AMI
+			return cloudprovidererrors.TerminalError{
+				Reason:  "AMI terms not accepted",
+				Message: err.Error(),
+			}
 		default:
 			return prepareAndReturnError()
 		}


### PR DESCRIPTION
Fixes #358

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
A terminal error will be set if an AMI is used whose terms were not accepted
```

/assign @mrIncompetent 

Result looks like this:

```
$ k get machine machinedeployment-kubermatic-rxhxx5tprc-xntcw-78ddbf7d89-plf9f -o json|jq '.status'
{
  "errorMessage": "An error of type = AMI terms not accepted, with message = OptInRequired: In order to use this AWS Marketplace product you need to accept terms and subscribe. To do so please visit https://aws.amazon.com/marketplace/pp?sku=aw0evgkw8e5c1q413zgy5pjce\n\tstatus code: 401, request id: 745ccd24-7b18-4e40-9f9e-f3476e2e3135 occurred. Unable to create a machine.",
  "errorReason": "CreateError"
}
```