### PR TITLE
Test Kubernetes 1.14

### DIFF
--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -17,9 +17,10 @@ var (
 	scenarios = buildScenarios()
 
 	versions = []*semver.Version{
-		semver.MustParse("v1.11.7"),
-		semver.MustParse("v1.12.5"),
-		semver.MustParse("v1.13.3"),
+		semver.MustParse("v1.11.9"),
+		semver.MustParse("v1.12.7"),
+		semver.MustParse("v1.13.5"),
+		semver.MustParse("v1.14.0"),
 	}
 
 	operatingSystems = []providerconfig.OperatingSystem{

--- a/test/tools/integration/provision_master.sh
+++ b/test/tools/integration/provision_master.sh
@@ -50,8 +50,8 @@ if ! which kubelet; then
   deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
   apt-get update
-  apt-get install -y kubelet=1.13.5-00 kubeadm=1.13.5-00 kubectl=1.13.5-00
-  kubeadm init --kubernetes-version=v1.13.5 --apiserver-advertise-address=$ADDR --pod-network-cidr=10.244.0.0/16 --service-cidr=172.16.0.0/12
+  apt-get install -y kubelet=1.14.0-00 kubeadm=1.14.0-00 kubectl=1.14.0-00
+  kubeadm init --kubernetes-version=v1.14.0 --apiserver-advertise-address=$ADDR --pod-network-cidr=10.244.0.0/16 --service-cidr=172.16.0.0/12
   sed -i 's/\(.*leader-elect=true\)/\1\n    - --feature-gates=ScheduleDaemonSetPods=false/g' /etc/kubernetes/manifests/kube-scheduler.yaml
   sed -i 's/\(.*leader-elect=true\)/\1\n    - --feature-gates=ScheduleDaemonSetPods=false/g' /etc/kubernetes/manifests/kube-controller-manager.yaml
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds Kubernetes 1.14 to the e2e tests. Also moves the e2e tests controller from 1.13 to 1.14

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
