### PR TITLE
Fix e2e tests for Ubuntu on Openstack

### DIFF
--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -29,9 +29,9 @@ var (
 	}
 
 	openStackImages = map[string]string{
-		string(providerconfig.OperatingSystemUbuntu): "kubermatic-e2e-ubuntu",
-		string(providerconfig.OperatingSystemCoreos): "coreos",
-		string(providerconfig.OperatingSystemCentOS): "centos",
+		string(providerconfig.OperatingSystemUbuntu): "machine-controller-e2e-ubuntu",
+		string(providerconfig.OperatingSystemCoreos): "machine-controller-e2e-coreos",
+		string(providerconfig.OperatingSystemCentOS): "machine-controller-e2e-centos",
 	}
 )
 

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -29,7 +29,7 @@ var (
 	}
 
 	openStackImages = map[string]string{
-		string(providerconfig.OperatingSystemUbuntu): "Ubuntu 18.04 LTS - 2018-08-10",
+		string(providerconfig.OperatingSystemUbuntu): "kubermatic-e2e-ubuntu",
 		string(providerconfig.OperatingSystemCoreos): "coreos",
 		string(providerconfig.OperatingSystemCentOS): "centos",
 	}

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
@@ -28,7 +28,7 @@ spec:
             username: "<< USERNAME >>"
             password: "<< PASSWORD >>"
             tenantName: "<< TENANT_NAME >>"
-            image: "Ubuntu 18.04 LTS - 2018-08-10"
+            image: "kubermatic-e2e-ubuntu"
             flavor: "m1.small"
             floatingIpPool: ""
             domainName: "<< DOMAIN_NAME >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
@@ -28,7 +28,7 @@ spec:
             username: "<< USERNAME >>"
             password: "<< PASSWORD >>"
             tenantName: "<< TENANT_NAME >>"
-            image: "kubermatic-e2e-ubuntu"
+            image: "machine-controller-e2e-ubuntu"
             flavor: "m1.small"
             floatingIpPool: ""
             domainName: "<< DOMAIN_NAME >>"


### PR DESCRIPTION
**What this PR does / why we need it**:

We previously used an image managed by our Openstack provider which got removed by them, thus making all Openstack Ubuntu testcases fail. This fixes the tests to use an image we created, so it wont vanish by itself.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
