### PR TITLE
vSphere VM cleanup after ISO failure

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -385,6 +385,9 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloud.MachineCreateDelet
 		}()
 
 		if err := uploadAndAttachISO(ctx, finder, virtualMachine, localUserdataIsoFilePath, config.Datastore); err != nil {
+			if osErr := os.Remove(localUserdataIsoFilePath); osErr != nil {
+				glog.V(3).Infof("failed to remove ISO after upload failure: %v", osErr)
+			}
 			return nil, machineInvalidConfigurationTerminalError(fmt.Errorf("failed to upload and attach userdata iso: %v", err))
 		}
 	}

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -386,7 +386,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloud.MachineCreateDelet
 
 		if err := uploadAndAttachISO(ctx, finder, virtualMachine, localUserdataIsoFilePath, config.Datastore); err != nil {
 			if osErr := os.Remove(localUserdataIsoFilePath); osErr != nil {
-				glog.V(3).Infof("failed to remove ISO after upload failure: %v", osErr)
+				utilruntime.HandleError(fmt.Errorf("failed to clean up local userdata iso file at %s after upload error: %v", localUserdataIsoFilePath, osErr))
 			}
 			return nil, machineInvalidConfigurationTerminalError(fmt.Errorf("failed to upload and attach userdata iso: %v", err))
 		}

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -386,12 +386,12 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloud.MachineCreateDelet
 
 		if err := uploadAndAttachISO(ctx, finder, virtualMachine, localUserdataIsoFilePath, config.Datastore); err != nil {
 			// Destroy VM to avoid a leftover.
-			destroyTask, err := virtualMachine.Destroy(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to destroy vm %s: %v", virtualMachine.Name(), err)
+			destroyTask, vmErr := virtualMachine.Destroy(ctx)
+			if vmErr != nil {
+				return nil, fmt.Errorf("failed to destroy vm %s after failing upload and attach userdata iso: %v / %v", virtualMachine.Name(), err, vmErr)
 			}
-			if err := destroyTask.Wait(ctx); err != nil {
-				return nil, fmt.Errorf("failed to destroy vm %s: %v", virtualMachine.Name(), err)
+			if vmErr := destroyTask.Wait(ctx); vmErr != nil {
+				return nil, fmt.Errorf("failed to destroy vm %s after failing upload and attach userdata iso: %v / %v", virtualMachine.Name(), err, vmErr)
 			}
 			return nil, machineInvalidConfigurationTerminalError(fmt.Errorf("failed to upload and attach userdata iso: %v", err))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

In case `uploadAndAttachISO()` fails the already created VM gets destroyed.

**Which issue(s) this PR fixes**:

Fixes #377 

**Special notes for your reviewer**:

```release-note
NONE
```
