### PR TITLE
Dont show leader election log by default

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -548,9 +548,9 @@ func readinessChecks(kubeconfigProvider machinecontroller.KubeconfigProvider) ma
 // createRecorder creates a new event recorder which is later used by the leader election
 // library to broadcast events
 func createRecorder(kubeClient *kubernetes.Clientset) record.EventRecorder {
-	glog.V(4).Info("creating event broadcaster")
+	glog.V(3).Info("creating event broadcaster")
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(glog.V(4).Infof)
+	eventBroadcaster.StartLogging(glog.V(3).Infof)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	return eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerName})
 }

--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -160,7 +160,7 @@ spec:
           command:
             - /usr/local/bin/machine-controller
             - -logtostderr
-            - -v=6
+            - -v=3
             - -worker-count=5
             - -cluster-dns=10.10.10.10
             - -internal-listen-address=0.0.0.0:8085

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -79,7 +79,7 @@ func createAdmissionResponse(original, mutated runtime.Object) (*admissionv1beta
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal json patch: %v", err)
 		}
-		glog.V(4).Infof("Produced jsonpatch: %s", string(patchRaw))
+		glog.V(3).Infof("Produced jsonpatch: %s", string(patchRaw))
 
 		response.Patch = patchRaw
 		response.PatchType = &jsonPatch

--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -27,7 +27,7 @@ func (ad *admissionData) mutateMachines(ar admissionv1beta1.AdmissionReview) (*a
 		return nil, fmt.Errorf("failed to unmarshal: %v", err)
 	}
 	machineOriginal := machine.DeepCopy()
-	glog.V(4).Infof("Defaulting and validating machine %s/%s", machine.Namespace, machine.Name)
+	glog.V(3).Infof("Defaulting and validating machine %s/%s", machine.Namespace, machine.Name)
 
 	// Mutating .Spec is never allowed
 	// Only hidden exception: the machine-controller may set the .Spec.Name to .Metadata.Name

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -150,7 +150,7 @@ func getDefaultAMIID(client *ec2.EC2, os providerconfig.OperatingSystem, region 
 	cacheKey := fmt.Sprintf("ami-id-%s-%s", region, os)
 	amiID, found := cache.Get(cacheKey)
 	if found {
-		glog.V(4).Info("found AMI-ID in cache!")
+		glog.V(3).Info("found AMI-ID in cache!")
 		return amiID.(string), nil
 	}
 
@@ -549,7 +549,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloud.MachineCreateDele
 	}
 
 	if *tOut.TerminatingInstances[0].PreviousState.Name != *tOut.TerminatingInstances[0].CurrentState.Name {
-		glog.V(4).Infof("successfully triggered termination of instance %s at aws", instance.ID())
+		glog.V(3).Infof("successfully triggered termination of instance %s at aws", instance.ID())
 	}
 
 	return false, nil

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -59,11 +59,11 @@ func (p *provider) Validate(machinespec v1alpha1.MachineSpec) error {
 	}
 
 	if fakeCloudProviderSpec.PassValidation {
-		glog.V(4).Infof("succeeding validation as requested")
+		glog.V(3).Infof("succeeding validation as requested")
 		return nil
 	}
 
