### PR TITLE
Extend cloudproviderinterface to accept providerData on GET

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,3 +36,4 @@ issues:
   - 'eviction\.go:221:4: the surrounding loop is unconditionally terminated'
   - '`client` can be `github.com/kubermatic/machine-controller/vendor/sigs.k8s.io/controller-runtime/pkg/client.Reader`'
   - '`client` can be `github.com/kubermatic/machine-controller/vendor/sigs.k8s.io/controller-runtime/pkg/client.StatusWriter`'
+  - 'cyclomatic complexity 31 of func `verifyMigrateUID` is high'

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -423,7 +423,7 @@ func startControllerViaLeaderElection(runOptions controllerRunOptions) error {
 
 		providerData := &cloudprovidertypes.ProviderData{
 			PVLister: runOptions.pvLister,
-			Updater:  cloudprovidertypes.GetMachineUpdater(ctx, mgr.GetClient()),
+			Update:   cloudprovidertypes.GetMachineUpdater(ctx, mgr.GetClient()),
 		}
 
 		//Migrate MachinesV1Alpha1Machine to ClusterV1Alpha1Machine

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/heptiolabs/healthcheck"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1/migrations"
+	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/clusterinfo"
 	machinecontroller "github.com/kubermatic/machine-controller/pkg/controller/machine"
 	machinehealth "github.com/kubermatic/machine-controller/pkg/health"
@@ -412,8 +413,21 @@ func startControllerViaLeaderElection(runOptions controllerRunOptions) error {
 	// and bad things can happen - the fact it works at the moment doesn't mean it will in the future
 	runController := func(ctx context.Context) {
 
+		mgrSyncPeriod := 5 * time.Minute
+		mgr, err := manager.New(runOptions.cfg, manager.Options{SyncPeriod: &mgrSyncPeriod})
+		if err != nil {
+			glog.Errorf("failed to create manager: %v", err)
+			runOptions.parentCtxDone()
+			return
+		}
+
+		providerData := &cloudprovidertypes.ProviderData{
+			PVLister: runOptions.pvLister,
+			Updater:  cloudprovidertypes.GetMachineUpdater(ctx, mgr.GetClient()),
+		}
+
 		//Migrate MachinesV1Alpha1Machine to ClusterV1Alpha1Machine
-		if err := migrations.MigrateMachinesv1Alpha1MachineToClusterv1Alpha1MachineIfNecessary(ctx, runOptions.ctrlruntimeClient, runOptions.kubeClient); err != nil {
+		if err := migrations.MigrateMachinesv1Alpha1MachineToClusterv1Alpha1MachineIfNecessary(ctx, runOptions.ctrlruntimeClient, runOptions.kubeClient, providerData); err != nil {
 			glog.Errorf("Migration to clusterv1alpha1 failed: %v", err)
 			runOptions.parentCtxDone()
 			return
@@ -426,13 +440,6 @@ func startControllerViaLeaderElection(runOptions controllerRunOptions) error {
 			return
 		}
 
-		mgrSyncPeriod := 5 * time.Minute
-		mgr, err := manager.New(runOptions.cfg, manager.Options{SyncPeriod: &mgrSyncPeriod})
-		if err != nil {
-			glog.Errorf("failed to start kubebuilder manager: %v", err)
-			runOptions.parentCtxDone()
-			return
-		}
 		if err := machinesetcontroller.Add(mgr); err != nil {
 			glog.Errorf("failed to add MachineSet controller to manager: %v", err)
 			runOptions.parentCtxDone()
@@ -459,11 +466,11 @@ func startControllerViaLeaderElection(runOptions controllerRunOptions) error {
 			runOptions.machineInformer,
 			runOptions.machineLister,
 			runOptions.secretSystemNsLister,
-			runOptions.pvLister,
 			runOptions.clusterDNSIPs,
 			runOptions.metrics,
 			runOptions.prometheusRegisterer,
 			runOptions.kubeconfigProvider,
+			providerData,
 			runOptions.joinClusterTimeout,
 			runOptions.externalCloudProvider,
 			runOptions.name,

--- a/pkg/apis/cluster/v1alpha1/migrations/migrations.go
+++ b/pkg/apis/cluster/v1alpha1/migrations/migrations.go
@@ -24,6 +24,7 @@ import (
 	machinecontrolleradmission "github.com/kubermatic/machine-controller/pkg/admission"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1/conversions"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider"
+	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	machinecontroller "github.com/kubermatic/machine-controller/pkg/controller/machine"
 	"github.com/kubermatic/machine-controller/pkg/machines"
 	machinesv1alpha1 "github.com/kubermatic/machine-controller/pkg/machines/v1alpha1"
@@ -136,7 +137,9 @@ func MigrateProviderConfigToProviderSpecIfNecesary(ctx context.Context, config *
 }
 
 func MigrateMachinesv1Alpha1MachineToClusterv1Alpha1MachineIfNecessary(
-	ctx context.Context, client ctrlruntimeclient.Client, kubeClient kubernetes.Interface) error {
+	ctx context.Context, client ctrlruntimeclient.Client,
+	kubeClient kubernetes.Interface,
+	providerData *cloudprovidertypes.ProviderData) error {
 
 	err := client.Get(ctx, types.NamespacedName{Name: machines.CRDName}, &apiextensionsv1beta1.CustomResourceDefinition{})
 	if err != nil {
@@ -152,7 +155,7 @@ func MigrateMachinesv1Alpha1MachineToClusterv1Alpha1MachineIfNecessary(
 		return fmt.Errorf("error when checking for existence of 'machines.cluster.k8s.io' crd: %v", err)
 	}
 
-	if err := migrateMachines(ctx, client, kubeClient); err != nil {
+	if err := migrateMachines(ctx, client, kubeClient, providerData); err != nil {
 		return fmt.Errorf("failed to migrate machines: %v", err)
 	}
 	glog.Infof("Attempting to delete CRD %s", machines.CRDName)
@@ -163,7 +166,7 @@ func MigrateMachinesv1Alpha1MachineToClusterv1Alpha1MachineIfNecessary(
 	return nil
 }
 
-func migrateMachines(ctx context.Context, client ctrlruntimeclient.Client, kubeClient kubernetes.Interface) error {
+func migrateMachines(ctx context.Context, client ctrlruntimeclient.Client, kubeClient kubernetes.Interface, providerData *cloudprovidertypes.ProviderData) error {
 	glog.Infof("Starting migration for machine.machines.k8s.io/v1alpha1 to machine.cluster.k8s.io/v1alpha1")
 
 	// Get machinesv1Alpha1Machines
@@ -269,7 +272,7 @@ func migrateMachines(ctx context.Context, client ctrlruntimeclient.Client, kubeC
 			// Block until we can actually GET the instance with the new UID
 			var isMigrated bool
 			for i := 0; i < 100; i++ {
-				if _, err := prov.Get(finalClusterV1Alpha1Machine); err == nil {
+				if _, err := prov.Get(finalClusterV1Alpha1Machine, providerData); err == nil {
 					isMigrated = true
 					break
 				}

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -451,7 +451,7 @@ func getVpc(client *ec2.EC2, id string) (*ec2.Vpc, error) {
 	return vpcOut.Vpcs[0], nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	config, pc, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -575,8 +575,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Ma
 	return awsInstance, nil
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
-	instance, err := p.Get(machine)
+func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
+	instance, err := p.get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return true, nil
@@ -611,7 +611,11 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.Mach
 	return false, nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+	return p.get(machine)
+}
+
+func (p *provider) get(machine *v1alpha1.Machine) (*awsInstance, error) {
 	config, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -696,7 +700,7 @@ func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]s
 }
 
 func (p *provider) MigrateUID(machine *v1alpha1.Machine, new types.UID) error {
-	instance, err := p.Get(machine)
+	instance, err := p.get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return nil

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -371,7 +371,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 	publicIPName := ifaceName + "-pubip"
 	var publicIP *network.PublicIPAddress
 	if config.AssignPublicIP {
-		if err = data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
+		if err = data.Update(machine, func(updatedMachine *v1alpha1.Machine) {
 			if !kuberneteshelper.HasFinalizer(updatedMachine, finalizerPublicIP) {
 				updatedMachine.Finalizers = append(updatedMachine.Finalizers, finalizerPublicIP)
 			}
@@ -384,7 +384,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 		}
 	}
 
-	if err := data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
+	if err := data.Update(machine, func(updatedMachine *v1alpha1.Machine) {
 		if !kuberneteshelper.HasFinalizer(updatedMachine, finalizerNIC) {
 			updatedMachine.Finalizers = append(updatedMachine.Finalizers, finalizerNIC)
 		}
@@ -442,7 +442,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 	}
 
 	glog.Infof("Creating machine %q", machine.Spec.Name)
-	if err := data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
+	if err := data.Update(machine, func(updatedMachine *v1alpha1.Machine) {
 		if !kuberneteshelper.HasFinalizer(updatedMachine, finalizerDisks) {
 			updatedMachine.Finalizers = append(updatedMachine.Finalizers, finalizerDisks)
 		}
@@ -503,7 +503,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 		}
 	}
 
-	if err := data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
+	if err := data.Update(machine, func(updatedMachine *v1alpha1.Machine) {
 		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerVM)
 	}); err != nil {
 		return false, err
@@ -513,7 +513,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 	if err := deleteDisksByMachineUID(context.TODO(), config, machine.UID); err != nil {
 		return false, fmt.Errorf("failed to remove disks of machine %q: %v", machine.Name, err)
 	}
-	if err := data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
+	if err := data.Update(machine, func(updatedMachine *v1alpha1.Machine) {
 		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerDisks)
 	}); err != nil {
 		return false, err
@@ -523,7 +523,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 	if err := deleteInterfacesByMachineUID(context.TODO(), config, machine.UID); err != nil {
 		return false, fmt.Errorf("failed to remove network interfaces of machine %q: %v", machine.Name, err)
 	}
-	if err := data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
+	if err := data.Update(machine, func(updatedMachine *v1alpha1.Machine) {
 		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerNIC)
 	}); err != nil {
 		return false, err
@@ -533,7 +533,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 	if err := deleteIPAddressesByMachineUID(context.TODO(), config, machine.UID); err != nil {
 		return false, fmt.Errorf("failed to remove public IP addresses of machine %q: %v", machine.Name, err)
 	}
-	if err := data.Updater(machine, func(updatedMachine *v1alpha1.Machine) {
+	if err := data.Update(machine, func(updatedMachine *v1alpha1.Machine) {
 		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerPublicIP)
 	}); err != nil {
 		return false, err

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -271,7 +271,7 @@ func uploadRandomSSHPublicKey(ctx context.Context, service godo.KeysService) (st
 	return newDoKey.Fingerprint, nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -343,8 +343,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Machi
 	return &doInstance{droplet: droplet}, err
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
-	instance, err := p.Get(machine)
+func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
+	instance, err := p.get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return true, nil
@@ -375,7 +375,11 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.Mach
 	return false, nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+	return p.get(machine)
+}
+
+func (p *provider) get(machine *v1alpha1.Machine) (*doInstance, error) {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -83,7 +83,7 @@ func (p *provider) Validate(machinespec v1alpha1.MachineSpec) error {
 	return fmt.Errorf("failing validation as requested")
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	return CloudProviderInstance{}, nil
 }
 
@@ -92,11 +92,11 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (string, string, er
 }
 
 // Create creates a cloud instance according to the given machine
-func (p *provider) Create(_ *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData, _ string) (instance.Instance, error) {
+func (p *provider) Create(_ *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, _ string) (instance.Instance, error) {
 	return CloudProviderInstance{}, nil
 }
 
-func (p *provider) Cleanup(_ *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
+func (p *provider) Cleanup(_ *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
 	return true, nil
 }
 

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -127,7 +127,11 @@ func (p *Provider) Validate(spec v1alpha1.MachineSpec) error {
 }
 
 // Get retrieves a node instance that is associated with the given machine.
-func (p *Provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *Provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+	return p.get(machine)
+}
+
+func (p *Provider) get(machine *v1alpha1.Machine) (*googleInstance, error) {
 	// Read configuration.
 	cfg, err := newConfig(p.resolver, machine.Spec.ProviderSpec)
 	if err != nil {
@@ -186,7 +190,7 @@ func (p *Provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 // Create inserts a cloud instance according to the given machine.
 func (p *Provider) Create(
 	machine *v1alpha1.Machine,
-	data *cloudprovidertypes.MachineCreateDeleteData,
+	data *cloudprovidertypes.ProviderData,
 	userdata string,
 ) (instance.Instance, error) {
 	// Read configuration.
@@ -255,14 +259,11 @@ func (p *Provider) Create(
 		return nil, newError(common.InvalidConfigurationMachineError, errInsertInstance, err)
 	}
 	// Retrieve it to get a full qualified instance.
-	return p.Get(machine)
+	return p.Get(machine, data)
 }
 
 // Cleanup deletes the instance associated with the machine and all associated resources.
-func (p *Provider) Cleanup(
-	machine *v1alpha1.Machine,
-	data *cloudprovidertypes.MachineCreateDeleteData,
-) (bool, error) {
+func (p *Provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
 	// Read configuration.
 	cfg, err := newConfig(p.resolver, machine.Spec.ProviderSpec)
 	if err != nil {
@@ -323,11 +324,14 @@ func (p *Provider) MigrateUID(machine *v1alpha1.Machine, newUID types.UID) error
 		return newError(common.InvalidConfigurationMachineError, errConnect, err)
 	}
 	// Retrieve instance.
-	inst, err := p.Get(machine)
+	inst, err := p.get(machine)
 	if err != nil {
+		if err == errors.ErrInstanceNotFound {
+			return nil
+		}
 		return err
 	}
-	ci := inst.(*googleInstance).ci
+	ci := inst.ci
 	// Create new labels and set them.
 	labels := ci.Labels
 	if labels == nil {

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -156,7 +156,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -245,8 +245,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Machi
 	return &hetznerServer{server: serverCreateRes.Server}, nil
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
-	instance, err := p.Get(machine)
+func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
+	instance, err := p.Get(machine, data)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return true, nil
@@ -279,7 +279,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	return spec, nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -142,7 +142,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfig.
 	return &config, &pconfig, nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -239,7 +239,7 @@ func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]s
 	return labels, err
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -331,7 +331,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Machi
 
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
+func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return false, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -223,7 +223,7 @@ func createRandomPassword() (string, error) {
 	return rootPass, nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -285,8 +285,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Machi
 	return &linodeInstance{linode: linode}, err
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
-	instance, err := p.Get(machine)
+func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
+	instance, err := p.Get(machine, data)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return true, nil
@@ -326,7 +326,7 @@ func getListOptions(name string) *linodego.ListOptions {
 	return listOptions
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -813,7 +813,7 @@ func (p *provider) cleanupFloatingIP(machine *v1alpha1.Machine, updater cloudpro
 	if err := osfloatingips.Delete(netClient, floatingIPID).ExtractErr(); err != nil && err.Error() != "Resource not found" {
 		return fmt.Errorf("failed to delete floating ip %s: %v", floatingIPID, err)
 	}
-	if _, err := updater(machine, func(m *v1alpha1.Machine) {
+	if err := updater(machine, func(m *v1alpha1.Machine) {
 		finalizers := sets.NewString(m.Finalizers...)
 		finalizers.Delete(floatingIPReleaseFinalizer)
 		m.Finalizers = finalizers.List()
@@ -857,7 +857,7 @@ func assignFloatingIPToInstance(machineUpdater cloudprovidertypes.MachineUpdater
 		if ip, err = createFloatingIP(client, region, port.ID, floatingIPPool); err != nil {
 			return osErrorToTerminalError(err, "failed to allocate a floating ip")
 		}
-		if _, err = machineUpdater(machine, func(m *v1alpha1.Machine) {
+		if err := machineUpdater(machine, func(m *v1alpha1.Machine) {
 			m.Finalizers = append(m.Finalizers, floatingIPReleaseFinalizer)
 			if m.Annotations == nil {
 				m.Annotations = map[string]string{}

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -462,7 +462,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 
 	// Find a free FloatingIP or allocate a new one
 	if c.FloatingIPPool != "" {
-		if err := assignFloatingIPToInstance(data.Updater, machine, client, server.ID, c.FloatingIPPool, c.Region, network); err != nil {
+		if err := assignFloatingIPToInstance(data.Update, machine, client, server.ID, c.FloatingIPPool, c.Region, network); err != nil {
 			defer deleteInstanceDueToFatalLogged(computeClient, server.ID)
 			return nil, fmt.Errorf("failed to assign a floating ip to instance %s: %v", server.ID, err)
 		}
@@ -524,7 +524,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			if hasFloatingIPReleaseFinalizer {
-				if err := p.cleanupFloatingIP(machine, data.Updater); err != nil {
+				if err := p.cleanupFloatingIP(machine, data.Update); err != nil {
 					return false, fmt.Errorf("failed to clean up floating ip: %v", err)
 				}
 			}
@@ -556,7 +556,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 	}
 
 	if hasFloatingIPReleaseFinalizer {
-		return false, p.cleanupFloatingIP(machine, data.Updater)
+		return false, p.cleanupFloatingIP(machine, data.Update)
 	}
 
 	return false, nil

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -388,7 +388,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, machineCreateDeleteData *cloudprovidertypes.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	c, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -462,7 +462,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, machineCreateDeleteData *cl
 
 	// Find a free FloatingIP or allocate a new one
 	if c.FloatingIPPool != "" {
-		if err := assignFloatingIPToInstance(machineCreateDeleteData.Updater, machine, client, server.ID, c.FloatingIPPool, c.Region, network); err != nil {
+		if err := assignFloatingIPToInstance(data.Updater, machine, client, server.ID, c.FloatingIPPool, c.Region, network); err != nil {
 			defer deleteInstanceDueToFatalLogged(computeClient, server.ID)
 			return nil, fmt.Errorf("failed to assign a floating ip to instance %s: %v", server.ID, err)
 		}
@@ -514,17 +514,17 @@ func deleteInstanceDueToFatalLogged(computeClient *gophercloud.ServiceClient, se
 	glog.V(0).Infof("Instance %s got deleted", serverID)
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, machineCreateDeleteData *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
+func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
 	var hasFloatingIPReleaseFinalizer bool
 	if finalizers := sets.NewString(machine.Finalizers...); finalizers.Has(floatingIPReleaseFinalizer) {
 		hasFloatingIPReleaseFinalizer = true
 	}
 
-	instance, err := p.Get(machine)
+	instance, err := p.Get(machine, data)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			if hasFloatingIPReleaseFinalizer {
-				if err := p.cleanupFloatingIP(machine, machineCreateDeleteData.Updater); err != nil {
+				if err := p.cleanupFloatingIP(machine, data.Updater); err != nil {
 					return false, fmt.Errorf("failed to clean up floating ip: %v", err)
 				}
 			}
@@ -556,13 +556,13 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, machineCreateDeleteData *c
 	}
 
 	if hasFloatingIPReleaseFinalizer {
-		return false, p.cleanupFloatingIP(machine, machineCreateDeleteData.Updater)
+		return false, p.cleanupFloatingIP(machine, data.Updater)
 	}
 
 	return false, nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	c, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/packet/provider.go
+++ b/pkg/cloudprovider/provider/packet/provider.go
@@ -205,7 +205,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	c, _, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -245,8 +245,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Machi
 	return &packetDevice{device: device}, nil
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
-	instance, err := p.Get(machine)
+func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
+	instance, err := p.Get(machine, data)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return true, nil
@@ -285,7 +285,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	return spec, nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	device, _, err := p.getPacketDevice(machine)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -359,7 +359,7 @@ func machineInvalidConfigurationTerminalError(err error) error {
 	}
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.MachineCreateDeleteData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -456,11 +456,11 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Machi
 	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value}, nil
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
+func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if _, err := p.Get(machine); err != nil {
+	if _, err := p.Get(machine, data); err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return true, nil
 		}
@@ -568,7 +568,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.M
 	return false, nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
+func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	ctx := context.Background()
 
 	config, pc, _, err := p.getConfig(machine.Spec.ProviderSpec)
@@ -612,7 +612,7 @@ func (p *provider) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
 	}
 	if fieldValue != machine.Spec.Name {
 		// TODO: This should leverage .Cleanup, but we can currently not do that,
-		// because .Cleanup needs cloud.MachineCreateDeleteData which we don't have here
+		// because .Cleanup needs cloud.ProviderData which we don't have here
 		if powerState == types.VirtualMachinePowerStatePoweredOn {
 			powerOffTask, err := virtualMachine.PowerOff(ctx)
 			if err != nil {

--- a/pkg/cloudprovider/types/types.go
+++ b/pkg/cloudprovider/types/types.go
@@ -86,7 +86,7 @@ type MachineUpdater func(*clusterv1alpha1.Machine, ...MachineModifier) error
 
 // ProviderData is the struct the cloud providers get when creating or deleting an instance
 type ProviderData struct {
-	Updater  MachineUpdater
+	Update   MachineUpdater
 	PVLister listerscorev1.PersistentVolumeLister
 }
 

--- a/pkg/cloudprovider/types/types.go
+++ b/pkg/cloudprovider/types/types.go
@@ -43,19 +43,19 @@ type Provider interface {
 	// See v1alpha1.MachineStatus for more info and TerminalError type
 	//
 	// In case the instance cannot be found, github.com/kubermatic/machine-controller/pkg/cloudprovider/errors/ErrInstanceNotFound will be returned
-	Get(machine *clusterv1alpha1.Machine) (instance.Instance, error)
+	Get(machine *clusterv1alpha1.Machine, data *ProviderData) (instance.Instance, error)
 
 	// GetCloudConfig will return the cloud provider specific cloud-config, which gets consumed by the kubelet
 	GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config string, name string, err error)
 
 	// Create creates a cloud instance according to the given machine
-	Create(machine *clusterv1alpha1.Machine, data *MachineCreateDeleteData, userdata string) (instance.Instance, error)
+	Create(machine *clusterv1alpha1.Machine, data *ProviderData, userdata string) (instance.Instance, error)
 
 	// Cleanup will delete the instance associated with the machine and all associated resources.
 	// If all resources have been cleaned up, true will be returned.
 	// In case the cleanup involves ansynchronous deletion of resources & those resources are not gone yet,
 	// false should be returned. This is to indicate that the cleanup is not done, but needs to be called again at a later point
-	Cleanup(machine *clusterv1alpha1.Machine, data *MachineCreateDeleteData) (bool, error)
+	Cleanup(machine *clusterv1alpha1.Machine, data *ProviderData) (bool, error)
 
 	// MachineMetricsLabels returns labels used for the Prometheus metrics
 	// about created machines, e.g. instance type, instance size, region
@@ -76,8 +76,8 @@ type Provider interface {
 // MachineUpdater defines a function to persist an update to a machine
 type MachineUpdater func(*clusterv1alpha1.Machine, func(*clusterv1alpha1.Machine)) (*clusterv1alpha1.Machine, error)
 
-// MachineCreateDeleteData is the struct the cloud providers get when creating or deleting an instance
-type MachineCreateDeleteData struct {
+// ProviderData is the struct the cloud providers get when creating or deleting an instance
+type ProviderData struct {
 	Updater  MachineUpdater
 	PVLister listerscorev1.PersistentVolumeLister
 }

--- a/pkg/cloudprovider/validationwrapper.go
+++ b/pkg/cloudprovider/validationwrapper.go
@@ -64,8 +64,8 @@ func (w *cachingValidationWrapper) Validate(spec v1alpha1.MachineSpec) error {
 }
 
 // Get just calls the underlying cloudproviders Get
-func (w *cachingValidationWrapper) Get(machine *v1alpha1.Machine) (instance.Instance, error) {
-	return w.actualProvider.Get(machine)
+func (w *cachingValidationWrapper) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+	return w.actualProvider.Get(machine, data)
 }
 
 // GetCloudConfig just calls the underlying cloudproviders GetCloudConfig
@@ -74,12 +74,12 @@ func (w *cachingValidationWrapper) GetCloudConfig(spec v1alpha1.MachineSpec) (st
 }
 
 // Create just calls the underlying cloudproviders Create
-func (w *cachingValidationWrapper) Create(m *v1alpha1.Machine, mcd *cloudprovidertypes.MachineCreateDeleteData, cloudConfig string) (instance.Instance, error) {
+func (w *cachingValidationWrapper) Create(m *v1alpha1.Machine, mcd *cloudprovidertypes.ProviderData, cloudConfig string) (instance.Instance, error) {
 	return w.actualProvider.Create(m, mcd, cloudConfig)
 }
 
 // Cleanup just calls the underlying cloudproviders Cleanup
-func (w *cachingValidationWrapper) Cleanup(m *v1alpha1.Machine, mcd *cloudprovidertypes.MachineCreateDeleteData) (bool, error) {
+func (w *cachingValidationWrapper) Cleanup(m *v1alpha1.Machine, mcd *cloudprovidertypes.ProviderData) (bool, error) {
 	return w.actualProvider.Cleanup(m, mcd)
 }
 

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -303,7 +303,7 @@ func (c *Controller) getNodeByNodeRef(nodeRef *corev1.ObjectReference) (*corev1.
 }
 
 func (c *Controller) updateMachine(m *clusterv1alpha1.Machine, modify ...cloudprovidertypes.MachineModifier) error {
-	return c.providerData.Updater(m, modify...)
+	return c.providerData.Update(m, modify...)
 }
 
 // updateMachine updates machine's ErrorMessage and ErrorReason regardless if they were set or not

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -92,7 +92,7 @@ type Controller struct {
 	clusterDNSIPs                    []net.IP
 	metrics                          *MetricsCollection
 	kubeconfigProvider               KubeconfigProvider
-	machineCreateDeleteData          *cloudprovidertypes.MachineCreateDeleteData
+	machineCreateDeleteData          *cloudprovidertypes.ProviderData
 	userDataManager                  *userdatamanager.Manager
 	joinClusterTimeout               *time.Duration
 	externalCloudProvider            bool
@@ -165,7 +165,7 @@ func NewMachineController(
 		skipEvictionAfter:                skipEvictionAfter,
 	}
 
-	controller.machineCreateDeleteData = &cloudprovidertypes.MachineCreateDeleteData{
+	controller.machineCreateDeleteData = &cloudprovidertypes.ProviderData{
 		Updater:  controller.updateMachine,
 		PVLister: pvLister,
 	}

--- a/test/e2e/provisioning/migrateuidscenario.go
+++ b/test/e2e/provisioning/migrateuidscenario.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provisioning
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/clientcmd"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
@@ -52,10 +54,14 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 	if err != nil {
 		return fmt.Errorf("error building kubernetes clientset: %v", err)
 	}
+	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
+	if err != nil {
+		return fmt.Errorf("failed to construct ctrlruntimeclient: %v", err)
+	}
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Minute*15)
 	pvLister := kubeInformerFactory.Core().V1().PersistentVolumes().Lister()
-	machineCreateDeleteData := &cloudprovidertypes.MachineCreateDeleteData{
-		Updater:  machineUpdater,
+	providerData := &cloudprovidertypes.ProviderData{
+		Updater:  cloudprovidertypes.GetMachineUpdater(context.Background(), client),
 		PVLister: pvLister,
 	}
 
@@ -96,7 +102,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 	// Step 0: Create instance with old UID
 	maxTries := 15
 	for i := 0; i < maxTries; i++ {
-		_, err := prov.Get(machine)
+		_, err := prov.Get(machine, providerData)
 		if err != nil {
 			if err != cloudprovidererrors.ErrInstanceNotFound {
 				if i < maxTries-1 {
@@ -106,7 +112,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 				}
 				return fmt.Errorf("failed to get machine %s before creating it: %v", machine.Name, err)
 			}
-			_, err := prov.Create(machine, machineCreateDeleteData, "#cloud-config\n")
+			_, err := prov.Create(machine, providerData, "#cloud-config\n")
 			if err != nil {
 				if i < maxTries-1 {
 					time.Sleep(10 * time.Second)
@@ -121,7 +127,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 
 	// Step 1: Verify we can successfully get the instance
 	for i := 0; i < maxTries; i++ {
-		if _, err := prov.Get(machine); err != nil {
+		if _, err := prov.Get(machine, providerData); err != nil {
 			if i < maxTries-1 {
 				glog.V(4).Infof("failed to get instance for machine %s before migrating on try %v with err=%v, will retry", machine.Name, i, err)
 				time.Sleep(10 * time.Second)
@@ -148,7 +154,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 
 	// Step 3: Verify we can successfully get the instance with the new UID
 	for i := 0; i < maxTries; i++ {
-		if _, err := prov.Get(machine); err != nil {
+		if _, err := prov.Get(machine, providerData); err != nil {
 			if i < maxTries-1 {
 				time.Sleep(10 * time.Second)
 				glog.V(4).Infof("failed to get instance for machine %s after migrating on try %v with err=%v, will retry", machine.Name, i, err)
@@ -163,7 +169,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 	for i := 0; i < maxTries; i++ {
 
 		// Deletion part 0: Delete and continue on err if there are tries left
-		done, err := prov.Cleanup(machine, machineCreateDeleteData)
+		done, err := prov.Cleanup(machine, providerData)
 		if err != nil {
 			if i < maxTries-1 {
 				glog.V(4).Infof("Failed to delete machine %s on try %v with err=%v, will retry", machine.Name, i, err)
@@ -179,7 +185,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 		}
 
 		// Deletion part 1: Get and continue if err != cloudprovidererrors.ErrInstanceNotFound if there are tries left
-		_, err = prov.Get(machine)
+		_, err = prov.Get(machine, providerData)
 		if err != nil && err == cloudprovidererrors.ErrInstanceNotFound {
 			break
 		}
@@ -193,9 +199,4 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 	}
 
 	return nil
-}
-
-func machineUpdater(machine *v1alpha1.Machine, updater func(*v1alpha1.Machine)) (*v1alpha1.Machine, error) {
-	updater(machine)
-	return machine, nil
 }

--- a/test/e2e/provisioning/migrateuidscenario.go
+++ b/test/e2e/provisioning/migrateuidscenario.go
@@ -61,7 +61,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, time.Minute*15)
 	pvLister := kubeInformerFactory.Core().V1().PersistentVolumes().Lister()
 	providerData := &cloudprovidertypes.ProviderData{
-		Updater:  cloudprovidertypes.GetMachineUpdater(context.Background(), client),
+		Update:   cloudprovidertypes.GetMachineUpdater(context.Background(), client),
 		PVLister: pvLister,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Extends cloudproviderinterface to accept providerData on GET
Ref: https://github.com/kubermatic/machine-controller/pull/531#discussion_r284574679

Unfortunately the PR got bigger than expected, I recommend reviewing it commit by commit :S

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```

/assign @mrIncompetent 
