### PR TITLE
Fix check-dependencies to use dep check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,4 +136,4 @@ check-dependencies:
 	# We need mercurial for bitbucket.org/ww/goautoneg, otherwise dep hangs forever
 	which hg >/dev/null 2>&1 || apt update && apt install -y mercurial
 	dep version || go get -u github.com/golang/dep/cmd/dep
-	dep status
+	dep check


### PR DESCRIPTION
**What this PR does / why we need it**:

`check-dependencies` should fail when vendor is directly updated without updating `Gopkg.toml`.  To have that, we should be using `dep check` instead of `dep status`.

Ref:
- https://golang.github.io/dep/docs/daily-dep.html#key-takeaways
- https://golang.github.io/dep/docs/ensure-mechanics.html#staying-in-sync

Related https://github.com/kubermatic/kubermatic/pull/3422

```release-note
NONE
```

/assign @alvaroaleman 