-	glog.V(4).Infof("failing validation as requested")
+	glog.V(3).Infof("failing validation as requested")
 	return fmt.Errorf("failing validation as requested")
 }
 

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -233,13 +233,13 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	}
 
 	if c.Region == "" {
-		glog.V(4).Infof("Trying to default region for machine '%s'...", spec.Name)
+		glog.V(3).Infof("Trying to default region for machine '%s'...", spec.Name)
 		regions, err := getRegions(client)
 		if err != nil {
 			return spec, osErrorToTerminalError(err, "failed to get regions")
 		}
 		if len(regions) == 1 {
-			glog.V(4).Infof("Defaulted region for machine '%s' to '%s'", spec.Name, regions[0].ID)
+			glog.V(3).Infof("Defaulted region for machine '%s' to '%s'", spec.Name, regions[0].ID)
 			rawConfig.Region.Value = regions[0].ID
 		} else {
 			return spec, fmt.Errorf("could not default region because got '%v' results", len(regions))
@@ -247,25 +247,25 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	}
 
 	if c.AvailabilityZone == "" {
-		glog.V(4).Infof("Trying to default availability zone for machine '%s'...", spec.Name)
+		glog.V(3).Infof("Trying to default availability zone for machine '%s'...", spec.Name)
 		availabilityZones, err := getAvailabilityZones(client, c.Region)
 		if err != nil {
 			return spec, osErrorToTerminalError(err, "failed to get availability zones")
 		}
 		if len(availabilityZones) == 1 {
-			glog.V(4).Infof("Defaulted availability zone for machine '%s' to '%s'", spec.Name, availabilityZones[0].ZoneName)
+			glog.V(3).Infof("Defaulted availability zone for machine '%s' to '%s'", spec.Name, availabilityZones[0].ZoneName)
 			rawConfig.AvailabilityZone.Value = availabilityZones[0].ZoneName
 		}
 	}
 
 	if c.Network == "" {
-		glog.V(4).Infof("Trying to default network for machine '%s'...", spec.Name)
+		glog.V(3).Infof("Trying to default network for machine '%s'...", spec.Name)
 		net, err := getDefaultNetwork(client, c.Region)
 		if err != nil {
 			return spec, osErrorToTerminalError(err, "failed to default network")
 		}
 		if net != nil {
-			glog.V(4).Infof("Defaulted network for machine '%s' to '%s'", spec.Name, net.Name)
+			glog.V(3).Infof("Defaulted network for machine '%s' to '%s'", spec.Name, net.Name)
 			// Use the id as the name may not be unique
 			rawConfig.Network.Value = net.ID
 		}
@@ -286,7 +286,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 			return spec, osErrorToTerminalError(err, "error defaulting subnet")
 		}
 		if subnet != nil {
-			glog.V(4).Infof("Defaulted subnet for machine '%s' to '%s'", spec.Name, *subnet)
+			glog.V(3).Infof("Defaulted subnet for machine '%s' to '%s'", spec.Name, *subnet)
 			rawConfig.Subnet.Value = *subnet
 		}
 	}

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -557,7 +557,7 @@ func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
 			}
 		}
 	} else {
-		glog.V(4).Infof("vmware guest utils for machine %s are not running, can't match it to a node!", machine.Spec.Name)
+		glog.V(3).Infof("vmware guest utils for machine %s are not running, can't match it to a node!", machine.Spec.Name)
 	}
 
 	return Server{name: virtualMachine.Name(), status: status, addresses: addresses, id: virtualMachine.Reference().Value}, nil

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -139,7 +139,7 @@ func NewMachineController(
 		return nil, err
 	}
 	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(glog.V(4).Infof)
