### PR TITLE
Remove unused `os` field from the packet spec

### DIFF
--- a/pkg/cloudprovider/provider/packet/provider.go
+++ b/pkg/cloudprovider/provider/packet/provider.go
@@ -54,7 +54,6 @@ type RawConfig struct {
 	BillingCycle providerconfig.ConfigVarString   `json:"billingCycle"`
 	InstanceType providerconfig.ConfigVarString   `json:"instanceType"`
 	Facilities   []providerconfig.ConfigVarString `json:"facilities"`
-	OS           providerconfig.ConfigVarString   `json:"os"`
 	Tags         []providerconfig.ConfigVarString `json:"tags"`
 }
 
@@ -64,7 +63,6 @@ type Config struct {
 	BillingCycle string
 	InstanceType string
 	Facilities   []string
-	OS           string
 	Tags         []string
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the unused `OS` field from the packet providerspec

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
