### PR TITLE
Support for network configuration of GCE instances

### DIFF
--- a/examples/gce-machinedeployment.yaml
+++ b/examples/gce-machinedeployment.yaml
@@ -49,7 +49,8 @@ spec:
             machineType: "n1-standard-2"
             # In GB
             diskSize: 50
-            # ether of two network/subnetwork could be specified
+            # The name or self_link of the network and subnetwork to attach this interface to;
+            # either of both can be provided, otherwise default network will taken
             # in case if both empty — default network will be used
             network: "my-cool-network"
             subnetwork: "my-cool-subnetwork"

--- a/examples/gce-machinedeployment.yaml
+++ b/examples/gce-machinedeployment.yaml
@@ -49,6 +49,10 @@ spec:
             machineType: "n1-standard-2"
             # In GB
             diskSize: 50
+            # ether of two network/subnetwork could be specified
+            # in case if both empty — default network will be used
+            network: "my-cool-network"
+            subnetwork: "my-cool-subnetwork"
             # Can be 'pd-standard' or 'pd-ssd'
             diskType: "pd-standard"
             labels:

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -167,7 +167,7 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 
 	cfg.subnetwork, err = resolver.GetConfigVarStringValue(cpSpec.Subnetwork)
 	if err != nil {
-		return nil, fmt.Errorf("cannot retrieve network: %v", err)
+		return nil, fmt.Errorf("cannot retrieve subnetwork: %v", err)
 	}
 
 	return cfg, nil

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -133,6 +133,8 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 		providerConfig: providerConfig,
 		labels:         cpSpec.Labels,
 		diskSize:       cpSpec.DiskSize,
+		network:        cpSpec.Network.Value,
+		subnetwork:     cpSpec.Subnetwork.Value,
 	}
 
 	cfg.serviceAccount, err = resolver.GetConfigVarStringValueOrEnv(cpSpec.ServiceAccount, envGoogleServiceAccount)

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -133,8 +133,6 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 		providerConfig: providerConfig,
 		labels:         cpSpec.Labels,
 		diskSize:       cpSpec.DiskSize,
-		network:        cpSpec.Network.Value,
-		subnetwork:     cpSpec.Subnetwork.Value,
 	}
 
 	cfg.serviceAccount, err = resolver.GetConfigVarStringValueOrEnv(cpSpec.ServiceAccount, envGoogleServiceAccount)
@@ -160,6 +158,16 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 	cfg.diskType, err = resolver.GetConfigVarStringValue(cpSpec.DiskType)
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve disk type: %v", err)
+	}
+
+	cfg.network, err = resolver.GetConfigVarStringValue(cpSpec.Network)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve network: %v", err)
+	}
+
+	cfg.subnetwork, err = resolver.GetConfigVarStringValue(cpSpec.Subnetwork)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve network: %v", err)
 	}
 
 	return cfg, nil

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -56,6 +56,8 @@ type cloudProviderSpec struct {
 	MachineType    providerconfig.ConfigVarString `json:"machineType"`
 	DiskSize       int64                          `json:"diskSize"`
 	DiskType       providerconfig.ConfigVarString `json:"diskType"`
+	Network        providerconfig.ConfigVarString `json:"network"`
+	Subnetwork     providerconfig.ConfigVarString `json:"subnetwork"`
 	Labels         map[string]string              `json:"labels"`
 }
 
@@ -111,6 +113,8 @@ type config struct {
 	machineType    string
 	diskSize       int64
 	diskType       string
+	network        string
+	subnetwork     string
 	labels         map[string]string
 	jwtConfig      *jwt.Config
 	providerConfig *providerconfig.Config
@@ -123,32 +127,39 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 	if err != nil {
 		return nil, err
 	}
+
 	// Setup configuration.
 	cfg := &config{
 		providerConfig: providerConfig,
+		labels:         cpSpec.Labels,
+		diskSize:       cpSpec.DiskSize,
 	}
+
 	cfg.serviceAccount, err = resolver.GetConfigVarStringValueOrEnv(cpSpec.ServiceAccount, envGoogleServiceAccount)
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve service account: %v", err)
 	}
+
 	err = cfg.postprocessServiceAccount()
 	if err != nil {
 		return nil, fmt.Errorf("cannot prepare JWT: %v", err)
 	}
+
 	cfg.zone, err = resolver.GetConfigVarStringValue(cpSpec.Zone)
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve zone: %v", err)
 	}
+
 	cfg.machineType, err = resolver.GetConfigVarStringValue(cpSpec.MachineType)
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve machine type: %v", err)
 	}
-	cfg.diskSize = cpSpec.DiskSize
+
 	cfg.diskType, err = resolver.GetConfigVarStringValue(cpSpec.DiskType)
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve disk type: %v", err)
 	}
-	cfg.labels = cpSpec.Labels
+
 	return cfg, nil
 }
 

--- a/pkg/cloudprovider/provider/gce/service.go
+++ b/pkg/cloudprovider/provider/gce/service.go
@@ -24,6 +24,10 @@ const (
 	statusDone = "DONE"
 )
 
+const (
+	defaultNetwork = "global/networks/default"
+)
+
 // service wraps a GCE compute service for the extension with helper methods.
 type service struct {
 	*compute.Service
@@ -40,6 +44,12 @@ func connectComputeService(cfg *config) (*service, error) {
 
 // networkInterfaces returns the configured network interfaces for an instance creation.
 func (svc *service) networkInterfaces(cfg *config) ([]*compute.NetworkInterface, error) {
+	network := cfg.network
+
+	if cfg.network == "" && cfg.subnetwork == "" {
+		network = defaultNetwork
+	}
+
 	ifc := &compute.NetworkInterface{
 		AccessConfigs: []*compute.AccessConfig{
 			{
@@ -47,8 +57,10 @@ func (svc *service) networkInterfaces(cfg *config) ([]*compute.NetworkInterface,
 				Type: "ONE_TO_ONE_NAT",
 			},
 		},
-		Network: "global/networks/default",
+		Network:    network,
+		Subnetwork: cfg.subnetwork,
 	}
+
 	return []*compute.NetworkInterface{ifc}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to better support network placement of nodes

```release-note
GCE network placement controls
```
