### PR TITLE
Update cluster-api to add selective downscaling

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1445,7 +1445,7 @@
   source = "github.com/kubevirt/kubevirt"
 
 [[projects]]
-  digest = "1:97ead2d8bca2711f52800f463517a15aeb48f4fbbed40d34da4c8e2ce79716ce"
+  digest = "1:5e7f4fb79e95cd032d2e6f6f1042165dc2b78d7f0b5d52016773fbd0bc615201"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "pkg/apis",
@@ -1468,7 +1468,7 @@
     "pkg/util",
   ]
   pruneopts = "NUT"
-  revision = "813b1fec840d79b37fe86778237b6db6d1cb959d"
+  revision = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
 
 [[projects]]
   digest = "1:52e73ab64f1026315715c24fd05d9b9544a51e1007a3f48dc61937ad3a1a2c2b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,7 +114,7 @@ required = [
 
 [[constraint]]
   name = "sigs.k8s.io/cluster-api"
-  revision = "813b1fec840d79b37fe86778237b6db6d1cb959d"
+  revision = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
 
 [[constraint]]
   name = "gopkg.in/gcfg.v1"

--- a/pkg/apis/cluster/v1alpha1/conversions/conversions.go
+++ b/pkg/apis/cluster/v1alpha1/conversions/conversions.go
@@ -15,7 +15,7 @@ import (
 const (
 	TypeRevisionAnnotationName = "machine-controller/machine-type-revision"
 
-	TypeRevisionCurrentVersion = "813b1fec840d79b37fe86778237b6db6d1cb959d"
+	TypeRevisionCurrentVersion = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
 )
 
 func Convert_MachinesV1alpha1Machine_To_ClusterV1alpha1Machine(in *machinesv1alpha1.Machine, out *clusterv1alpha1.Machine) error {

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/aws.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: 813b1fec840d79b37fe86778237b6db6d1cb959d
+    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
   creationTimestamp: null
   finalizers:
   - machine-delete-finalizer

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/azure.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/azure.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: 813b1fec840d79b37fe86778237b6db6d1cb959d
+    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
   creationTimestamp: null
   name: azure
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/digitalocean.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/digitalocean.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: 813b1fec840d79b37fe86778237b6db6d1cb959d
+    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
   creationTimestamp: null
   name: digitalocean
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/hetzner.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/hetzner.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: 813b1fec840d79b37fe86778237b6db6d1cb959d
+    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
   creationTimestamp: null
   name: hetzner
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/linode.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/linode.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: 813b1fec840d79b37fe86778237b6db6d1cb959d
+    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
   creationTimestamp: null
   name: linode
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/openstack.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/openstack.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: 813b1fec840d79b37fe86778237b6db6d1cb959d
+    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
   creationTimestamp: null
   name: openstack
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/vsphere-static-ip.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/vsphere-static-ip.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: 813b1fec840d79b37fe86778237b6db6d1cb959d
+    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
   creationTimestamp: null
   name: vsphere-static-ip
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/vsphere.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/vsphere.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: 813b1fec840d79b37fe86778237b6db6d1cb959d
+    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
   creationTimestamp: null
   name: vsphere
   namespace: kube-system

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/common/consts.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/common/consts.go
@@ -51,6 +51,13 @@ const (
 	// Example: timeout trying to connect to GCE.
 	CreateMachineError MachineStatusError = "CreateError"
 
+	// There was an error while trying to update a Node that this
+	// Machine represents. This may indicate a transient problem that will be
+	// fixed automatically with time, such as a service outage,
+	//
+	// Example: error updating load balancers
+	UpdateMachineError MachineStatusError = "UpdateError"
+
 	// An error was encountered while trying to delete the Node that this
 	// Machine represents. This could be a transient or terminal error, but
 	// will only be observable if the provider's Machine controller has

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -38,6 +38,8 @@ const (
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
+// +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Machine status such as Terminating/Pending/Running/Failed etc"
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -57,9 +59,12 @@ type MachineSpec struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// Taints is the full, authoritative list of taints to apply to the corresponding
-	// Node. This list will overwrite any modifications made to the Node on
-	// an ongoing basis.
+	// The list of the taints to be applied to the corresponding Node in additive
+	// manner. This list will not overwrite any other taints added to the Node on
+	// an ongoing basis by other entities. These taints should be actively reconciled
+	// e.g. if you ask the machine controller to apply a taint and then manually remove
+	// the taint the machine controller will put it back) but not have the machine controller
+	// remove any taints
 	// +optional
 	Taints []corev1.Taint `json:"taints,omitempty"`
 
@@ -87,12 +92,12 @@ type MachineSpec struct {
 	// ProviderID is the identification ID of the machine provided by the provider.
 	// This field must match the provider ID as seen on the node object corresponding to this machine.
 	// This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
-	// with cluster-api as provider. Clean-up login in the autoscaler compares machines v/s nodes to find out
+	// with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
 	// machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
 	// generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
-	// able to have a provider view of the list of machines. Another list of nodes is queries from the k8s apiserver
-	// and then comparison is done to find out unregistered machines and are marked for delete.
-	// This field will be set by the actuators and consumed by higher level entities like autoscaler  who will
+	// able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+	// and then a comparison is done to find out unregistered machines and are marked for delete.
+	// This field will be set by the actuators and consumed by higher level entities like autoscaler that will
 	// be interfacing with cluster-api as generic provider.
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -58,6 +58,11 @@ type MachineSetSpec struct {
 	// +optional
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
 
+	// DeletePolicy defines the policy used to identify nodes to delete when downscaling.
+	// Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+	// +kubebuilder:validation:Enum=Random,Newest,Oldest
+	DeletePolicy string `json:"deletePolicy,omitempty"`
+
 	// Selector is a label query over machines that should match the replica count.
 	// Label keys and values that must match in order to be controlled by this MachineSet.
 	// It must match the machine template's labels.
@@ -69,6 +74,30 @@ type MachineSetSpec struct {
 	// +optional
 	Template MachineTemplateSpec `json:"template,omitempty"`
 }
+
+// MachineSetDeletePolicy defines how priority is assigned to nodes to delete when
+// downscaling a MachineSet. Defaults to "Random".
+type MachineSetDeletePolicy string
+
+const (
+	// RandomMachineSetDeletePolicy prioritizes both Machines that have the annotation
+	// "cluster.k8s.io/delete-machine=yes" and Machines that are unhealthy
+	// (Status.ErrorReason or Status.ErrorMessage are set to a non-empty value).
+	// Finally, it picks Machines at random to delete.
+	RandomMachineSetDeletePolicy MachineSetDeletePolicy = "Random"
+
+	// NewestMachineSetDeletePolicy prioritizes both Machines that have the annotation
+	// "cluster.k8s.io/delete-machine=yes" and Machines that are unhealthy
+	// (Status.ErrorReason or Status.ErrorMessage are set to a non-empty value).
+	// It then prioritizes the newest Machines for deletion based on the Machine's CreationTimestamp.
+	NewestMachineSetDeletePolicy MachineSetDeletePolicy = "Newest"
+
+	// OldestMachineSetDeletePolicy prioritizes both Machines that have the annotation
+	// "cluster.k8s.io/delete-machine=yes" and Machines that are unhealthy
+	// (Status.ErrorReason or Status.ErrorMessage are set to a non-empty value).
+	// It then prioritizes the oldest Machines for deletion based on the Machine's CreationTimestamp.
+	OldestMachineSetDeletePolicy MachineSetDeletePolicy = "Oldest"
+)
 
 /// [MachineSetSpec] // doxygen marker
 
@@ -169,6 +198,12 @@ func (m *MachineSet) Default() {
 
 	if len(m.Namespace) == 0 {
 		m.Namespace = metav1.NamespaceDefault
+	}
+
+	if m.Spec.DeletePolicy == "" {
+		randomPolicy := string(RandomMachineSetDeletePolicy)
+		log.Printf("Defaulting to %s\n", randomPolicy)
+		m.Spec.DeletePolicy = randomPolicy
 	}
 }
 

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/controller.go
@@ -113,15 +113,9 @@ func (r *ReconcileMachineDeployment) getMachineSetsForDeployment(d *v1alpha1.Mac
 		return nil, err
 	}
 
-	// TODO: flush out machine set adoption.
-
 	filteredMS := make([]*v1alpha1.MachineSet, 0, len(machineSets.Items))
 	for idx := range machineSets.Items {
 		ms := &machineSets.Items[idx]
-		if metav1.GetControllerOf(ms) == nil || (metav1.GetControllerOf(ms) != nil && !metav1.IsControlledBy(ms, d)) {
-			klog.V(4).Infof("%s not controlled by %v", ms.Name, d.Name)
-			continue
-		}
 
 		selector, err := metav1.LabelSelectorAsSelector(&d.Spec.Selector)
 		if err != nil {
@@ -140,10 +134,28 @@ func (r *ReconcileMachineDeployment) getMachineSetsForDeployment(d *v1alpha1.Mac
 			continue
 		}
 
+		// Attempt to adopt machine if it meets previous conditions and it has no controller references.
+		if metav1.GetControllerOf(ms) == nil {
+			if err := r.adoptOrphan(d, ms); err != nil {
+				klog.Warningf("Failed to adopt MachineSet %q into MachineDeployment %q: %v", ms.Name, d.Name, err)
+				continue
+			}
+		}
+
+		if !metav1.IsControlledBy(ms, d) {
+			continue
+		}
+
 		filteredMS = append(filteredMS, ms)
 	}
 
 	return filteredMS, nil
+}
+
+func (r *ReconcileMachineDeployment) adoptOrphan(deployment *v1alpha1.MachineDeployment, machineSet *v1alpha1.MachineSet) error {
+	newRef := *metav1.NewControllerRef(deployment, controllerKind)
+	machineSet.OwnerReferences = append(machineSet.OwnerReferences, newRef)
+	return r.Client.Update(context.Background(), machineSet)
 }
 
 // Reconcile reads that state of the cluster for a MachineDeployment object and makes changes based on the state read
@@ -217,10 +229,11 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1alpha1.
 	}
 
 	// Add foregroundDeletion finalizer if MachineDeployment isn't deleted and linked to a cluster.
-	if cluster != nil && d.ObjectMeta.DeletionTimestamp.IsZero() {
-		if !util.Contains(d.Finalizers, metav1.FinalizerDeleteDependents) {
-			d.Finalizers = append(d.ObjectMeta.Finalizers, metav1.FinalizerDeleteDependents)
-		}
+	if cluster != nil &&
+		d.ObjectMeta.DeletionTimestamp.IsZero() &&
+		!util.Contains(d.Finalizers, metav1.FinalizerDeleteDependents) {
+
+		d.Finalizers = append(d.ObjectMeta.Finalizers, metav1.FinalizerDeleteDependents)
 
 		if err := r.Client.Update(context.Background(), d); err != nil {
 			klog.Infof("Failed to add finalizers to MachineSet %q: %v", d.Name, err)

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/machine.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/machine.go
@@ -60,14 +60,17 @@ func hasMatchingLabels(machineSet *v1alpha1.MachineSet, machine *v1alpha1.Machin
 		klog.Warningf("unable to convert selector: %v", err)
 		return false
 	}
+
 	// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
 	if selector.Empty() {
 		klog.V(2).Infof("%v machineset has empty selector", machineSet.Name)
 		return false
 	}
+
 	if !selector.Matches(labels.Set(machine.Labels)) {
 		klog.V(4).Infof("%v machine has mismatch labels", machine.Name)
 		return false
 	}
+
 	return true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the cluster-api dependency so selective downscaling of MachineSets is possible, xref kubernetes-sigs/cluster-api#726

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
