### PR TITLE
Don't render null ssh key into cloud-init

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -128,7 +128,7 @@ func (p Provider) UserData(
 const userDataTemplate = `#cloud-config
 {{ if ne .CloudProvider "aws" }}
 hostname: {{ .MachineSpec.Name }}
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
+{{- /* Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name */}}
 {{ end }}
 
 {{- if .OSConfig.DistUpgradeOnBoot }}
@@ -180,18 +180,18 @@ write_files:
 
     setenforce 0 || true
 
-    # As we added some modules and don't want to reboot, restart the service
+{{- /* As we added some modules and don't want to reboot, restart the service */}}
     systemctl restart systemd-modules-load.service
     sysctl --system
 
-    # Make sure we always disable swap - Otherwise the kubelet won't start
+{{- /* Make sure we always disable swap - Otherwise the kubelet won't start */}}
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
     {{ if ne .CloudProvider "aws" }}
-    # The normal way of setting it via cloud-init is broken:
-    # https://bugs.launchpad.net/cloud-init/+bug/1662542
+{{- /*  The normal way of setting it via cloud-init is broken, see */}}
+{{- /*  https://bugs.launchpad.net/cloud-init/+bug/1662542 */}}
     hostnamectl set-hostname {{ .MachineSpec.Name }}
     {{ end }}
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -51,12 +51,8 @@ write_files:
     set -xeuo pipefail
 
     setenforce 0 || true
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -74,18 +70,14 @@ write_files:
       curl \
       ipvsadm
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.10.2/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -51,12 +51,8 @@ write_files:
     set -xeuo pipefail
 
     setenforce 0 || true
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -74,18 +70,14 @@ write_files:
       curl \
       ipvsadm
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -51,12 +51,8 @@ write_files:
     set -xeuo pipefail
 
     setenforce 0 || true
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -74,18 +70,14 @@ write_files:
       curl \
       ipvsadm
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -51,12 +51,8 @@ write_files:
     set -xeuo pipefail
 
     setenforce 0 || true
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -74,18 +70,14 @@ write_files:
       curl \
       ipvsadm
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -1,7 +1,6 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
@@ -54,19 +53,13 @@ write_files:
     set -xeuo pipefail
 
     setenforce 0 || true
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    # The normal way of setting it via cloud-init is broken:
-    # https://bugs.launchpad.net/cloud-init/+bug/1662542
     hostnamectl set-hostname node1
 
 
@@ -82,18 +75,14 @@ write_files:
       ipvsadm \
       open-vm-tools
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -51,12 +51,8 @@ write_files:
     set -xeuo pipefail
 
     setenforce 0 || true
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -74,18 +70,14 @@ write_files:
       curl \
       ipvsadm
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.9.2/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -117,11 +117,13 @@ func (p Provider) UserData(
 
 // UserData template.
 const userDataTemplate = `passwd:
+{{- if ne (len .ProviderSpec.SSHPublicKeys) 0 }}
   users:
     - name: core
       ssh_authorized_keys:
         {{range .ProviderSpec.SSHPublicKeys}}- {{.}}
         {{end}}
+{{- end }}
 
 {{- if .ProviderSpec.Network }}
 networkd:

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -284,14 +284,11 @@ storage:
         inline: |
           #!/bin/bash
           set -xeuo pipefail
-          #setup some common directories
           mkdir -p /opt/bin/
           mkdir -p /var/lib/calico
           mkdir -p /etc/kubernetes/manifests
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
-
-          # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
           fi

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -284,14 +284,11 @@ storage:
         inline: |
           #!/bin/bash
           set -xeuo pipefail
-          #setup some common directories
           mkdir -p /opt/bin/
           mkdir -p /var/lib/calico
           mkdir -p /etc/kubernetes/manifests
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
-
-          # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
           fi

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -305,14 +305,11 @@ storage:
         inline: |
           #!/bin/bash
           set -xeuo pipefail
-          #setup some common directories
           mkdir -p /opt/bin/
           mkdir -p /var/lib/calico
           mkdir -p /etc/kubernetes/manifests
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
-
-          # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
           fi

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -306,14 +306,11 @@ storage:
         inline: |
           #!/bin/bash
           set -xeuo pipefail
-          #setup some common directories
           mkdir -p /opt/bin/
           mkdir -p /var/lib/calico
           mkdir -p /etc/kubernetes/manifests
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
-
-          # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
           fi

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -282,14 +282,11 @@ storage:
         inline: |
           #!/bin/bash
           set -xeuo pipefail
-          #setup some common directories
           mkdir -p /opt/bin/
           mkdir -p /var/lib/calico
           mkdir -p /etc/kubernetes/manifests
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
-
-          # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
           fi

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -283,14 +283,11 @@ storage:
         inline: |
           #!/bin/bash
           set -xeuo pipefail
-          #setup some common directories
           mkdir -p /opt/bin/
           mkdir -p /var/lib/calico
           mkdir -p /etc/kubernetes/manifests
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
-
-          # cni
           if [ ! -f /opt/cni/bin/loopback ]; then
               curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
           fi

--- a/pkg/userdata/helper/download_binaries_script.go
+++ b/pkg/userdata/helper/download_binaries_script.go
@@ -23,20 +23,20 @@ import (
 )
 
 const (
-	downloadBinariesTpl = `#setup some common directories
+	downloadBinariesTpl = `{{- /*setup some common directories */ -}}
 mkdir -p /opt/bin/
 mkdir -p /var/lib/calico
 mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 
-# cni
+{{- /* # cni */}}
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
 fi
 
 {{- if .DownloadKubelet }}
-# kubelet
+{{- /* kubelet */}}
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v{{ .KubeletVersion }}/bin/linux/amd64/kubelet
     chmod +x /opt/bin/kubelet

--- a/pkg/userdata/helper/testdata/download_binaries_v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.10.0.golden
@@ -1,15 +1,11 @@
-#setup some common directories
 mkdir -p /opt/bin/
 mkdir -p /var/lib/calico
 mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
-
-# cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
 fi
-# kubelet
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubelet
     chmod +x /opt/bin/kubelet

--- a/pkg/userdata/helper/testdata/download_binaries_v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.11.0-rc.2.golden
@@ -1,15 +1,11 @@
-#setup some common directories
 mkdir -p /opt/bin/
 mkdir -p /var/lib/calico
 mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
-
-# cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
 fi
-# kubelet
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.0-rc.2/bin/linux/amd64/kubelet
     chmod +x /opt/bin/kubelet

--- a/pkg/userdata/helper/testdata/download_binaries_v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.11.0.golden
@@ -1,15 +1,11 @@
-#setup some common directories
 mkdir -p /opt/bin/
 mkdir -p /var/lib/calico
 mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
-
-# cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
 fi
-# kubelet
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubelet
     chmod +x /opt/bin/kubelet

--- a/pkg/userdata/helper/testdata/download_binaries_v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.11.3.golden
@@ -1,15 +1,11 @@
-#setup some common directories
 mkdir -p /opt/bin/
 mkdir -p /var/lib/calico
 mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
-
-# cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
 fi
-# kubelet
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
     chmod +x /opt/bin/kubelet

--- a/pkg/userdata/helper/testdata/download_binaries_v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.12.0.golden
@@ -1,15 +1,11 @@
-#setup some common directories
 mkdir -p /opt/bin/
 mkdir -p /var/lib/calico
 mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
-
-# cni
 if [ ! -f /opt/cni/bin/loopback ]; then
     curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
 fi
-# kubelet
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet
     chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -146,8 +140,6 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade -y
@@ -155,18 +147,14 @@ write_files:
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -146,26 +140,20 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -146,26 +140,20 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 - "ssh-rsa CCCDDD"
@@ -113,15 +111,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -148,26 +142,20 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -146,26 +140,20 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -146,26 +140,20 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -146,26 +140,20 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.10.10/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -146,26 +140,20 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -146,26 +140,20 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.1/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -146,26 +140,20 @@ write_files:
       util-linux \
       ${CR_PKG} \
       ipvsadm
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.9.10/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -1,11 +1,9 @@
 #cloud-config
 
 hostname: node1
-# Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name
 
 
 ssh_pwauth: no
-
 ssh_authorized_keys:
 - "ssh-rsa AAABBB"
 
@@ -111,15 +109,11 @@ write_files:
   content: |
     #!/bin/bash
     set -xeuo pipefail
-
-    # As we added some modules and don't want to reboot, restart the service
     systemctl restart systemd-modules-load.service
     sysctl --system
 
     apt-key add /opt/docker.asc
     apt-get update
-
-    # Make sure we always disable swap - Otherwise the kubelet won't start'.
     cp /etc/fstab /etc/fstab.orig
     cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
     mv /etc/fstab.noswap /etc/fstab
@@ -147,26 +141,20 @@ write_files:
       ${CR_PKG} \
       ipvsadm \
       open-vm-tools
-
-    # If something failed during package installation but docker got installed, we need to put it on hold
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi
 
-    #setup some common directories
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
     mkdir -p /etc/kubernetes/manifests
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
-
-    # cni
     if [ ! -f /opt/cni/bin/loopback ]; then
         curl -L https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar -xvzC /opt/cni/bin -f -
     fi
-    # kubelet
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet
         chmod +x /opt/bin/kubelet


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoids rendering a nil ssh_keys field as some providers cloud-init cant handle that. Also avoids rendering comments into the cloud-config

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #556

**Special notes for your reviewer**:

```release-note
none
```
