### PR TITLE
Re-check after instance creation

### DIFF
--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -614,6 +614,8 @@ func (c *Controller) ensureInstanceExistsForMachine(prov cloud.Provider, machine
 			}
 			c.recorder.Event(machine, corev1.EventTypeNormal, "Created", "Successfully created instance")
 			glog.V(3).Infof("Created machine %s at cloud provider", machine.Name)
+			// Reqeue the machine to make sure we notice if creation failed silently
+			c.enqueueMachineAfter(machine, 30*time.Second)
 			return nil
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We currently don't re-enque machines after instance creation. That means if the creation fails silently, we will never notice because nothing triggers the reconciliation of the machine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
