### PR TITLE
typo in vmSize for azure provider.go

### DIFF
--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -72,7 +72,7 @@ type RawConfig struct {
 
 	Location          providerconfig.ConfigVarString `json:"location"`
 	ResourceGroup     providerconfig.ConfigVarString `json:"resourceGroup"`
-	VMSize            providerconfig.ConfigVarString `json:"vmSizei"`
+	VMSize            providerconfig.ConfigVarString `json:"vmSize"`
 	VNetName          providerconfig.ConfigVarString `json:"vnetName"`
 	SubnetName        providerconfig.ConfigVarString `json:"subnetName"`
 	RouteTableName    providerconfig.ConfigVarString `json:"routeTableName"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a typo in the azure provider

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
```