+	eventBroadcaster.StartLogging(glog.V(3).Infof)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 
 	if prometheusRegistry != nil {
@@ -397,7 +397,7 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	if listerMachine.Annotations[AnnotationMachineUninitialized] != "" {
-		glog.V(4).Infof("Ignoring machine %q because it has a non-emtpy %q annotation", listerMachine.Name, AnnotationMachineUninitialized)
+		glog.V(3).Infof("Ignoring machine %q because it has a non-emtpy %q annotation", listerMachine.Name, AnnotationMachineUninitialized)
 		return nil
 	}
 
@@ -441,7 +441,7 @@ func (c *Controller) syncHandler(key string) error {
 	if err != nil {
 		//In case we cannot find a node for the NodeRef we must remove the NodeRef & recreate an instance on the next sync
 		if kerrors.IsNotFound(err) {
-			glog.V(4).Infof("found invalid NodeRef on machine %s. Deleting reference...", machine.Name)
+			glog.V(3).Infof("found invalid NodeRef on machine %s. Deleting reference...", machine.Name)
 			_, err = c.updateMachine(machine, func(m *clusterv1alpha1.Machine) {
 				m.Status.NodeRef = nil
 			})
@@ -588,7 +588,7 @@ func (c *Controller) ensureInstanceExistsForMachine(prov cloud.Provider, machine
 
 		// case 2.1: instance was not found and we are going to create one
 		if err == cloudprovidererrors.ErrInstanceNotFound {
-			glog.V(4).Infof("Validated machine spec of %s", machine.Name)
+			glog.V(3).Infof("Validated machine spec of %s", machine.Name)
 
 			kubeconfig, err := c.createBootstrapKubeconfig(machine.Name)
 			if err != nil {
@@ -613,7 +613,7 @@ func (c *Controller) ensureInstanceExistsForMachine(prov cloud.Provider, machine
 				return c.updateMachineErrorIfTerminalError(machine, common.CreateMachineError, message, err, "failed to create machine at cloudprover")
 			}
 			c.recorder.Event(machine, corev1.EventTypeNormal, "Created", "Successfully created instance")
-			glog.V(4).Infof("Created machine %s at cloud provider", machine.Name)
+			glog.V(3).Infof("Created machine %s at cloud provider", machine.Name)
 			return nil
 		}
 
@@ -670,7 +670,7 @@ func (c *Controller) ensureNodeOwnerRefAndConfigSource(providerInstance instance
 			}); err != nil {
 				return fmt.Errorf("failed to update node %s after setting the config source: %v", node.Name, err)
 			}
-			glog.V(4).Infof("Added config source to node %s (machine %s)", node.Name, machine.Name)
+			glog.V(3).Infof("Added config source to node %s (machine %s)", node.Name, machine.Name)
 		}
 		err = c.updateMachineStatus(machine, node)
 		if err != nil {
@@ -741,7 +741,7 @@ func (c *Controller) ensureNodeLabelsAnnotationsAndTaints(node *corev1.Node, mac
 			return fmt.Errorf("failed to update node %s after setting labels/annotations/taints: %v", node.Name, err)
 		}
 		c.recorder.Event(machine, corev1.EventTypeNormal, "LabelsAnnotationsTaintsUpdated", "Successfully updated labels/annotations/taints")
-		glog.V(4).Infof("Added labels/annotations/taints to node %s (machine %s)", node.Name, machine.Name)
+		glog.V(3).Infof("Added labels/annotations/taints to node %s (machine %s)", node.Name, machine.Name)
 	}
 
 	return nil
@@ -838,7 +838,7 @@ func (c *Controller) handleObject(obj interface{}) {
 			utilruntime.HandleError(fmt.Errorf("error decoding object tombstone, invalid type"))
 			return
 		}
-		glog.V(4).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
+		glog.V(3).Infof("Recovered deleted object '%s' from tombstone", object.GetName())
 	}
 
 	machinesList, err := c.machinesLister.List(labels.Everything())
@@ -914,7 +914,7 @@ func (c *Controller) ensureDeleteFinalizerExists(machine *clusterv1alpha1.Machin
 		}); err != nil {
 			return nil, fmt.Errorf("failed to update machine after adding the delete instance finalizer: %v", err)
 		}
-		glog.V(4).Infof("Added delete finalizer to machine %s", machine.Name)
+		glog.V(3).Infof("Added delete finalizer to machine %s", machine.Name)
 	}
 	return machine, nil
 }

--- a/pkg/node/eviction/eviction.go
+++ b/pkg/node/eviction/eviction.go
@@ -46,10 +46,10 @@ func (ne *NodeEviction) Run() error {
 	}
 	node := listerNode.DeepCopy()
 	if _, exists := node.Annotations[SkipEvictionAnnotationKey]; exists {
-		glog.V(4).Infof("Skipping eviction for node %s as it has a %s annotation", ne.nodeName, SkipEvictionAnnotationKey)
+		glog.V(3).Infof("Skipping eviction for node %s as it has a %s annotation", ne.nodeName, SkipEvictionAnnotationKey)
 		return nil
 	}
-	glog.V(4).Infof("Starting to evict node %s", ne.nodeName)
+	glog.V(3).Infof("Starting to evict node %s", ne.nodeName)
 
 	if err := ne.cordonNode(node); err != nil {
 		return fmt.Errorf("failed to cordon node %s: %v", ne.nodeName, err)
@@ -71,7 +71,7 @@ func (ne *NodeEviction) Run() error {
 	if err := ne.waitForDeletion(podsToEvict); err != nil {
 		return fmt.Errorf("failed waiting for pods of node %s to be deleted: %v", ne.nodeName, err)
 	}
-	glog.V(4).Infof("All pods of node %s were successfully evicted", ne.nodeName)
+	glog.V(3).Infof("All pods of node %s were successfully evicted", ne.nodeName)
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables logging of leader election related messages by default. Additionally moves all our debug log to level 3, as level 4 contains the leader election log

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #424 

**Special notes for your reviewer**:

```release-note
none
```
