### PR TITLE
Add swapoff to centos so kubelet starts

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -168,6 +168,12 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
+    # Make sure we always disable swap - Otherwise the kubelet won't start
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
+    swapoff -a
+
     {{ if ne .CloudProvider "aws" }}
     # The normal way of setting it via cloud-init is broken:
     # https://bugs.launchpad.net/cloud-init/+bug/1662542

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.golden
@@ -56,6 +56,12 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
+    # Make sure we always disable swap - Otherwise the kubelet won't start
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
+    swapoff -a
+
     
 
     yum install -y docker-1.13.1 \

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.golden
@@ -56,6 +56,12 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
+    # Make sure we always disable swap - Otherwise the kubelet won't start
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
+    swapoff -a
+
     
 
     yum install -y docker-1.13.1 \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.golden
@@ -56,6 +56,12 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
+    # Make sure we always disable swap - Otherwise the kubelet won't start
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
+    swapoff -a
+
     
 
     yum install -y docker-1.13.1 \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.golden
@@ -56,6 +56,12 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
+    # Make sure we always disable swap - Otherwise the kubelet won't start
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
+    swapoff -a
+
     
 
     yum install -y docker-1.13.1 \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.golden
@@ -59,6 +59,12 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
+    # Make sure we always disable swap - Otherwise the kubelet won't start
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
+    swapoff -a
+
     
     # The normal way of setting it via cloud-init is broken:
     # https://bugs.launchpad.net/cloud-init/+bug/1662542

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.golden
@@ -56,6 +56,12 @@ write_files:
     systemctl restart systemd-modules-load.service
     sysctl --system
 
+    # Make sure we always disable swap - Otherwise the kubelet won't start
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
+    swapoff -a
+
     
 
     yum install -y docker-1.13.1 \

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -221,7 +221,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.golden
@@ -122,7 +122,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/openstack.golden
+++ b/pkg/userdata/ubuntu/testdata/openstack.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'

--- a/pkg/userdata/ubuntu/testdata/vsphere.golden
+++ b/pkg/userdata/ubuntu/testdata/vsphere.golden
@@ -120,7 +120,9 @@ write_files:
     apt-get update
 
     # Make sure we always disable swap - Otherwise the kubelet won't start'.
-    systemctl mask swap.target
+    cp /etc/fstab /etc/fstab.orig
+    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
+    mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable swap on lentos so Kubelet starts. 

We already do it for Ubuntu [here](https://github.com/kubermatic/machine-controller/blob/master/pkg/userdata/ubuntu/provider.go#L223-L225) for exactly the same reason, so we should do it for centos as well. As discussed with @mrIncompetent and @thz in Slack.

Using exact same language/code for centos as Ubuntu.


```release-note
Disable swap on centos like on ubuntu
```