### PR TITLE
Openstack validation: Force passing in image and flavor

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -18,6 +18,7 @@ package openstack
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -324,6 +325,14 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	c, _, _, err := p.getConfig(spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %v", err)
+	}
+
+	if c.Image == "" {
+		return errors.New("image must be configured")
+	}
+
+	if c.Flavor == "" {
+		return errors.New("flavor must be configured")
 	}
 
 	client, err := getClient(c)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the Openstack validation to now allow an empty image and flavor. It is possible that there is an image or flavor without a name in the openstack API which will then be used.

/assign @nikhita 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
