### PR TITLE
Skip eviction if there is no possible target

### DIFF
--- a/pkg/node/eviction/eviction.go
+++ b/pkg/node/eviction/eviction.go
@@ -93,11 +93,13 @@ func (ne *NodeEviction) Run() error {
 }
 
 func (ne *NodeEviction) cordonNode(node *corev1.Node) error {
-	_, err := ne.updateNode(func(n *corev1.Node) {
-		n.Spec.Unschedulable = true
-	})
-	if err != nil {
-		return err
+	if !node.Spec.Unschedulable {
+		_, err := ne.updateNode(func(n *corev1.Node) {
+			n.Spec.Unschedulable = true
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	// Be paranoid and wait until the change got propagated to the lister


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #541 #542 

**Special notes for your reviewer**:

```release-note
Before an eviciton is attempted, the machine-controller will now check if there is a possible target and if no, omit it
```
