### PR TITLE
Fix CVE-2019-573 for Ubuntu and CoreOS

### DIFF
--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
@@ -240,13 +240,6 @@ storage:
           sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-
 
 
     - path: /etc/hostname

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
@@ -240,13 +240,6 @@ storage:
           sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-
 
 
     - path: /etc/hostname

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
@@ -261,13 +261,6 @@ storage:
           sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-
 
 
     - path: /etc/hostname

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
@@ -244,13 +244,6 @@ storage:
           sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-
 
 
 

--- a/pkg/userdata/coreos/userdata.go
+++ b/pkg/userdata/coreos/userdata.go
@@ -292,15 +292,6 @@ storage:
         inline: |
 {{ .KubernetesCACert | indent 10 }}
 
-{{- if semverCompare "<=1.11.*" .KubeletVersion }}
-    - path: /etc/coreos/docker-1.12
-      mode: 0644
-      filesystem: root
-      contents:
-        inline: |
-          yes
-{{ end }}
-
 {{ if ne .CloudProvider "aws" }}
     - path: /etc/hostname
       filesystem: root

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
@@ -123,7 +123,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/openstack.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker-ce=18.06.0~ce~3-0~ubuntu'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/testdata/vsphere.golden
+++ b/pkg/userdata/ubuntu/testdata/vsphere.golden
@@ -121,7 +121,8 @@ write_files:
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
     systemctl mask swap.target
     swapoff -a
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
+
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \

--- a/pkg/userdata/ubuntu/userdata.go
+++ b/pkg/userdata/ubuntu/userdata.go
@@ -240,11 +240,7 @@ write_files:
     systemctl mask swap.target
     swapoff -a
 
-{{- if semverCompare "<1.12.0" .KubeletVersion }}
-    export CR_PKG='docker.io=17.12.1-0ubuntu1'
-{{- else }}
-    export CR_PKG='docker-ce=18.06.0~ce~3-0~ubuntu'
-{{- end }}
+    export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes  CVE-2019-573 for Ubuntu and CoreOS. For CentOS there is no updates package available yet

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
