### PR TITLE
Default AWS ami in AddDefaults instead of Create

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -168,7 +168,7 @@ func getDefaultAMIID(client *ec2.EC2, os providerconfig.OperatingSystem, region 
 	cacheKey := fmt.Sprintf("ami-id-%s-%s", region, os)
 	amiID, found := cache.Get(cacheKey)
 	if found {
-		glog.V(3).Info("found AMI-ID %q for OperatingSystem %q in cache", amiID, os)
+		glog.V(3).Infof("found AMI-ID %q for OperatingSystem %q in cache", amiID.(string), os)
 		return amiID.(string), nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets the default AWS AMI in `AddDefaults` instead of `Create`. This has two advantages:

* Reproducibility: All machines for a given `MachineDeployment` will always use the same AMI
* Insigts: It is possible to find out which AMI was used if it got defaulted

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
