### PR TITLE
Enable fine-grained control over coreos update.

### DIFF
--- a/pkg/userdata/coreos/coreos.go
+++ b/pkg/userdata/coreos/coreos.go
@@ -24,7 +24,9 @@ import (
 
 // Config contains specific configuration for CoreOS.
 type Config struct {
-	DisableAutoUpdate bool `json:"disableAutoUpdate"`
+	DisableAutoUpdate   bool `json:"disableAutoUpdate"`
+	DisableLocksmithD   bool `json:"disableLocksmithD"`
+	DisableUpdateEngine bool `json:"disableUpdateEngine"`
 }
 
 // LoadConfig retrieves the CoreOS configuration from raw data.

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -81,6 +81,11 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		}
 	}
 
+	if coreosConfig.DisableAutoUpdate {
+		coreosConfig.DisableLocksmithD = true
+		coreosConfig.DisableUpdateEngine = true
+	}
+
 	data := struct {
 		plugin.UserDataRequest
 		ProviderSpec           *providerconfig.Config
@@ -137,12 +142,14 @@ networkd:
 
 systemd:
   units:
-{{- if .CoreOSConfig.DisableAutoUpdate }}
+{{- if .CoreOSConfig.DisableUpdateEngine }}
     - name: update-engine.service
       mask: true
+{{- end }}
+{{- if .CoreOSConfig.DisableLocksmithD }}
     - name: locksmithd.service
       mask: true
-{{ end }}
+{{- end }}
     - name: docker.service
       enabled: true
 

--- a/pkg/userdata/coreos/provider_test.go
+++ b/pkg/userdata/coreos/provider_test.go
@@ -139,6 +139,50 @@ func TestUserDataGeneration(t *testing.T) {
 			},
 		},
 		{
+			name: "v1.9.2-disable-locksmith-aws",
+			providerSpec: &providerconfig.Config{
+				CloudProvider: "aws",
+				SSHPublicKeys: []string{"ssh-rsa AAABBB", "ssh-rsa CCCDDD"},
+			},
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.9.2",
+				},
+			},
+			ccProvider: &fakeCloudConfigProvider{
+				name:   "aws",
+				config: "{aws-config:true}",
+				err:    nil,
+			},
+			DNSIPs: []net.IP{net.ParseIP("10.10.10.10")},
+			osConfig: &Config{
+				DisableLocksmithD: true,
+			},
+		},
+		{
+			name: "v1.9.2-disable-update-engine-aws",
+			providerSpec: &providerconfig.Config{
+				CloudProvider: "aws",
+				SSHPublicKeys: []string{"ssh-rsa AAABBB", "ssh-rsa CCCDDD"},
+			},
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.9.2",
+				},
+			},
+			ccProvider: &fakeCloudConfigProvider{
+				name:   "aws",
+				config: "{aws-config:true}",
+				err:    nil,
+			},
+			DNSIPs: []net.IP{net.ParseIP("10.10.10.10")},
+			osConfig: &Config{
+				DisableUpdateEngine: true,
+			},
+		},
+		{
 			name: "v1.9.2-disable-auto-update-aws-external",
 			providerSpec: &providerconfig.Config{
 				CloudProvider: "aws",

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -28,7 +28,6 @@ systemd:
       mask: true
     - name: locksmithd.service
       mask: true
-
     - name: docker.service
       enabled: true
 

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -28,7 +28,6 @@ systemd:
       mask: true
     - name: locksmithd.service
       mask: true
-
     - name: docker.service
       enabled: true
     - name: update-engine.service

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -6,7 +6,6 @@ systemd:
       mask: true
     - name: locksmithd.service
       mask: true
-
     - name: docker.service
       enabled: true
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -12,7 +12,6 @@ systemd:
       mask: true
     - name: locksmithd.service
       mask: true
-
     - name: docker.service
       enabled: true
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -12,7 +12,6 @@ systemd:
       mask: true
     - name: locksmithd.service
       mask: true
-
     - name: docker.service
       enabled: true
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -5,27 +5,9 @@ passwd:
         - ssh-rsa AAABBB
         - ssh-rsa CCCDDD
 
-networkd:
-  units:
-    - name: static-nic.network
-      contents: |
-        [Match]
-        # Because of difficulty predicting specific NIC names on different cloud providers,
-        # we only support static addressing on VSphere. There should be a single NIC attached
-        # that we will match by name prefix 'en' which denotes ethernet devices.
-        Name=en*
-
-        [Network]
-        DHCP=no
-        Address=192.168.81.4/24
-        Gateway=192.168.81.1
-        DNS=8.8.8.8
-
 
 systemd:
   units:
-    - name: update-engine.service
-      mask: true
     - name: locksmithd.service
       mask: true
     - name: docker.service
@@ -95,7 +77,7 @@ systemd:
         CPUAccounting=true
         MemoryAccounting=true
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.12.0
+        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --insecure-options=image \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
@@ -126,12 +108,12 @@ systemd:
           --cni-bin-dir=/opt/cni/bin \
           --authorization-mode=Webhook \
           --client-ca-file=/etc/kubernetes/pki/ca.crt \
+          --cadvisor-port=0 \
           --rotate-certificates=true \
           --cert-dir=/etc/kubernetes/pki \
           --authentication-token-webhook=true \
-          --cloud-provider=vsphere \
+          --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --hostname-override=node1 \
           --read-only-port=0 \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
@@ -240,9 +222,7 @@ storage:
       mode: 0400
       contents:
         inline: |
-          my
-          custom
-          cloud-config
+          {aws-config:true}
 
     - path: /etc/kubernetes/pki/ca.crt
       filesystem: root
@@ -276,11 +256,6 @@ storage:
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
 
-    - path: /etc/hostname
-      filesystem: root
-      mode: 0600
-      contents:
-        inline: 'node1'
 
     - path: /etc/ssh/sshd_config
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -5,28 +5,10 @@ passwd:
         - ssh-rsa AAABBB
         - ssh-rsa CCCDDD
 
-networkd:
-  units:
-    - name: static-nic.network
-      contents: |
-        [Match]
-        # Because of difficulty predicting specific NIC names on different cloud providers,
-        # we only support static addressing on VSphere. There should be a single NIC attached
-        # that we will match by name prefix 'en' which denotes ethernet devices.
-        Name=en*
-
-        [Network]
-        DHCP=no
-        Address=192.168.81.4/24
-        Gateway=192.168.81.1
-        DNS=8.8.8.8
-
 
 systemd:
   units:
     - name: update-engine.service
-      mask: true
-    - name: locksmithd.service
       mask: true
     - name: docker.service
       enabled: true
@@ -95,7 +77,7 @@ systemd:
         CPUAccounting=true
         MemoryAccounting=true
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.12.0
+        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
         Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
           --insecure-options=image \
           --volume=resolv,kind=host,source=/etc/resolv.conf \
@@ -126,12 +108,12 @@ systemd:
           --cni-bin-dir=/opt/cni/bin \
           --authorization-mode=Webhook \
           --client-ca-file=/etc/kubernetes/pki/ca.crt \
+          --cadvisor-port=0 \
           --rotate-certificates=true \
           --cert-dir=/etc/kubernetes/pki \
           --authentication-token-webhook=true \
-          --cloud-provider=vsphere \
+          --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --hostname-override=node1 \
           --read-only-port=0 \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
@@ -240,9 +222,7 @@ storage:
       mode: 0400
       contents:
         inline: |
-          my
-          custom
-          cloud-config
+          {aws-config:true}
 
     - path: /etc/kubernetes/pki/ca.crt
       filesystem: root
@@ -276,11 +256,6 @@ storage:
           kPe6XoSbiLm/kxk32T0=
           -----END CERTIFICATE-----
 
-    - path: /etc/hostname
-      filesystem: root
-      mode: 0600
-      contents:
-        inline: 'node1'
 
     - path: /etc/ssh/sshd_config
       filesystem: root


### PR DESCRIPTION
For certain setups, mainly the ones using the Container Linux Update Operator,
it's required to have the CoreOS update-engine enabled while disabling
locksmithd. Previously, you could only enable/disable these together.
Thos patch adds two options so that they can be individually tweaked
while also retaining the old behaviour.

This patch also fixes the test data, as my patch introduced some
whitespace differences.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
Add Container Linux specific config options: `disableLocksmithD` and `disableUpdateEngine`, to allow for more fine-grained control over the Container Linux update process.
```
