### PR TITLE
Reduce e2e control plane size

### DIFF
--- a/test/tools/integration/hetzner.tf
+++ b/test/tools/integration/hetzner.tf
@@ -10,7 +10,7 @@ resource "hcloud_ssh_key" "default" {
 resource "hcloud_server" "machine-controller-test" {
   name        = "${var.hcloud_test_server_name}"
   image       = "ubuntu-18.04"
-  server_type = "cx41"
+  server_type = "cx21"
   ssh_keys    = ["${hcloud_ssh_key.default.id}"]
   location    = "nbg1"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce e2e control plane size. We don't need such a big node if we have a dedicated control plane for each provider.

```release-note
NONE
```
