### PR TITLE
Update cluster-api to 2ec456177c0e8f0a903f4e746d44baaae54cc591

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1448,7 +1448,7 @@
   source = "github.com/kubevirt/kubevirt"
 
 [[projects]]
-  digest = "1:b170e3fa79b80326857ff0ba0aaa266be428392f6b24246f0aecf21a5527a58b"
+  digest = "1:277b9f21a736a3361d67daa0f68308184219a4fb90967c116aaed5947214ab6d"
   name = "sigs.k8s.io/cluster-api"
   packages = [
     "pkg/apis/cluster/common",
@@ -1470,7 +1470,7 @@
     "pkg/util",
   ]
   pruneopts = "NUT"
-  revision = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
+  revision = "2ec456177c0e8f0a903f4e746d44baaae54cc591"
 
 [[projects]]
   digest = "1:52e73ab64f1026315715c24fd05d9b9544a51e1007a3f48dc61937ad3a1a2c2b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,7 +114,7 @@ required = [
 
 [[constraint]]
   name = "sigs.k8s.io/cluster-api"
-  revision = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
+  revision = "2ec456177c0e8f0a903f4e746d44baaae54cc591"
 
 [[constraint]]
   name = "gopkg.in/gcfg.v1"

--- a/pkg/apis/cluster/v1alpha1/conversions/conversions.go
+++ b/pkg/apis/cluster/v1alpha1/conversions/conversions.go
@@ -31,7 +31,7 @@ import (
 const (
 	TypeRevisionAnnotationName = "machine-controller/machine-type-revision"
 
-	TypeRevisionCurrentVersion = "c63bf6f67ab631a449b6eb76dfe29458441051e0"
+	TypeRevisionCurrentVersion = "2ec456177c0e8f0a903f4e746d44baaae54cc591"
 )
 
 func Convert_MachinesV1alpha1Machine_To_ClusterV1alpha1Machine(in *machinesv1alpha1.Machine, out *clusterv1alpha1.Machine) error {

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/aws.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
+    machine-controller/machine-type-revision: 2ec456177c0e8f0a903f4e746d44baaae54cc591
   creationTimestamp: null
   finalizers:
   - machine-delete-finalizer

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/azure.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/azure.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
+    machine-controller/machine-type-revision: 2ec456177c0e8f0a903f4e746d44baaae54cc591
   creationTimestamp: null
   name: azure
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/digitalocean.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/digitalocean.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
+    machine-controller/machine-type-revision: 2ec456177c0e8f0a903f4e746d44baaae54cc591
   creationTimestamp: null
   name: digitalocean
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/hetzner.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/hetzner.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
+    machine-controller/machine-type-revision: 2ec456177c0e8f0a903f4e746d44baaae54cc591
   creationTimestamp: null
   name: hetzner
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/linode.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/linode.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
+    machine-controller/machine-type-revision: 2ec456177c0e8f0a903f4e746d44baaae54cc591
   creationTimestamp: null
   name: linode
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/openstack.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/openstack.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
+    machine-controller/machine-type-revision: 2ec456177c0e8f0a903f4e746d44baaae54cc591
   creationTimestamp: null
   name: openstack
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/vsphere-static-ip.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/vsphere-static-ip.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
+    machine-controller/machine-type-revision: 2ec456177c0e8f0a903f4e746d44baaae54cc591
   creationTimestamp: null
   name: vsphere-static-ip
   namespace: kube-system

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/vsphere.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/vsphere.yaml
@@ -1,6 +1,6 @@
 metadata:
   annotations:
-    machine-controller/machine-type-revision: c63bf6f67ab631a449b6eb76dfe29458441051e0
+    machine-controller/machine-type-revision: 2ec456177c0e8f0a903f4e746d44baaae54cc591
   creationTimestamp: null
   name: vsphere
   namespace: kube-system

--- a/vendor/sigs.k8s.io/cluster-api/logos/LICENSE.md
+++ b/vendor/sigs.k8s.io/cluster-api/logos/LICENSE.md
@@ -1,0 +1,13 @@
+All artwork in this repo is made available under the Linux Foundation trademark
+usage [guidelines](https://www.linuxfoundation.org/trademark-usage/).
+
+This text from those guidelines, and the correct and incorrect usage examples, are
+particularly helpful:
+
+> Certain marks of The Linux Foundation have been created to enable you to
+> communicate compatibility or interoperability of software or products.
+> In addition to the requirement that any use of a mark to make an assertion
+> of compatibility must, of course, be accurate, the use of these marks must
+> avoid confusion regarding The Linux Foundation’s association with the product.
+> The use of the mark cannot imply that The Linux Foundation or its projects are
+> sponsoring or endorsing the product.

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/cluster_types.go
@@ -31,6 +31,7 @@ const ClusterFinalizer = "cluster.cluster.k8s.io"
 /// [Cluster]
 // Cluster is the Schema for the clusters API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=cl
 // +kubebuilder:subresource:status
 type Cluster struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machine_types.go
@@ -37,9 +37,11 @@ const (
 /// [Machine]
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=ma
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Machine status such as Terminating/Pending/Running/Failed etc"
+// +kubebuilder:printcolumn:name="NodeName",type="string",JSONPath=".status.nodeRef.name",description="Node name associated with this machine",priority=1
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineclass_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineclass_types.go
@@ -30,6 +30,7 @@ import (
 // across multiple Machines / MachineSets / MachineDeployments.
 // +k8s:openapi-gen=true
 // +resource:path=machineclasses
+// +kubebuilder:resource:shortName=mc
 type MachineClass struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -167,6 +167,7 @@ type MachineDeploymentStatus struct {
 /// [MachineDeployment]
 // MachineDeployment is the Schema for the machinedeployments API
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=md
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 type MachineDeployment struct {

--- a/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1/machineset_types.go
@@ -32,6 +32,7 @@ import (
 /// [MachineSet]
 // MachineSet ensures that a specified number of machines replicas are running at any given time.
 // +k8s:openapi-gen=true
+// +kubebuilder:resource:shortName=ms
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
 type MachineSet struct {

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/machinedeployment_controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/machinedeployment_controller.go
@@ -40,13 +40,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+// controllerName is the name of this controller
+const controllerName = "machinedeployment-controller"
+
 var (
 	// controllerKind contains the schema.GroupVersionKind for this controller type.
 	controllerKind = v1alpha1.SchemeGroupVersion.WithKind("MachineDeployment")
 )
-
-// controllerName is the name of this controller
-const controllerName = "machinedeployment-controller"
 
 // ReconcileMachineDeployment reconciles a MachineDeployment object.
 type ReconcileMachineDeployment struct {
@@ -92,7 +92,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler, mapFn handler.ToRequestsFu
 		return err
 	}
 
-	// Map MachineSet changes to MachineDeployment.
+	// Watch for changes to MachineSets using a mapping function to MachineDeployment.
+	// This watcher is required for use cases like adoption. In case a MachineSet doesn't have
+	// a controller reference, it'll look for potential matching MachineDeployments to reconcile.
 	err = c.Watch(
 		&source.Kind{Type: &v1alpha1.MachineSet{}},
 		&handler.EnqueueRequestsFromMapFunc{ToRequests: mapFn},
@@ -104,63 +106,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler, mapFn handler.ToRequestsFu
 	return nil
 }
 
-func (r *ReconcileMachineDeployment) getMachineSetsForDeployment(d *v1alpha1.MachineDeployment) ([]*v1alpha1.MachineSet, error) {
-	// List all MachineSets to find those we own but that no longer match our selector.
-	machineSets := &v1alpha1.MachineSetList{}
-	listOptions := &client.ListOptions{Namespace: d.Namespace}
-
-	if err := r.Client.List(context.Background(), listOptions, machineSets); err != nil {
-		return nil, err
-	}
-
-	filteredMS := make([]*v1alpha1.MachineSet, 0, len(machineSets.Items))
-	for idx := range machineSets.Items {
-		ms := &machineSets.Items[idx]
-
-		selector, err := metav1.LabelSelectorAsSelector(&d.Spec.Selector)
-		if err != nil {
-			klog.Errorf("Skipping machineset %v, failed to get label selector from spec selector.", ms.Name)
-			continue
-		}
-
-		// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
-		if selector.Empty() {
-			klog.Warningf("Skipping machineset %v as the selector is empty.", ms.Name)
-			continue
-		}
-
-		if !selector.Matches(labels.Set(ms.Labels)) {
-			klog.V(4).Infof("Skipping machineset %v, label mismatch.", ms.Name)
-			continue
-		}
-
-		// Attempt to adopt machine if it meets previous conditions and it has no controller references.
-		if metav1.GetControllerOf(ms) == nil {
-			if err := r.adoptOrphan(d, ms); err != nil {
-				klog.Warningf("Failed to adopt MachineSet %q into MachineDeployment %q: %v", ms.Name, d.Name, err)
-				continue
-			}
-		}
-
-		if !metav1.IsControlledBy(ms, d) {
-			continue
-		}
-
-		filteredMS = append(filteredMS, ms)
-	}
-
-	return filteredMS, nil
-}
-
-func (r *ReconcileMachineDeployment) adoptOrphan(deployment *v1alpha1.MachineDeployment, machineSet *v1alpha1.MachineSet) error {
-	newRef := *metav1.NewControllerRef(deployment, controllerKind)
-	machineSet.OwnerReferences = append(machineSet.OwnerReferences, newRef)
-	return r.Client.Update(context.Background(), machineSet)
-}
-
 // Reconcile reads that state of the cluster for a MachineDeployment object and makes changes based on the state read
-// and what is in the MachineDeployment.Spec
-// +kubebuilder:rbac:groups=cluster.k8s.io,resources=machinedeployments,verbs=get;list;watch;create;update;patch;delete
+// and what is in the MachineDeployment.Spec.
+//
+// +kubebuilder:rbac:groups=cluster.k8s.io,resources=machinedeployments;machinedeployments/status,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileMachineDeployment) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the MachineDeployment instance
 	d := &v1alpha1.MachineDeployment{}
@@ -174,6 +123,13 @@ func (r *ReconcileMachineDeployment) Reconcile(request reconcile.Request) (recon
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+
+	// Ignore deleted MachineDeployments, this can happen when foregroundDeletion
+	// is enabled
+	if d.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
 	result, err := r.reconcile(ctx, d)
 	if err != nil {
 		klog.Errorf("Failed to reconcile MachineDeployment %q: %v", request.NamespacedName, err)
@@ -191,14 +147,14 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1alpha1.
 		if d.Status.ObservedGeneration < d.Generation {
 			d.Status.ObservedGeneration = d.Generation
 			if err := r.Status().Update(context.Background(), d); err != nil {
-				klog.Warningf("Failed to update status for deployment %v. %v", d.Name, err)
+				klog.Warningf("Failed to update status for MachineDeployment %q: %v", d.Name, err)
 				return reconcile.Result{}, err
 			}
 		}
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true}, nil
 	}
 
-	// Make sure that label selector can match template's labels.
+	// Make sure that label selector can match the template's labels.
 	// TODO(vincepri): Move to a validation (admission) webhook when supported.
 	selector, err := metav1.LabelSelectorAsSelector(&d.Spec.Selector)
 	if err != nil {
@@ -206,7 +162,7 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1alpha1.
 	}
 
 	if !selector.Matches(labels.Set(d.Spec.Template.Labels)) {
-		return reconcile.Result{}, errors.Errorf("failed validation on MachineDeployment %q label selector, cannot match any machines ", d.Name)
+		return reconcile.Result{}, errors.Errorf("failed validation on MachineDeployment %q label selector, cannot match Machine template labels", d.Name)
 	}
 
 	// Cluster might be nil as some providers might not require a cluster object
@@ -241,7 +197,7 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1alpha1.
 		}
 
 		// Since adding the finalizer updates the object return to avoid later update issues
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	msList, err := r.getMachineSetsForDeployment(d)
@@ -270,9 +226,10 @@ func (r *ReconcileMachineDeployment) reconcile(ctx context.Context, d *v1alpha1.
 	return reconcile.Result{}, errors.Errorf("unexpected deployment strategy type: %s", d.Spec.Strategy.Type)
 }
 
+// getCluster reuturns the Cluster associated with the MachineDeployment, if any.
 func (r *ReconcileMachineDeployment) getCluster(d *v1alpha1.MachineDeployment) (*v1alpha1.Cluster, error) {
 	if d.Spec.Template.Labels[v1alpha1.MachineClusterLabelName] == "" {
-		klog.Infof("Deployment %q in namespace %q doesn't specify %q label, assuming nil cluster", d.Name, v1alpha1.MachineClusterLabelName, d.Namespace)
+		klog.Infof("Deployment %q in namespace %q doesn't specify %q label, assuming nil cluster", d.Name, d.Namespace, v1alpha1.MachineClusterLabelName)
 		return nil, nil
 	}
 
@@ -289,42 +246,65 @@ func (r *ReconcileMachineDeployment) getCluster(d *v1alpha1.MachineDeployment) (
 	return cluster, nil
 }
 
-// getMachineDeploymentsForMachineSet returns a list of Deployments that potentially
-// match a MachineSet.
-func (r *ReconcileMachineDeployment) getMachineDeploymentsForMachineSet(ms *v1alpha1.MachineSet) []*v1alpha1.MachineDeployment {
-	if len(ms.Labels) == 0 {
-		klog.Warningf("No machine deployments found for MachineSet %v because it has no labels", ms.Name)
-		return nil
+// getMachineSetsForDeployment returns a list of MachineSets associated with a MachineDeployment.
+func (r *ReconcileMachineDeployment) getMachineSetsForDeployment(d *v1alpha1.MachineDeployment) ([]*v1alpha1.MachineSet, error) {
+
+	// List all MachineSets to find those we own but that no longer match our selector.
+	machineSets := &v1alpha1.MachineSetList{}
+	listOptions := &client.ListOptions{Namespace: d.Namespace}
+	if err := r.Client.List(context.Background(), listOptions, machineSets); err != nil {
+		return nil, err
 	}
 
-	dList := &v1alpha1.MachineDeploymentList{}
-	listOptions := &client.ListOptions{Namespace: ms.Namespace}
-	if err := r.Client.List(context.Background(), listOptions, dList); err != nil {
-		klog.Warningf("Failed to list machine deployments: %v", err)
-		return nil
-	}
+	filtered := make([]*v1alpha1.MachineSet, 0, len(machineSets.Items))
+	for idx := range machineSets.Items {
+		ms := &machineSets.Items[idx]
 
-	deployments := make([]*v1alpha1.MachineDeployment, 0, len(dList.Items))
-	for idx, d := range dList.Items {
 		selector, err := metav1.LabelSelectorAsSelector(&d.Spec.Selector)
 		if err != nil {
+			klog.Errorf("Skipping MachineSet %q, failed to get label selector from spec selector: %v", ms.Name, err)
 			continue
 		}
 
-		// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
-		if selector.Empty() || !selector.Matches(labels.Set(ms.Labels)) {
+		// If a MachineDeployment with a nil or empty selector creeps in, it should match nothing, not everything.
+		if selector.Empty() {
+			klog.Warningf("Skipping MachineSet %q as the selector is empty", ms.Name)
 			continue
 		}
 
-		deployments = append(deployments, &dList.Items[idx])
+		if !selector.Matches(labels.Set(ms.Labels)) {
+			klog.V(4).Infof("Skipping MachineSet %v, label mismatch", ms.Name)
+			continue
+		}
+
+		// Attempt to adopt machine if it meets previous conditions and it has no controller references.
+		if metav1.GetControllerOf(ms) == nil {
+			if err := r.adoptOrphan(d, ms); err != nil {
+				klog.Warningf("Failed to adopt MachineSet %q into MachineDeployment %q: %v", ms.Name, d.Name, err)
+				continue
+			}
+		}
+
+		if !metav1.IsControlledBy(ms, d) {
+			continue
+		}
+
+		filtered = append(filtered, ms)
 	}
 
-	return deployments
+	return filtered, nil
+}
+
+// adoptOrphan sets the MachineDeployment as a controller OwnerReference to the MachineSet.
+func (r *ReconcileMachineDeployment) adoptOrphan(deployment *v1alpha1.MachineDeployment, machineSet *v1alpha1.MachineSet) error {
+	newRef := *metav1.NewControllerRef(deployment, controllerKind)
+	machineSet.OwnerReferences = append(machineSet.OwnerReferences, newRef)
+	return r.Client.Update(context.Background(), machineSet)
 }
 
 // getMachineMapForDeployment returns the Machines managed by a Deployment.
 //
-// It returns a map from MachineSet UID to a list of Machines controlled by that MS,
+// It returns a map from MachineSet UID to a list of Machines controlled by that MachineSet,
 // according to the Machine's ControllerRef.
 func (r *ReconcileMachineDeployment) getMachineMapForDeployment(d *v1alpha1.MachineDeployment, msList []*v1alpha1.MachineSet) (map[types.UID]*v1alpha1.MachineList, error) {
 	// TODO(droot): double check if previous selector maps correctly to new one.
@@ -367,16 +347,54 @@ func (r *ReconcileMachineDeployment) getMachineMapForDeployment(d *v1alpha1.Mach
 	return machineMap, nil
 }
 
+// getMachineDeploymentsForMachineSet returns a list of MachineDeployments that could potentially match a MachineSet.
+func (r *ReconcileMachineDeployment) getMachineDeploymentsForMachineSet(ms *v1alpha1.MachineSet) []*v1alpha1.MachineDeployment {
+	if len(ms.Labels) == 0 {
+		klog.Warningf("No machine deployments found for MachineSet %q because it has no labels", ms.Name)
+		return nil
+	}
+
+	dList := &v1alpha1.MachineDeploymentList{}
+	listOptions := &client.ListOptions{Namespace: ms.Namespace}
+	if err := r.Client.List(context.Background(), listOptions, dList); err != nil {
+		klog.Warningf("Failed to list machine deployments: %v", err)
+		return nil
+	}
+
+	deployments := make([]*v1alpha1.MachineDeployment, 0, len(dList.Items))
+	for idx, d := range dList.Items {
+		selector, err := metav1.LabelSelectorAsSelector(&d.Spec.Selector)
+		if err != nil {
+			continue
+		}
+
+		// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
+		if selector.Empty() || !selector.Matches(labels.Set(ms.Labels)) {
+			continue
+		}
+
+		deployments = append(deployments, &dList.Items[idx])
+	}
+
+	return deployments
+}
+
+// MachineSetTodeployments is a handler.ToRequestsFunc to be used to enqeue requests for reconciliation
+// for MachineDeployments that might adopt an orphaned MachineSet.
 func (r *ReconcileMachineDeployment) MachineSetToDeployments(o handler.MapObject) []reconcile.Request {
 	result := []reconcile.Request{}
 
 	ms := &v1alpha1.MachineSet{}
 	key := client.ObjectKey{Namespace: o.Meta.GetNamespace(), Name: o.Meta.GetName()}
 	if err := r.Client.Get(context.Background(), key, ms); err != nil {
-		klog.Errorf("Unable to retrieve Machineset %v from store: %v", key, err)
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("Unable to retrieve MachineSet %q for possible MachineDeployment adoption: %v", key, err)
+		}
 		return nil
 	}
 
+	// Check if the controller reference is already set and
+	// return an empty result when one is found.
 	for _, ref := range ms.ObjectMeta.OwnerReferences {
 		if ref.Controller != nil && *ref.Controller {
 			return result

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/rolling.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machinedeployment/rolling.go
@@ -182,6 +182,7 @@ func (r *ReconcileMachineDeployment) cleanupUnhealthyReplicas(oldMSs []*v1alpha1
 	// such that not-ready < ready, unscheduled < scheduled, and pending < running. This ensures that unhealthy replicas will
 	// been deleted first and won't increase unavailability.
 	totalScaledDown := int32(0)
+
 	for _, targetMS := range oldMSs {
 		if targetMS.Spec.Replicas == nil {
 			return nil, 0, errors.Errorf("spec replicas for machine set %v is nil, this is unexpected", targetMS.Name)

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/delete_policy.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/delete_policy.go
@@ -25,7 +25,10 @@ import (
 	"sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
-type deletePriority float64
+type (
+	deletePriority     float64
+	deletePriorityFunc func(machine *v1alpha1.Machine) deletePriority
+)
 
 const (
 
@@ -40,8 +43,6 @@ const (
 
 	secondsPerTenDays float64 = 864000
 )
-
-type deletePriorityFunc func(machine *v1alpha1.Machine) deletePriority
 
 // maps the creation timestamp onto the 0-100 priority range
 func oldestDeletePriority(machine *v1alpha1.Machine) deletePriority {

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/machineset_controller.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/machineset_controller.go
@@ -41,7 +41,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+// controllerName is the name of this controller
+const controllerName = "machineset-controller"
+
 var (
+	// controllerKind contains the schema.GroupVersionKind for this controller type.
 	controllerKind = clusterv1alpha1.SchemeGroupVersion.WithKind("MachineSet")
 
 	// stateConfirmationTimeout is the amount of time allowed to wait for desired state.
@@ -50,9 +54,6 @@ var (
 	// stateConfirmationInterval is the amount of time between polling for the desired state.
 	// The polling is against a local memory cache.
 	stateConfirmationInterval = 100 * time.Millisecond
-
-	// controllerName is the name of this controller
-	controllerName = "machineset-controller"
 )
 
 // Add creates a new MachineSet Controller and adds it to the Manager with default RBAC.
@@ -84,7 +85,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler, mapFn handler.ToRequestsFu
 		return err
 	}
 
-	// Map Machine changes to MachineSets using ControllerRef.
+	// Watch for changes to Machines and reconcile the owner MachineSet.
 	err = c.Watch(
 		&source.Kind{Type: &clusterv1alpha1.Machine{}},
 		&handler.EnqueueRequestForOwner{IsController: true, OwnerType: &clusterv1alpha1.MachineSet{}},
@@ -93,7 +94,9 @@ func add(mgr manager.Manager, r reconcile.Reconciler, mapFn handler.ToRequestsFu
 		return err
 	}
 
-	// Map Machine changes to MachineSets by machining labels.
+	// Watch for changes to Machines using a mapping function to MachineSets.
+	// This watcher is required for use cases like adoption. In case a Machine doesn't have
+	// a controller reference, it'll look for potential matching MachineSet to reconcile.
 	return c.Watch(
 		&source.Kind{Type: &clusterv1alpha1.Machine{}},
 		&handler.EnqueueRequestsFromMapFunc{ToRequests: mapFn},
@@ -107,40 +110,10 @@ type ReconcileMachineSet struct {
 	recorder record.EventRecorder
 }
 
-func (r *ReconcileMachineSet) MachineToMachineSets(o handler.MapObject) []reconcile.Request {
-	result := []reconcile.Request{}
-	m := &clusterv1alpha1.Machine{}
-	key := client.ObjectKey{Namespace: o.Meta.GetNamespace(), Name: o.Meta.GetName()}
-	err := r.Client.Get(context.Background(), key, m)
-	if err != nil {
-		klog.Errorf("Unable to retrieve Machine %v from store: %v", key, err)
-		return nil
-	}
-
-	for _, ref := range m.ObjectMeta.OwnerReferences {
-		if ref.Controller != nil && *ref.Controller {
-			return result
-		}
-	}
-
-	mss := r.getMachineSetsForMachine(m)
-	if len(mss) == 0 {
-		klog.V(4).Infof("Found no machine set for machine: %v", m.Name)
-		return nil
-	}
-
-	for _, ms := range mss {
-		name := client.ObjectKey{Namespace: ms.Namespace, Name: ms.Name}
-		result = append(result, reconcile.Request{NamespacedName: name})
-	}
-
-	return result
-}
-
 // Reconcile reads that state of the cluster for a MachineSet object and makes changes based on the state read
 // and what is in the MachineSet.Spec
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
-// +kubebuilder:rbac:groups=cluster.k8s.io,resources=machinesets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cluster.k8s.io,resources=machinesets;machinesets/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.k8s.io,resources=machines,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileMachineSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	// Fetch the MachineSet instance
@@ -148,12 +121,18 @@ func (r *ReconcileMachineSet) Reconcile(request reconcile.Request) (reconcile.Re
 	machineSet := &clusterv1alpha1.MachineSet{}
 	if err := r.Get(ctx, request.NamespacedName, machineSet); err != nil {
 		if apierrors.IsNotFound(err) {
-			// Object not found, return.  Created objects are automatically garbage collected.
+			// Object not found, return. Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
+	}
+
+	// Ignore deleted MachineSets, this can happen when foregroundDeletion
+	// is enabled
+	if machineSet.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
 	}
 
 	result, err := r.reconcile(ctx, machineSet)
@@ -215,6 +194,11 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 		}
 
 		// Since adding the finalizer updates the object return to avoid later update issues
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	// Return early if the MachineSet is deleted.
+	if !machineSet.ObjectMeta.DeletionTimestamp.IsZero() {
 		return reconcile.Result{}, nil
 	}
 
@@ -251,6 +235,10 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 		return reconcile.Result{}, errors.Wrap(err, "failed to update machine set status")
 	}
 
+	if syncErr != nil {
+		return reconcile.Result{}, errors.Wrapf(syncErr, "failed to sync Machineset replicas")
+	}
+
 	var replicas int32
 	if updatedMS.Spec.Replicas != nil {
 		replicas = *updatedMS.Spec.Replicas
@@ -263,19 +251,20 @@ func (r *ReconcileMachineSet) reconcile(ctx context.Context, machineSet *cluster
 	// exceeds MinReadySeconds could be incorrect.
 	// To avoid an available replica stuck in the ready state, we force a reconcile after MinReadySeconds,
 	// at which point it should confirm any available replica to be available.
-	if syncErr == nil && updatedMS.Spec.MinReadySeconds > 0 &&
+	if updatedMS.Spec.MinReadySeconds > 0 &&
 		updatedMS.Status.ReadyReplicas == replicas &&
 		updatedMS.Status.AvailableReplicas != replicas {
 
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{RequeueAfter: time.Duration(updatedMS.Spec.MinReadySeconds) * time.Second}, nil
 	}
 
 	return reconcile.Result{}, nil
 }
 
+// getCluster reuturns the Cluster associated with the MachineSet, if any.
 func (r *ReconcileMachineSet) getCluster(ms *clusterv1alpha1.MachineSet) (*clusterv1alpha1.Cluster, error) {
 	if ms.Spec.Template.Labels[clusterv1alpha1.MachineClusterLabelName] == "" {
-		klog.Infof("MachineSet %q in namespace %q doesn't specify %q label, assuming nil cluster", ms.Name, clusterv1alpha1.MachineClusterLabelName, ms.Namespace)
+		klog.Infof("MachineSet %q in namespace %q doesn't specify %q label, assuming nil cluster", ms.Name, ms.Namespace, clusterv1alpha1.MachineClusterLabelName)
 		return nil, nil
 	}
 
@@ -292,7 +281,7 @@ func (r *ReconcileMachineSet) getCluster(ms *clusterv1alpha1.MachineSet) (*clust
 	return cluster, nil
 }
 
-// syncReplicas essentially scales machine resources up and down.
+// syncReplicas scales Machine resources up or down.
 func (r *ReconcileMachineSet) syncReplicas(ms *clusterv1alpha1.MachineSet, machines []*clusterv1alpha1.Machine) error {
 	if ms.Spec.Replicas == nil {
 		return errors.Errorf("the Replicas field in Spec for machineset %v is nil, this should not be allowed", ms.Name)
@@ -369,8 +358,8 @@ func (r *ReconcileMachineSet) syncReplicas(ms *clusterv1alpha1.MachineSet, machi
 	return nil
 }
 
-// createMachine creates a machine resource.
-// the name of the newly created resource is going to be created by the API server, we set the generateName field
+// createMachine creates a Machine resource. The name of the newly created resource is going
+// to be created by the API server, we set the generateName field.
 func (r *ReconcileMachineSet) createMachine(machineSet *clusterv1alpha1.MachineSet) *clusterv1alpha1.Machine {
 	gv := clusterv1alpha1.SchemeGroupVersion
 	machine := &clusterv1alpha1.Machine{
@@ -384,7 +373,6 @@ func (r *ReconcileMachineSet) createMachine(machineSet *clusterv1alpha1.MachineS
 	machine.ObjectMeta.GenerateName = fmt.Sprintf("%s-", machineSet.Name)
 	machine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(machineSet, controllerKind)}
 	machine.Namespace = machineSet.Namespace
-
 	return machine
 }
 
@@ -407,6 +395,7 @@ func shouldExcludeMachine(machineSet *clusterv1alpha1.MachineSet, machine *clust
 	return false
 }
 
+// adoptOrphan sets the MachineSet as a controller OwnerReference to the Machine.
 func (r *ReconcileMachineSet) adoptOrphan(machineSet *clusterv1alpha1.MachineSet, machine *clusterv1alpha1.Machine) error {
 	newRef := *metav1.NewControllerRef(machineSet, controllerKind)
 	machine.OwnerReferences = append(machine.OwnerReferences, newRef)
@@ -458,4 +447,40 @@ func (r *ReconcileMachineSet) waitForMachineDeletion(machineList []*clusterv1alp
 		}
 	}
 	return nil
+}
+
+// MachineToMachineSets is a handler.ToRequestsFunc to be used to enqeue requests for reconciliation
+// for MachineSets that might adopt an orphaned Machine.
+func (r *ReconcileMachineSet) MachineToMachineSets(o handler.MapObject) []reconcile.Request {
+	result := []reconcile.Request{}
+
+	m := &clusterv1alpha1.Machine{}
+	key := client.ObjectKey{Namespace: o.Meta.GetNamespace(), Name: o.Meta.GetName()}
+	if err := r.Client.Get(context.Background(), key, m); err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("Unable to retrieve Machine %q for possible MachineSet adoption: %v", key, err)
+		}
+		return nil
+	}
+
+	// Check if the controller reference is already set and
+	// return an empty result when one is found.
+	for _, ref := range m.ObjectMeta.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			return result
+		}
+	}
+
+	mss := r.getMachineSetsForMachine(m)
+	if len(mss) == 0 {
+		klog.V(4).Infof("Found no MachineSet for Machine %q", m.Name)
+		return nil
+	}
+
+	for _, ms := range mss {
+		name := client.ObjectKey{Namespace: ms.Namespace, Name: ms.Name}
+		result = append(result, reconcile.Request{NamespacedName: name})
+	}
+
+	return result
 }

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/status.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/machineset/status.go
@@ -112,7 +112,7 @@ func updateMachineSetStatus(c client.Client, ms *v1alpha1.MachineSet, newStatus 
 			break
 		}
 		// Update the MachineSet with the latest resource version for the next poll
-		if getErr = c.Get(context.Background(), client.ObjectKey{Name: ms.Name}, ms); getErr != nil {
+		if getErr = c.Get(context.Background(), client.ObjectKey{Namespace: ms.Namespace, Name: ms.Name}, ms); getErr != nil {
 			// If the GET fails we can't trust status.Replicas anymore. This error
 			// is bound to be more interesting than the update failure.
 			return nil, getErr

--- a/vendor/sigs.k8s.io/cluster-api/pkg/controller/noderefutil/util.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/controller/noderefutil/util.go
@@ -60,7 +60,7 @@ func GetReadyCondition(status *corev1.NodeStatus) *corev1.NodeCondition {
 
 // IsNodeReady returns true if a node is ready; false otherwise.
 func IsNodeReady(node *corev1.Node) bool {
-	if node == nil || &node.Status == nil {
+	if node == nil {
 		return false
 	}
 	for _, c := range node.Status.Conditions {

--- a/vendor/sigs.k8s.io/cluster-api/pkg/util/util.go
+++ b/vendor/sigs.k8s.io/cluster-api/pkg/util/util.go
@@ -85,16 +85,6 @@ func GetControlPlaneMachines(machines []*clusterv1.Machine) (res []*clusterv1.Ma
 	return
 }
 
-// MachineP converts a slice of machines into a slice of machine pointers.
-func MachineP(machines []clusterv1.Machine) []*clusterv1.Machine {
-	// Convert to list of pointers
-	ret := make([]*clusterv1.Machine, 0, len(machines))
-	for _, machine := range machines {
-		ret = append(ret, machine.DeepCopy())
-	}
-	return ret
-}
-
 // Home returns the user home directory.
 func Home() string {
 	home := os.Getenv("HOME")
@@ -247,8 +237,7 @@ func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
 	var (
 		bytes       [][]byte
 		machineList clusterv1.MachineList
-		machine     clusterv1.Machine
-		machines    = []clusterv1.Machine{}
+		machines    = []*clusterv1.Machine{}
 	)
 
 	// TODO: use the universal decoder instead of doing this.
@@ -264,7 +253,8 @@ func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
 		if err := json.Unmarshal(ml, &machineList); err != nil {
 			return nil, err
 		}
-		for _, machine := range machineList.Items {
+		for i := range machineList.Items {
+			machine := &machineList.Items[i]
 			if machine.APIVersion == "" || machine.Kind == "" {
 				return nil, errors.New(MachineListFormatDeprecationMessage)
 			}
@@ -282,13 +272,14 @@ func ParseMachinesYaml(file string) ([]*clusterv1.Machine, error) {
 	}
 
 	for _, m := range bytes {
-		if err := json.Unmarshal(m, &machine); err != nil {
+		machine := &clusterv1.Machine{}
+		if err := json.Unmarshal(m, machine); err != nil {
 			return nil, err
 		}
 		machines = append(machines, machine)
 	}
 
-	return MachineP(machines), nil
+	return machines, nil
 }
 
 // isMissingKind reimplements runtime.IsMissingKind as the YAMLOrJSONDecoder


### PR DESCRIPTION
This allows us to use foreground deletion:
https://github.com/kubernetes-sigs/cluster-api/pull/953

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
