### PR TITLE
e2e tests: respect local KUBECONFIG env before using hardcoded path

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ locally, the following steps are required:
 * Run `make e2e-cluster` to get a simple kubeadm cluster on Hetzner
 * Run `hack/run-machine-controller.sh` to locally run the machine-controller for your freshly created cluster
 
+If you want to use an existing cluster to test against, you can simply set the `KUBECONFIG` environment variable.
+In this case, first make sure that a kubeconfig created by `make e2e-cluster` at `$(go env GOPATH)/src/github.com/kubermatic/machine-controller/.kubeconfig`
+doesn't exist, since the tests will default to this hardcoded path and only use the env var as fallback.
+
 Now you can either
 
 * Run the tests for all providers via

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -110,10 +110,13 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 	// only used by OpenStack scenarios
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< OS_IMAGE >>=%s", openStackImages[testCase.osName]))
 
-	gopath := os.Getenv("GOPATH")
-	projectDir := filepath.Join(gopath, "src/github.com/kubermatic/machine-controller")
+	kubeConfig := os.Getenv("KUBECONFIG")
+	if kubeConfig == "" {
+		gopath := os.Getenv("GOPATH")
+		projectDir := filepath.Join(gopath, "src/github.com/kubermatic/machine-controller")
 
-	kubeConfig := filepath.Join(projectDir, ".kubeconfig")
+		kubeConfig = filepath.Join(projectDir, ".kubeconfig")
+	}
 
 	// the golang test runtime waits for individual subtests to complete before reporting the status.
 	// if one of them is blocking/waiting and the global timeout is reached the status will not be reported/visible.


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows easily running the tests against any environment when running them locally. Previously, the hardcoded path required copying/linking the kubeconfig to `$(go env GOPATH)/src/github.com/kubermatic/machine-controller/.kubeconfig`

```release-note
NONE
```