### PR TITLE
add a cmdline flag to enable profiling

### DIFF
--- a/hack/run-machine-controller.sh
+++ b/hack/run-machine-controller.sh
@@ -9,4 +9,5 @@ $(dirname $0)/../machine-controller \
   -logtostderr \
   -v=6 \
   -cluster-dns=172.16.0.10 \
+  -enable-profiling \
   -internal-listen-address=0.0.0.0:8085


### PR DESCRIPTION
**What this PR does / why we need it**:
Profiling and debugging issues with machine-controller, e.g. orphaned goroutines in #447

```release-note
NONE
```
