### PR TITLE
Make CloudProviderSpec public so that it can be exported

### DIFF
--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -48,9 +48,9 @@ const (
 	defaultDiskSize = 25
 )
 
-// cloudProviderSpec contains the specification of the cloud provider taken
+// CloudProviderSpec contains the specification of the cloud provider taken
 // from the provider configuration.
-type cloudProviderSpec struct {
+type CloudProviderSpec struct {
 	ServiceAccount providerconfig.ConfigVarString `json:"serviceAccount"`
 	Zone           providerconfig.ConfigVarString `json:"zone"`
 	MachineType    providerconfig.ConfigVarString `json:"machineType"`
@@ -64,7 +64,7 @@ type cloudProviderSpec struct {
 
 // newCloudProviderSpec creates a cloud provider specification out of the
 // given ProviderSpec.
-func newCloudProviderSpec(spec v1alpha1.ProviderSpec) (*cloudProviderSpec, *providerconfig.Config, error) {
+func newCloudProviderSpec(spec v1alpha1.ProviderSpec) (*CloudProviderSpec, *providerconfig.Config, error) {
 	// Retrieve provider configuration from machine specification.
 	if spec.Value == nil {
 		return nil, nil, fmt.Errorf("machine.spec.providerconfig.value is nil")
@@ -75,7 +75,7 @@ func newCloudProviderSpec(spec v1alpha1.ProviderSpec) (*cloudProviderSpec, *prov
 		return nil, nil, fmt.Errorf("cannot unmarshal machine.spec.providerconfig.value: %v", err)
 	}
 	// Retrieve cloud provider specification from cloud provider specification.
-	cpSpec := &cloudProviderSpec{}
+	cpSpec := &CloudProviderSpec{}
 	err = json.Unmarshal(providerConfig.CloudProviderSpec.Raw, cpSpec)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot unmarshal cloud provider specification: %v", err)
@@ -85,7 +85,7 @@ func newCloudProviderSpec(spec v1alpha1.ProviderSpec) (*cloudProviderSpec, *prov
 
 // updateProviderSpec updates the given provider spec with changed
 // configuration values.
-func (cpSpec *cloudProviderSpec) updateProviderSpec(spec v1alpha1.ProviderSpec) (*runtime.RawExtension, error) {
+func (cpSpec *CloudProviderSpec) updateProviderSpec(spec v1alpha1.ProviderSpec) (*runtime.RawExtension, error) {
 	if spec.Value == nil {
 		return nil, fmt.Errorf("machine.spec.providerconfig.value is nil")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This needs to be exported for adding GCP support in Kubermatic. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
for https://github.com/kubermatic/kubermatic/issues/3120

**Special notes for your reviewer**:

```release-note
NONE
```
