### PR TITLE
Use docker repo for centOS

### DIFF
--- a/cmd/provision/README.md
+++ b/cmd/provision/README.md
@@ -62,7 +62,7 @@ The following steps belong into the base provisioning:
 #### Join
 
 This part will:
-- Write & start the kubelet systemd unit 
+- Write & start the kubelet systemd unit
 
 ## Offline usage
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
@@ -57,7 +57,13 @@ write_files:
 
     
 
-    yum install -y docker-1.13.1 \
+    yum install -y yum-utils
+    yum-config-manager --add-repo \
+      https://download.docker.com/linux/centos/docker-ce.repo
+
+    yum install -y docker-ce \
+      docker-ce-cli \
+      containerd.io \
       ebtables \
       ethtool \
       nfs-utils \
@@ -149,7 +155,7 @@ write_files:
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |
     [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
+    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=cgroupfs"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
@@ -57,7 +57,13 @@ write_files:
 
     
 
-    yum install -y docker-1.13.1 \
+    yum install -y yum-utils
+    yum-config-manager --add-repo \
+      https://download.docker.com/linux/centos/docker-ce.repo
+
+    yum install -y docker-ce \
+      docker-ce-cli \
+      containerd.io \
       ebtables \
       ethtool \
       nfs-utils \
@@ -148,7 +154,7 @@ write_files:
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |
     [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
+    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=cgroupfs"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
@@ -64,7 +64,13 @@ write_files:
     hostnamectl set-hostname node1
     
 
-    yum install -y docker-1.13.1 \
+    yum install -y yum-utils
+    yum-config-manager --add-repo \
+      https://download.docker.com/linux/centos/docker-ce.repo
+
+    yum install -y docker-ce \
+      docker-ce-cli \
+      containerd.io \
       ebtables \
       ethtool \
       nfs-utils \
@@ -159,7 +165,7 @@ write_files:
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |
     [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
+    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=cgroupfs"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
@@ -57,7 +57,13 @@ write_files:
 
     
 
-    yum install -y docker-1.13.1 \
+    yum install -y yum-utils
+    yum-config-manager --add-repo \
+      https://download.docker.com/linux/centos/docker-ce.repo
+
+    yum install -y docker-ce \
+      docker-ce-cli \
+      containerd.io \
       ebtables \
       ethtool \
       nfs-utils \
@@ -149,7 +155,7 @@ write_files:
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |
     [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
+    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=cgroupfs"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/userdata.go
+++ b/pkg/userdata/centos/userdata.go
@@ -190,7 +190,13 @@ write_files:
     hostnamectl set-hostname {{ .MachineSpec.Name }}
     {{ end }}
 
-    yum install -y docker-1.13.1 \
+    yum install -y yum-utils
+    yum-config-manager --add-repo \
+      https://download.docker.com/linux/centos/docker-ce.repo
+
+    yum install -y docker-ce \
+      docker-ce-cli \
+      containerd.io \
       ebtables \
       ethtool \
       nfs-utils \
@@ -228,7 +234,7 @@ write_files:
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |
     [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
+    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=cgroupfs"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |


### PR DESCRIPTION
**What this PR does / why we need it**:
The provision path for centOS installs docker in version 1.13.1 (w/ backports). This PR changes the installation source to the docker repository.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #460

**Special notes for your reviewer**:

```release-note
```
