### PR TITLE
Use nbg1 as region for Hetzner Cloud instances during e2e tests

### DIFF
--- a/test/e2e/provisioning/testdata/machinedeployment-hetzner.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-hetzner.yaml
@@ -27,7 +27,7 @@ spec:
             token: << HETZNER_TOKEN >>
             serverType: "cx11"
             datacenter: ""
-            location: "fsn1"
+            location: "nbg1"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/tools/integration/hetzner.tf
+++ b/test/tools/integration/hetzner.tf
@@ -12,5 +12,5 @@ resource "hcloud_server" "machine-controller-test" {
   image       = "ubuntu-18.04"
   server_type = "cx41"
   ssh_keys    = ["${hcloud_ssh_key.default.id}"]
-  location    = "hel1"
+  location    = "nbg1"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `nbg1` as region for Hetzner Cloud instances during e2e tests (Also master)

```release-note
NONE
```
