### PR TITLE
Add Openstack tenant id

### DIFF
--- a/pkg/cloudprovider/provider/openstack/cloudconfig.go
+++ b/pkg/cloudprovider/provider/openstack/cloudconfig.go
@@ -32,6 +32,7 @@ auth-url    = {{ .Global.AuthURL | iniEscape }}
 username    = {{ .Global.Username | iniEscape }}
 password    = {{ .Global.Password | iniEscape }}
 tenant-name = {{ .Global.TenantName | iniEscape }}
+tenant-id   = {{ .Global.TenantID | iniEscape }}
 domain-name = {{ .Global.DomainName | iniEscape }}
 region      = {{ .Global.Region | iniEscape }}
 
@@ -85,6 +86,7 @@ type GlobalOpts struct {
 	Username   string
 	Password   string
 	TenantName string `gcfg:"tenant-name"`
+	TenantID   string `gcfg:"tenant-id"`
 	DomainName string `gcfg:"domain-name"`
 	Region     string
 }

--- a/pkg/cloudprovider/provider/openstack/testdata/bs-defaulting-config.golden
+++ b/pkg/cloudprovider/provider/openstack/testdata/bs-defaulting-config.golden
@@ -3,6 +3,7 @@ auth-url    = "https://127.0.0.1:8443"
 username    = ""
 password    = ""
 tenant-name = ""
+tenant-id   = ""
 domain-name = ""
 region      = ""
 

--- a/pkg/cloudprovider/provider/openstack/testdata/config-with-special-chars.golden
+++ b/pkg/cloudprovider/provider/openstack/testdata/config-with-special-chars.golden
@@ -3,6 +3,7 @@ auth-url    = "https://127.0.0.1:8443"
 username    = "admin"
 password    = ".)\\^x[tt0L@};p<KJ|f.VQ]7r9u;\"ZF|"
 tenant-name = "Test"
+tenant-id   = ""
 domain-name = "Default"
 region      = "eu-central1"
 

--- a/pkg/cloudprovider/provider/openstack/testdata/simple-config.golden
+++ b/pkg/cloudprovider/provider/openstack/testdata/simple-config.golden
@@ -3,6 +3,7 @@ auth-url    = "https://127.0.0.1:8443"
 username    = "admin"
 password    = "password"
 tenant-name = "Test"
+tenant-id   = ""
 domain-name = "Default"
 region      = "eu-central1"
 

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -297,10 +297,7 @@ func (configVarResolver *ConfigVarResolver) GetConfigVarStringValueOrEnv(configV
 		return cfgVar, err
 	}
 
-	envVal, envValFound := os.LookupEnv(envVarName)
-	if !envValFound {
-		return "", fmt.Errorf("all mechanisms(value, secret, configMap) of getting the value failed, including reading from environment variable = %s which was not set", envVarName)
-	}
+	envVal, _ := os.LookupEnv(envVarName)
 	return envVal, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to set the TenantID for OpenStack machines.

Fixes #568

```release-note
Add support to set the TenantID for OpenStack machines.
```

/hold 
needs at least a manual test run