### PR TITLE
Add NodeTags to GCE CloudConfig

### DIFF
--- a/pkg/cloudprovider/provider/gce/cloudconfig.go
+++ b/pkg/cloudprovider/provider/gce/cloudconfig.go
@@ -39,7 +39,8 @@ const cloudConfigTemplate = "[global]\n" +
 	"subnetwork-name = {{ .Global.SubnetworkName | iniEscape }}\n" +
 	"token-url = {{ .Global.TokenURL | iniEscape }}\n" +
 	"multizone = {{ .Global.MultiZone }}\n" +
-	"regional = {{ .Global.Regional }}\n"
+	"regional = {{ .Global.Regional }}\n" +
+	"{{ range .Global.NodeTags }}node-tags = {{ . | iniEscape }}\n{{end}}"
 
 // GlobalOpts contains the values of the global section of the cloud configuration.
 type GlobalOpts struct {
@@ -50,6 +51,7 @@ type GlobalOpts struct {
 	TokenURL       string
 	MultiZone      bool
 	Regional       bool
+	NodeTags       []string
 }
 
 // CloudConfig contains only the section global.

--- a/pkg/cloudprovider/provider/gce/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/gce/cloudconfig_test.go
@@ -43,6 +43,7 @@ func TestCloudConfigAsString(t *testing.T) {
 					TokenURL:       "nil",
 					MultiZone:      true,
 					Regional:       true,
+					NodeTags:       []string{"tag1", "tag2"},
 				},
 			},
 			contents: "[global]\n" +
@@ -52,7 +53,9 @@ func TestCloudConfigAsString(t *testing.T) {
 				"subnetwork-name = \"my-cool-subnetwork\"\n" +
 				"token-url = \"nil\"\n" +
 				"multizone = true\n" +
-				"regional = true\n",
+				"regional = true\n" +
+				"node-tags = \"tag1\"\n" +
+				"node-tags = \"tag2\"\n",
 		},
 	}
 

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -178,6 +178,7 @@ func (p *Provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 			Regional:       cfg.regional,
 			NetworkName:    cfg.network,
 			SubnetworkName: cfg.subnetwork,
+			NodeTags:       cfg.tags,
 		},
 	}
 	config, err = cc.AsString()


### PR DESCRIPTION
`NodeTags` is the list of tags to use on firewall rules for load balancers. This is necessary for LBs to work on GCP.

For https://github.com/kubermatic/kubermatic/pull/3572

Ref:

- https://github.com/kubernetes/kubernetes/blob/ef7808fec57284582c7bf3fc834570e5769df83e/staging/src/k8s.io/legacy-cloud-providers/gce/gce.go#L121

- https://github.com/kubernetes/kubernetes/blob/ef7808fec57284582c7bf3fc834570e5769df83e/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go#L979-L981


```release-note
NONE
```

/assign @alvaroaleman 