### PR TITLE
GCE public IP by default

### DIFF
--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -214,12 +214,12 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 
 	cfg.multizone, err = resolver.GetConfigVarBoolValue(cpSpec.MultiZone)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve assignPublicIPAddress: %v", err)
+		return nil, fmt.Errorf("failed to retrieve multizone: %v", err)
 	}
 
 	cfg.regional, err = resolver.GetConfigVarBoolValue(cpSpec.Regional)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve assignPublicIPAddress: %v", err)
+		return nil, fmt.Errorf("failed to retrieve regional: %v", err)
 	}
 
 	return cfg, nil

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -77,7 +77,7 @@ type CloudProviderSpec struct {
 	Preemptible           providerconfig.ConfigVarBool   `json:"preemptible"`
 	Labels                map[string]string              `json:"labels"`
 	Tags                  []string                       `json:"tags"`
-	AssignPublicIPAddress providerconfig.ConfigVarBool   `json:"assignPublicIPAddress"`
+	AssignPublicIPAddress *providerconfig.ConfigVarBool  `json:"assignPublicIPAddress"`
 	MultiZone             providerconfig.ConfigVarBool   `json:"multizone"`
 	Regional              providerconfig.ConfigVarBool   `json:"regional"`
 }
@@ -202,9 +202,14 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 		return nil, fmt.Errorf("cannot retrieve preemptible: %v", err)
 	}
 
-	cfg.assignPublicIPAddress, err = resolver.GetConfigVarBoolValue(cpSpec.AssignPublicIPAddress)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve assignPublicIPAddress: %v", err)
+	// make it true by default
+	cfg.assignPublicIPAddress = true
+
+	if cpSpec.AssignPublicIPAddress != nil {
+		cfg.assignPublicIPAddress, err = resolver.GetConfigVarBoolValue(*cpSpec.AssignPublicIPAddress)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve assignPublicIPAddress: %v", err)
+		}
 	}
 
 	cfg.multizone, err = resolver.GetConfigVarBoolValue(cpSpec.MultiZone)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes breaking change introduced in #510 

```release-note
GCE public IP by default
```