### PR TITLE
Allow creating GCP instances without public address

### DIFF
--- a/examples/gce-machinedeployment.yaml
+++ b/examples/gce-machinedeployment.yaml
@@ -60,6 +60,8 @@ spec:
             diskType: "pd-standard"
             labels:
               "kubernetes_cluster": "my-cluster"
+            # Whether to assign a public IP Address. Required for Internet access
+            assignPublicIPAddress: true
           # Can be 'ubuntu' or 'coreos'
           operatingSystem: "coreos"
           operatingSystemSpec:

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -67,15 +67,16 @@ const (
 // CloudProviderSpec contains the specification of the cloud provider taken
 // from the provider configuration.
 type CloudProviderSpec struct {
-	ServiceAccount providerconfig.ConfigVarString `json:"serviceAccount"`
-	Zone           providerconfig.ConfigVarString `json:"zone"`
-	MachineType    providerconfig.ConfigVarString `json:"machineType"`
-	DiskSize       int64                          `json:"diskSize"`
-	DiskType       providerconfig.ConfigVarString `json:"diskType"`
-	Network        providerconfig.ConfigVarString `json:"network"`
-	Subnetwork     providerconfig.ConfigVarString `json:"subnetwork"`
-	Preemptible    providerconfig.ConfigVarBool   `json:"preemptible"`
-	Labels         map[string]string              `json:"labels"`
+	ServiceAccount        providerconfig.ConfigVarString `json:"serviceAccount"`
+	Zone                  providerconfig.ConfigVarString `json:"zone"`
+	MachineType           providerconfig.ConfigVarString `json:"machineType"`
+	DiskSize              int64                          `json:"diskSize"`
+	DiskType              providerconfig.ConfigVarString `json:"diskType"`
+	Network               providerconfig.ConfigVarString `json:"network"`
+	Subnetwork            providerconfig.ConfigVarString `json:"subnetwork"`
+	Preemptible           providerconfig.ConfigVarBool   `json:"preemptible"`
+	Labels                map[string]string              `json:"labels"`
+	AssignPublicIPAddress providerconfig.ConfigVarBool   `json:"assignPublicIPAddress"`
 }
 
 // newCloudProviderSpec creates a cloud provider specification out of the
@@ -124,18 +125,19 @@ func (cpSpec *CloudProviderSpec) updateProviderSpec(spec v1alpha1.ProviderSpec) 
 
 // config contains the configuration of the Provider.
 type config struct {
-	serviceAccount string
-	projectID      string
-	zone           string
-	machineType    string
-	diskSize       int64
-	diskType       string
-	network        string
-	subnetwork     string
-	preemptible    bool
-	labels         map[string]string
-	jwtConfig      *jwt.Config
-	providerConfig *providerconfig.Config
+	serviceAccount        string
+	projectID             string
+	zone                  string
+	machineType           string
+	diskSize              int64
+	diskType              string
+	network               string
+	subnetwork            string
+	preemptible           bool
+	labels                map[string]string
+	jwtConfig             *jwt.Config
+	providerConfig        *providerconfig.Config
+	assignPublicIPAddress bool
 }
 
 // newConfig creates a Provider configuration out of the passed resolver and spec.
@@ -191,6 +193,11 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 	cfg.preemptible, err = resolver.GetConfigVarBoolValue(cpSpec.Preemptible)
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve preemptible: %v", err)
+	}
+
+	cfg.assignPublicIPAddress, err = resolver.GetConfigVarBoolValue(cpSpec.AssignPublicIPAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve assignPublicIPAddress: %v", err)
 	}
 
 	return cfg, nil

--- a/pkg/cloudprovider/provider/gce/service.go
+++ b/pkg/cloudprovider/provider/gce/service.go
@@ -67,14 +67,15 @@ func (svc *service) networkInterfaces(cfg *config) ([]*compute.NetworkInterface,
 	}
 
 	ifc := &compute.NetworkInterface{
-		AccessConfigs: []*compute.AccessConfig{
-			{
-				Name: "External NAT",
-				Type: "ONE_TO_ONE_NAT",
-			},
-		},
 		Network:    network,
 		Subnetwork: cfg.subnetwork,
+	}
+
+	if cfg.assignPublicIPAddress {
+		ifc.AccessConfigs = []*compute.AccessConfig{{
+			Name: "External NAT",
+			Type: "ONE_TO_ONE_NAT",
+		}}
 	}
 
 	return []*compute.NetworkInterface{ifc}, nil

--- a/test/e2e/provisioning/testdata/machinedeployment-gce.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-gce.yaml
@@ -35,7 +35,8 @@ spec:
             # Can be 'pd-standard' or 'pd-ssd'
             diskType: "pd-standard"
             labels:
-                "kubernetes_cluster": "gce-test-cluster"            
+                "kubernetes_cluster": "gce-test-cluster"
+            assignPublicIPAddress: true
           # Can be 'ubuntu' or 'coreos'
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows to create instances on GCP without a public IP. Note that this also swaps the default to not assign a public IP by default.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```

/assign @mrIncompetent 
CC @nikhita 
