### PR TITLE
Add CPU and memory accounting cgroup settings for CoreOS and Ubuntu

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -214,12 +214,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
-- path: "/etc/systemd/system/kubelet.service.d/11-cgroups.conf"
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
 {{ .CloudConfig | indent 4 }}

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
@@ -117,6 +117,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
@@ -151,12 +153,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
-
-- path: "/etc/systemd/system/kubelet.service.d/11-cgroups.conf"
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
@@ -119,7 +119,7 @@ write_files:
     RestartSec=10
     CPUAccounting=true
     MemoryAccounting=true
-
+    
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
@@ -117,7 +117,9 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
+    CPUAccounting=true
+    MemoryAccounting=true
+
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
@@ -151,12 +153,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
-
-- path: "/etc/systemd/system/kubelet.service.d/11-cgroups.conf"
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.golden
@@ -119,7 +119,7 @@ write_files:
     RestartSec=10
     CPUAccounting=true
     MemoryAccounting=true
-
+    
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.golden
@@ -117,7 +117,9 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
+    CPUAccounting=true
+    MemoryAccounting=true
+
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
@@ -149,12 +151,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
-
-- path: "/etc/systemd/system/kubelet.service.d/11-cgroups.conf"
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
@@ -117,7 +117,9 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
+    CPUAccounting=true
+    MemoryAccounting=true
+
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
@@ -150,12 +152,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
-
-- path: "/etc/systemd/system/kubelet.service.d/11-cgroups.conf"
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
@@ -119,7 +119,7 @@ write_files:
     RestartSec=10
     CPUAccounting=true
     MemoryAccounting=true
-
+    
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
@@ -127,7 +127,9 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
+    CPUAccounting=true
+    MemoryAccounting=true
+
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
@@ -161,12 +163,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
-
-- path: "/etc/systemd/system/kubelet.service.d/11-cgroups.conf"
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
@@ -129,7 +129,7 @@ write_files:
     RestartSec=10
     CPUAccounting=true
     MemoryAccounting=true
-
+    
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
@@ -119,7 +119,7 @@ write_files:
     RestartSec=10
     CPUAccounting=true
     MemoryAccounting=true
-
+    
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
@@ -117,7 +117,9 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
-    
+    CPUAccounting=true
+    MemoryAccounting=true
+
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
@@ -151,12 +153,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
-
-- path: "/etc/systemd/system/kubelet.service.d/11-cgroups.conf"
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -311,6 +311,15 @@ storage:
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
 
+    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline:
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -182,6 +182,8 @@ systemd:
         After=docker.service
         [Service]
         TimeoutStartSec=5min
+        CPUAccounting=true
+        MemoryAccounting=true
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:{{ .HyperkubeImageTag }}
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --insecure-options=image \
@@ -310,15 +312,6 @@ storage:
         inline: |
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
-
-    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          CPUAccounting=true
-          MemoryAccounting=true
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -315,7 +315,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        inline:
+        inline: |
           [Service]
           CPUAccounting=true
           MemoryAccounting=true

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
@@ -280,7 +280,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        inline:
+        inline: |
           [Service]
           CPUAccounting=true
           MemoryAccounting=true

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
@@ -73,6 +73,8 @@ systemd:
         After=docker.service
         [Service]
         TimeoutStartSec=5min
+        CPUAccounting=true
+        MemoryAccounting=true
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --insecure-options=image \
@@ -275,15 +277,6 @@ storage:
         inline: |
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
-
-    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          CPUAccounting=true
-          MemoryAccounting=true
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.golden
@@ -276,6 +276,15 @@ storage:
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
 
+    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline:
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
@@ -280,7 +280,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        inline:
+        inline: |
           [Service]
           CPUAccounting=true
           MemoryAccounting=true

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
@@ -73,6 +73,8 @@ systemd:
         After=docker.service
         [Service]
         TimeoutStartSec=5min
+        CPUAccounting=true
+        MemoryAccounting=true
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.10.3
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --insecure-options=image \
@@ -275,15 +277,6 @@ storage:
         inline: |
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
-
-    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          CPUAccounting=true
-          MemoryAccounting=true
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.golden
@@ -276,6 +276,15 @@ storage:
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
 
+    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline:
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
@@ -301,7 +301,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        inline:
+        inline: |
           [Service]
           CPUAccounting=true
           MemoryAccounting=true

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
@@ -94,6 +94,8 @@ systemd:
         After=docker.service
         [Service]
         TimeoutStartSec=5min
+        CPUAccounting=true
+        MemoryAccounting=true
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.11.2
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --insecure-options=image \
@@ -296,15 +298,6 @@ storage:
         inline: |
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
-
-    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          CPUAccounting=true
-          MemoryAccounting=true
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.golden
@@ -297,6 +297,15 @@ storage:
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
 
+    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline:
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.golden
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.golden
@@ -302,7 +302,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        inline:
+        inline: |
           [Service]
           CPUAccounting=true
           MemoryAccounting=true

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.golden
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.golden
@@ -298,6 +298,15 @@ storage:
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
 
+    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline:
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.golden
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.golden
@@ -94,6 +94,8 @@ systemd:
         After=docker.service
         [Service]
         TimeoutStartSec=5min
+        CPUAccounting=true
+        MemoryAccounting=true
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.12.0
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --insecure-options=image \
@@ -297,15 +299,6 @@ storage:
         inline: |
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
-
-    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          CPUAccounting=true
-          MemoryAccounting=true
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.golden
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.golden
@@ -278,7 +278,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        inline:
+        inline: |
           [Service]
           CPUAccounting=true
           MemoryAccounting=true

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.golden
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.golden
@@ -274,6 +274,15 @@ storage:
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
 
