### PR TITLE
gce: allow specifying tags for instances

### DIFF
--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -76,6 +76,7 @@ type CloudProviderSpec struct {
 	Subnetwork            providerconfig.ConfigVarString `json:"subnetwork"`
 	Preemptible           providerconfig.ConfigVarBool   `json:"preemptible"`
 	Labels                map[string]string              `json:"labels"`
+	Tags                  []string                       `json:"tags"`
 	AssignPublicIPAddress providerconfig.ConfigVarBool   `json:"assignPublicIPAddress"`
 }
 
@@ -135,6 +136,7 @@ type config struct {
 	subnetwork            string
 	preemptible           bool
 	labels                map[string]string
+	tags                  []string
 	jwtConfig             *jwt.Config
 	providerConfig        *providerconfig.Config
 	assignPublicIPAddress bool
@@ -152,6 +154,7 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 	cfg := &config{
 		providerConfig: providerConfig,
 		labels:         cpSpec.Labels,
+		tags:           cpSpec.Tags,
 		diskSize:       cpSpec.DiskSize,
 	}
 

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -238,6 +238,9 @@ func (p *Provider) Create(
 				},
 			},
 		},
+		Tags: &compute.Tags{
+			Items: cfg.tags,
+		},
 	}
 	op, err := svc.Instances.Insert(cfg.projectID, cfg.zone, inst).Do()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows specifying tags for GCE instances. This is necessary so that we can add firewall support in kubermatic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
For https://github.com/kubermatic/kubermatic/pull/3350

```release-note
NONE
```

/assign @alvaroaleman 
/cc @themue 
