### PR TITLE
Make Openstack NodeVolumeAttachLimit configurable

### DIFF
--- a/pkg/cloudprovider/provider/openstack/cloudconfig.go
+++ b/pkg/cloudprovider/provider/openstack/cloudconfig.go
@@ -58,6 +58,9 @@ ignore-volume-az  = {{ .BlockStorage.IgnoreVolumeAZ }}
 {{- end }}
 trust-device-path = {{ .BlockStorage.TrustDevicePath }}
 bs-version        = {{ default "auto" .BlockStorage.BSVersion | iniEscape }}
+{{- if .BlockStorage.NodeVolumeAttachLimit }}
+node-volume-attach-limit = {{ .BlockStorage.NodeVolumeAttachLimit }}
+{{- end }}
 `
 )
 
@@ -75,9 +78,10 @@ type LoadBalancerOpts struct {
 }
 
 type BlockStorageOpts struct {
-	BSVersion       string `gcfg:"bs-version"`
-	TrustDevicePath bool   `gcfg:"trust-device-path"`
-	IgnoreVolumeAZ  bool   `gcfg:"ignore-volume-az"`
+	BSVersion             string `gcfg:"bs-version"`
+	TrustDevicePath       bool   `gcfg:"trust-device-path"`
+	IgnoreVolumeAZ        bool   `gcfg:"ignore-volume-az"`
+	NodeVolumeAttachLimit uint   `gcfg:"node-volume-attach-limit"`
 }
 
 type GlobalOpts struct {

--- a/pkg/cloudprovider/provider/openstack/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/openstack/cloudconfig_test.go
@@ -46,9 +46,10 @@ func TestCloudConfigToString(t *testing.T) {
 					Region:     "eu-central1",
 				},
 				BlockStorage: BlockStorageOpts{
-					BSVersion:       "v2",
-					IgnoreVolumeAZ:  true,
-					TrustDevicePath: true,
+					BSVersion:             "v2",
+					IgnoreVolumeAZ:        true,
+					TrustDevicePath:       true,
+					NodeVolumeAttachLimit: 25,
 				},
 				LoadBalancer: LoadBalancerOpts{
 					ManageSecurityGroups: true,
@@ -68,9 +69,10 @@ func TestCloudConfigToString(t *testing.T) {
 					Region:     "eu-central1",
 				},
 				BlockStorage: BlockStorageOpts{
-					BSVersion:       "v2",
-					IgnoreVolumeAZ:  true,
-					TrustDevicePath: true,
+					BSVersion:             "v2",
+					IgnoreVolumeAZ:        true,
+					TrustDevicePath:       true,
+					NodeVolumeAttachLimit: 25,
 				},
 				LoadBalancer: LoadBalancerOpts{
 					ManageSecurityGroups: true,

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -75,15 +75,16 @@ type RawConfig struct {
 	Region           providerconfig.ConfigVarString `json:"region,omitempty"`
 
 	// Machine details
-	Image            providerconfig.ConfigVarString   `json:"image"`
-	Flavor           providerconfig.ConfigVarString   `json:"flavor"`
-	SecurityGroups   []providerconfig.ConfigVarString `json:"securityGroups,omitempty"`
-	Network          providerconfig.ConfigVarString   `json:"network,omitempty"`
-	Subnet           providerconfig.ConfigVarString   `json:"subnet,omitempty"`
-	FloatingIPPool   providerconfig.ConfigVarString   `json:"floatingIpPool,omitempty"`
-	AvailabilityZone providerconfig.ConfigVarString   `json:"availabilityZone,omitempty"`
-	TrustDevicePath  providerconfig.ConfigVarBool     `json:"trustDevicePath"`
-	RootDiskSizeGB   *int                             `json:"rootDiskSizeGB"`
+	Image                 providerconfig.ConfigVarString   `json:"image"`
+	Flavor                providerconfig.ConfigVarString   `json:"flavor"`
+	SecurityGroups        []providerconfig.ConfigVarString `json:"securityGroups,omitempty"`
+	Network               providerconfig.ConfigVarString   `json:"network,omitempty"`
+	Subnet                providerconfig.ConfigVarString   `json:"subnet,omitempty"`
+	FloatingIPPool        providerconfig.ConfigVarString   `json:"floatingIpPool,omitempty"`
+	AvailabilityZone      providerconfig.ConfigVarString   `json:"availabilityZone,omitempty"`
+	TrustDevicePath       providerconfig.ConfigVarBool     `json:"trustDevicePath"`
+	RootDiskSizeGB        *int                             `json:"rootDiskSizeGB"`
+	NodeVolumeAttachLimit *uint                            `json:"nodeVolumeAttachLimit"`
 	// This tag is related to server metadata, not compute server's tag
 	Tags map[string]string `json:"tags,omitempty"`
 }
@@ -98,15 +99,16 @@ type Config struct {
 	Region           string
 
 	// Machine details
-	Image            string
-	Flavor           string
-	SecurityGroups   []string
-	Network          string
-	Subnet           string
-	FloatingIPPool   string
-	AvailabilityZone string
-	TrustDevicePath  bool
-	RootDiskSizeGB   *int
+	Image                 string
+	Flavor                string
+	SecurityGroups        []string
+	Network               string
+	Subnet                string
+	FloatingIPPool        string
+	AvailabilityZone      string
+	TrustDevicePath       bool
+	RootDiskSizeGB        *int
+	NodeVolumeAttachLimit *uint
 
 	Tags map[string]string
 }
@@ -201,6 +203,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfig.
 		return nil, nil, nil, err
 	}
 	c.RootDiskSizeGB = rawConfig.RootDiskSizeGB
+	c.NodeVolumeAttachLimit = rawConfig.NodeVolumeAttachLimit
 	c.Tags = rawConfig.Tags
 	if c.Tags == nil {
 		c.Tags = map[string]string{}
@@ -703,6 +706,9 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 			IgnoreVolumeAZ:  true,
 		},
 		Version: spec.Versions.Kubelet,
+	}
+	if c.NodeVolumeAttachLimit != nil {
+		cc.BlockStorage.NodeVolumeAttachLimit = *c.NodeVolumeAttachLimit
 	}
 
 	s, err := CloudConfigToString(cc)

--- a/pkg/cloudprovider/provider/openstack/testdata/config-with-special-chars.golden
+++ b/pkg/cloudprovider/provider/openstack/testdata/config-with-special-chars.golden
@@ -22,3 +22,4 @@ manage-security-groups = true
 ignore-volume-az  = true
 trust-device-path = true
 bs-version        = "v2"
+node-volume-attach-limit = 25

--- a/pkg/cloudprovider/provider/openstack/testdata/simple-config.golden
+++ b/pkg/cloudprovider/provider/openstack/testdata/simple-config.golden
@@ -17,3 +17,4 @@ lb-provider = ""
 ignore-volume-az  = true
 trust-device-path = true
 bs-version        = "v2"
+node-volume-attach-limit = 25


### PR DESCRIPTION
**What this PR does / why we need it**:

This makes the Openstack `node-volume-attach-limit` cloud-config setting configurable in the openstack machine settings. If set, the value will be written to cloud-config when the node is created.

**Special notes for your reviewer**:

The kubelet will write this to the node object (status.allocatable.attachable-volumes-cinder), where the scheduler will use it if configured to do so ("MaxCinderVolumeCount" scheduler predicate; not enabled by default).

```release-note
Openstack node-volume-attach-limit setting configurable per machine
```