+    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline:
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.golden
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.golden
@@ -78,6 +78,8 @@ systemd:
         After=docker.service
         [Service]
         TimeoutStartSec=5min
+        CPUAccounting=true
+        MemoryAccounting=true
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --insecure-options=image \
@@ -273,15 +275,6 @@ storage:
         inline: |
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
-
-    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          CPUAccounting=true
-          MemoryAccounting=true
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
@@ -279,7 +279,7 @@ storage:
       filesystem: root
       mode: 0644
       contents:
-        inline:
+        inline: |
           [Service]
           CPUAccounting=true
           MemoryAccounting=true

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
@@ -78,6 +78,8 @@ systemd:
         After=docker.service
         [Service]
         TimeoutStartSec=5min
+        CPUAccounting=true
+        MemoryAccounting=true
         Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --insecure-options=image \
@@ -274,15 +276,6 @@ storage:
         inline: |
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
-
-    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          [Service]
-          CPUAccounting=true
-          MemoryAccounting=true
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.golden
@@ -275,6 +275,15 @@ storage:
           [Service]
           Environment=DOCKER_OPTS=--storage-driver=overlay2
 
+    - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline:
+          [Service]
+          CPUAccounting=true
+          MemoryAccounting=true
+
     - path: /opt/bin/download.sh
       filesystem: root
       mode: 0755

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -48,6 +48,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
@@ -9,6 +9,8 @@ Documentation=https://kubernetes.io/docs/home/
 Restart=always
 StartLimitInterval=0
 RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
 
 Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
 

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -286,11 +286,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -283,14 +283,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
 {{ .CloudConfig | indent 4 }}

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -283,6 +283,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
 {{ .CloudConfig | indent 4 }}

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
@@ -240,11 +240,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
@@ -237,14 +237,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
@@ -237,6 +237,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
@@ -203,6 +203,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
@@ -236,14 +236,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
@@ -236,6 +236,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
@@ -202,6 +202,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
@@ -239,11 +239,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
@@ -236,14 +236,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
@@ -236,6 +236,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
@@ -202,6 +202,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
@@ -239,11 +239,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
@@ -241,11 +241,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
@@ -238,14 +238,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
@@ -238,6 +238,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
@@ -204,6 +204,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
@@ -241,11 +241,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
@@ -202,6 +202,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
@@ -238,6 +238,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     custom

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
@@ -238,14 +238,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     custom

--- a/pkg/userdata/ubuntu/testdata/openstack.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack.golden
@@ -241,11 +241,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/openstack.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack.golden
@@ -202,6 +202,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/openstack.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack.golden
@@ -238,14 +238,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     {openstack-config:true}

--- a/pkg/userdata/ubuntu/testdata/openstack.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack.golden
@@ -238,6 +238,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     {openstack-config:true}

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
@@ -236,14 +236,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
@@ -236,6 +236,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
@@ -202,6 +202,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
@@ -239,11 +239,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
@@ -236,14 +236,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
@@ -236,6 +236,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
@@ -202,6 +202,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
@@ -239,11 +239,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
@@ -238,11 +238,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
@@ -235,14 +235,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
@@ -235,6 +235,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
@@ -202,6 +202,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
@@ -236,14 +236,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
@@ -236,6 +236,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
@@ -202,6 +202,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
@@ -239,11 +239,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/vsphere.golden
+++ b/pkg/userdata/ubuntu/testdata/vsphere.golden
@@ -239,14 +239,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
-  filesystem: root
-  mode: 0644
-  content: |
-    [Service]
-    CPUAccounting=true
-    MemoryAccounting=true
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
     custom

--- a/pkg/userdata/ubuntu/testdata/vsphere.golden
+++ b/pkg/userdata/ubuntu/testdata/vsphere.golden
@@ -239,6 +239,15 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+- path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
+  filesystem: root
+  mode: 0644
+  contents:
+    inline:
+      [Service]
+      CPUAccounting=true
+      MemoryAccounting=true
+
 - path: "/etc/kubernetes/cloud-config"
   content: |
     custom

--- a/pkg/userdata/ubuntu/testdata/vsphere.golden
+++ b/pkg/userdata/ubuntu/testdata/vsphere.golden
@@ -242,11 +242,10 @@ write_files:
 - path: /etc/systemd/system/kubelet.service.d/11-cgroups.conf
   filesystem: root
   mode: 0644
-  contents:
-    inline:
-      [Service]
-      CPUAccounting=true
-      MemoryAccounting=true
+  content: |
+    [Service]
+    CPUAccounting=true
+    MemoryAccounting=true
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/ubuntu/testdata/vsphere.golden
+++ b/pkg/userdata/ubuntu/testdata/vsphere.golden
@@ -203,6 +203,8 @@ write_files:
     Restart=always
     StartLimitInterval=0
     RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
     
     Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
     


### PR DESCRIPTION
**What this PR does / why we need it**:

cgroup settings are already changed for CentOS due to issue https://github.com/kubernetes/kubernetes/issues/56850. Now adding same change for CoreOS and Ubuntu to keep code base homogenous.

Changes allow the *kubelet /stats/summary API* to report the correct *systemContainer* metrics for the runtime and kubelet.

**Which issue(s) this PR fixes**

Fixes #491 

**Special notes for your reviewer**:

```release-note
NONE
```
