### PR TITLE
Add TokenURL in GCE CloudConfig

### DIFF
--- a/pkg/cloudprovider/provider/gce/cloudconfig.go
+++ b/pkg/cloudprovider/provider/gce/cloudconfig.go
@@ -37,6 +37,7 @@ const cloudConfigTemplate = "[global]\n" +
 	"local-zone = {{ .Global.LocalZone | iniEscape }}\n" +
 	"network-name = {{ .Global.NetworkName | iniEscape }}\n" +
 	"subnetwork-name = {{ .Global.SubnetworkName | iniEscape }}\n" +
+	"token-url = {{ .Global.TokenURL | iniEscape }}\n" +
 	"multizone = {{ .Global.MultiZone }}\n" +
 	"regional = {{ .Global.Regional }}\n"
 
@@ -46,6 +47,7 @@ type GlobalOpts struct {
 	LocalZone      string
 	NetworkName    string
 	SubnetworkName string
+	TokenURL       string
 	MultiZone      bool
 	Regional       bool
 }

--- a/pkg/cloudprovider/provider/gce/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/gce/cloudconfig_test.go
@@ -40,6 +40,7 @@ func TestCloudConfigAsString(t *testing.T) {
 					LocalZone:      "my-zone",
 					NetworkName:    "my-cool-network",
 					SubnetworkName: "my-cool-subnetwork",
+					TokenURL:       "nil",
 					MultiZone:      true,
 					Regional:       true,
 				},
@@ -49,6 +50,7 @@ func TestCloudConfigAsString(t *testing.T) {
 				"local-zone = \"my-zone\"\n" +
 				"network-name = \"my-cool-network\"\n" +
 				"subnetwork-name = \"my-cool-subnetwork\"\n" +
+				"token-url = \"nil\"\n" +
 				"multizone = true\n" +
 				"regional = true\n",
 		},


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/blob/release-1.14/pkg/cloudprovider/providers/gce/gce.go#L305

I'm not adding it to the CloudProviderConfig because I intend to default it to `nil` in Kubermatic.

/cc @alvaroaleman @mrIncompetent 

```release-note
NONE
```
