### PR TITLE
use automatic detection of the OpenStack BS version

### DIFF
--- a/pkg/cloudprovider/provider/openstack/cloudconfig.go
+++ b/pkg/cloudprovider/provider/openstack/cloudconfig.go
@@ -41,7 +41,7 @@ manage-security-groups = {{ .LoadBalancer.ManageSecurityGroups }}
 ignore-volume-az  = {{ .BlockStorage.IgnoreVolumeAZ }}
 {{- end }}
 trust-device-path = {{ .BlockStorage.TrustDevicePath }}
-bs-version        = {{ .BlockStorage.BSVersion | iniEscape }}
+bs-version        = {{ default "auto" .BlockStorage.BSVersion | iniEscape }}
 `
 )
 

--- a/pkg/cloudprovider/provider/openstack/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/openstack/cloudconfig_test.go
@@ -71,6 +71,17 @@ func TestCloudConfigToString(t *testing.T) {
 				Version: "1.12.0",
 			},
 		},
+		{
+			name: "bs-defaulting-config",
+			config: &CloudConfig{
+				Global: GlobalOpts{
+					AuthURL: "https://127.0.0.1:8443",
+				},
+				BlockStorage: BlockStorageOpts{},
+				LoadBalancer: LoadBalancerOpts{},
+				Version:      "1.10.0",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -641,7 +641,7 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 			ManageSecurityGroups: true,
 		},
 		BlockStorage: BlockStorageOpts{
-			BSVersion:       "v2",
+			BSVersion:       "auto",
 			TrustDevicePath: false,
 			IgnoreVolumeAZ:  true,
 		},

--- a/pkg/cloudprovider/provider/openstack/testdata/bs-defaulting-config.golden
+++ b/pkg/cloudprovider/provider/openstack/testdata/bs-defaulting-config.golden
@@ -1,0 +1,19 @@
+[Global]
+auth-url    = "https://127.0.0.1:8443"
+username    = ""
+password    = ""
+tenant-name = ""
+domain-name = ""
+region      = ""
+
+[LoadBalancer]
+lb-version = "v2"
+subnet-id = ""
+floating-network-id = ""
+lb-method = "ROUND_ROBIN"
+lb-provider = ""
+
+[BlockStorage]
+ignore-volume-az  = false
+trust-device-path = false
+bs-version        = "auto"


### PR DESCRIPTION
**What this PR does / why we need it**:
Use automatic detection of the OpenStack BS version.

```release-note
Use automatic detection of the OpenStack BS version in the Kubelet's cloud-config
```
