### PR TITLE
Configure a five minute resync period for upstream controllers

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -379,7 +379,8 @@ func startControllerViaLeaderElection(runOptions controllerRunOptions) error {
 			return
 		}
 
-		mgr, err := manager.New(runOptions.cfg, manager.Options{})
+		mgrSyncPeriod := 5 * time.Minute
+		mgr, err := manager.New(runOptions.cfg, manager.Options{SyncPeriod: &mgrSyncPeriod})
 		if err != nil {
 			glog.Errorf("failed to start kubebuilder manager: %v", err)
 			runOptions.parentCtxDone()


### PR DESCRIPTION
This is made to ensure that the status of MachineDeployments and
MachineSets converges in less than 10 hours.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
Periodically reconcile MachineDeployments and MachineSets
```

/assign @mrIncompetent 

CC @xrstf 