### PR TITLE
Allow using a serviceAccount token instead of bootstrap tokens

### DIFF
--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -39,6 +39,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -98,6 +99,8 @@ type Controller struct {
 	externalCloudProvider bool
 
 	name string
+
+	bootstrapTokenServiceAccountName *types.NamespacedName
 }
 
 type KubeconfigProvider interface {
@@ -127,7 +130,8 @@ func NewMachineController(
 	kubeconfigProvider KubeconfigProvider,
 	joinClusterTimeout *time.Duration,
 	externalCloudProvider bool,
-	name string) (*Controller, error) {
+	name string,
+	bootstrapTokenServiceAccountName *types.NamespacedName) (*Controller, error) {
 
 	if err := machinescheme.AddToScheme(scheme.Scheme); err != nil {
 		return nil, err
@@ -160,6 +164,8 @@ func NewMachineController(
 		externalCloudProvider: externalCloudProvider,
 
 		name: name,
+
+		bootstrapTokenServiceAccountName: bootstrapTokenServiceAccountName,
 	}
 
 	controller.machineCreateDeleteData = &cloud.MachineCreateDeleteData{

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -182,6 +182,20 @@ func NewMachineController(
 			if newNode.ResourceVersion == oldNode.ResourceVersion {
 				return
 			}
+			// Dont do anything if the ready condition hasnt changed
+			for _, newCondition := range newNode.Status.Conditions {
+				if newCondition.Type != corev1.NodeReady {
+					continue
+				}
+				for _, oldCondition := range oldNode.Status.Conditions {
+					if oldCondition.Type != corev1.NodeReady {
+						continue
+					}
+					if newCondition.Status == oldCondition.Status {
+						return
+					}
+				}
+			}
 			controller.handleObject(new)
 		},
 		DeleteFunc: controller.handleObject,


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows to use the token from a configured service account as bootstrap token instead of dynamically creating one

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
