### PR TITLE
Add NetworkName and SubnetworkName to GCP cloudconfig

### DIFF
--- a/pkg/cloudprovider/provider/gce/cloudconfig.go
+++ b/pkg/cloudprovider/provider/gce/cloudconfig.go
@@ -35,15 +35,19 @@ import (
 const cloudConfigTemplate = "[global]\n" +
 	"project-id = {{ .Global.ProjectID | iniEscape }}\n" +
 	"local-zone = {{ .Global.LocalZone | iniEscape }}\n" +
+	"network-name = {{ .Global.NetworkName | iniEscape }}\n" +
+	"subnetwork-name = {{ .Global.SubnetworkName | iniEscape }}\n" +
 	"multizone = {{ .Global.MultiZone }}\n" +
 	"regional = {{ .Global.Regional }}\n"
 
 // GlobalOpts contains the values of the global section of the cloud configuration.
 type GlobalOpts struct {
-	ProjectID string
-	LocalZone string
-	MultiZone bool
-	Regional  bool
+	ProjectID      string
+	LocalZone      string
+	NetworkName    string
+	SubnetworkName string
+	MultiZone      bool
+	Regional       bool
 }
 
 // CloudConfig contains only the section global.

--- a/pkg/cloudprovider/provider/gce/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/gce/cloudconfig_test.go
@@ -36,15 +36,19 @@ func TestCloudConfigAsString(t *testing.T) {
 			name: "minimum test",
 			config: &CloudConfig{
 				Global: GlobalOpts{
-					ProjectID: "my-project-id",
-					LocalZone: "my-zone",
-					MultiZone: true,
-					Regional:  true,
+					ProjectID:      "my-project-id",
+					LocalZone:      "my-zone",
+					NetworkName:    "my-cool-network",
+					SubnetworkName: "my-cool-subnetwork",
+					MultiZone:      true,
+					Regional:       true,
 				},
 			},
 			contents: "[global]\n" +
 				"project-id = \"my-project-id\"\n" +
 				"local-zone = \"my-zone\"\n" +
+				"network-name = \"my-cool-network\"\n" +
+				"subnetwork-name = \"my-cool-subnetwork\"\n" +
 				"multizone = true\n" +
 				"regional = true\n",
 		},

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -78,6 +78,8 @@ type CloudProviderSpec struct {
 	Labels                map[string]string              `json:"labels"`
 	Tags                  []string                       `json:"tags"`
 	AssignPublicIPAddress providerconfig.ConfigVarBool   `json:"assignPublicIPAddress"`
+	MultiZone             providerconfig.ConfigVarBool   `json:"multizone"`
+	Regional              providerconfig.ConfigVarBool   `json:"regional"`
 }
 
 // newCloudProviderSpec creates a cloud provider specification out of the
@@ -140,6 +142,8 @@ type config struct {
 	jwtConfig             *jwt.Config
 	providerConfig        *providerconfig.Config
 	assignPublicIPAddress bool
+	multizone             bool
+	regional              bool
 }
 
 // newConfig creates a Provider configuration out of the passed resolver and spec.
@@ -199,6 +203,16 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 	}
 
 	cfg.assignPublicIPAddress, err = resolver.GetConfigVarBoolValue(cpSpec.AssignPublicIPAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve assignPublicIPAddress: %v", err)
+	}
+
+	cfg.multizone, err = resolver.GetConfigVarBoolValue(cpSpec.MultiZone)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve assignPublicIPAddress: %v", err)
+	}
+
+	cfg.regional, err = resolver.GetConfigVarBoolValue(cpSpec.Regional)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve assignPublicIPAddress: %v", err)
 	}

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -168,8 +168,12 @@ func (p *Provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 	// Init cloud configuration.
 	cc := &CloudConfig{
 		Global: GlobalOpts{
-			ProjectID: cfg.projectID,
-			LocalZone: cfg.zone,
+			ProjectID:      cfg.projectID,
+			LocalZone:      cfg.zone,
+			MultiZone:      cfg.multizone,
+			Regional:       cfg.regional,
+			NetworkName:    cfg.network,
+			SubnetworkName: cfg.subnetwork,
 		},
 	}
 	config, err = cc.AsString()


### PR DESCRIPTION
The controller-manager crashes with:

```
F0510 08:44:10.389281       1 controllermanager.go:213] error building controller context: cloud provider could not be initialized: could not init cloud provider "gce": metadata: GCE metadata "instance/network-interfaces/0/network" not defined
```

This comes from https://github.com/kubernetes/kubernetes/blob/b9ccdd2824c8df7711d3aed985d3e1b549a40de3/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go#L787-L791 when it tries to find the networkName via metadata but fails...which occurs due to https://github.com/kubernetes/kubernetes/blob/b9ccdd2824c8df7711d3aed985d3e1b549a40de3/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go#L342-L354

/assign @alvaroaleman 

```release-note
NONE
```
