### PR TITLE
Run Docker with systemd cgroup driver

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -220,11 +220,6 @@ write_files:
   content: |
 {{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage | indent 4 }}
 
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
-
 - path: "/etc/kubernetes/cloud-config"
   content: |
 {{ .CloudConfig | indent 4 }}

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -146,15 +146,11 @@ write_files:
       --cluster-dns= \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -146,15 +146,11 @@ write_files:
       --cluster-dns= \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -144,15 +144,11 @@ write_files:
       --cluster-dns= \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -145,15 +145,11 @@ write_files:
       --cluster-dns= \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -162,15 +162,11 @@ write_files:
       --cluster-domain=cluster.local \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -162,15 +162,11 @@ write_files:
       --cluster-domain=cluster.local \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -153,15 +153,11 @@ write_files:
       --cluster-dns= \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -146,15 +146,11 @@ write_files:
       --cluster-dns= \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
-
-- path: "/etc/systemd/system/kubelet.service.d/extras.conf"
-  content: |
-    [Service]
-    Environment="KUBELET_EXTRA_ARGS=--cgroup-driver=systemd"
 
 - path: "/etc/kubernetes/cloud-config"
   content: |

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -121,7 +121,8 @@ systemd:
           --cluster-dns=10.10.10.10 \
           --cluster-domain=cluster.local \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -285,7 +286,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -121,7 +121,8 @@ systemd:
           --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
           --cluster-domain=cluster.local \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -285,7 +286,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -141,7 +141,8 @@ systemd:
           --cluster-dns=10.10.10.10 \
           --cluster-domain=cluster.local \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -305,7 +306,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -147,7 +147,8 @@ systemd:
           --cluster-domain=cluster.local \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -322,7 +323,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":["https://registry.docker-cn.com"]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":["https://registry.docker-cn.com"]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -140,7 +140,8 @@ systemd:
           --cluster-dns=10.10.10.10 \
           --cluster-domain=cluster.local \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -306,7 +307,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -147,7 +147,8 @@ systemd:
           --cluster-domain=cluster.local \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -322,7 +323,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":["192.168.100.100:5000","10.0.0.1:5000"],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":["192.168.100.100:5000","10.0.0.1:5000"],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -117,7 +117,8 @@ systemd:
           --cluster-dns=10.10.10.10 \
           --cluster-domain=cluster.local \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -281,7 +282,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -123,7 +123,8 @@ systemd:
           --cluster-dns=10.10.10.10 \
           --cluster-domain=cluster.local \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -282,7 +283,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -124,7 +124,8 @@ systemd:
           --cluster-dns=10.10.10.10 \
           --cluster-domain=cluster.local \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -283,7 +284,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -122,7 +122,8 @@ systemd:
           --cluster-dns=10.10.10.10 \
           --cluster-domain=cluster.local \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -281,7 +282,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -122,7 +122,8 @@ systemd:
           --cluster-dns=10.10.10.10 \
           --cluster-domain=cluster.local \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --cgroup-driver=systemd
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -281,7 +282,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+          {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
     - path: /opt/bin/download.sh
       filesystem: root

--- a/pkg/userdata/helper/helper.go
+++ b/pkg/userdata/helper/helper.go
@@ -93,6 +93,7 @@ SystemMaxUse=5G
 }
 
 type dockerConfig struct {
+	ExecOpts           []string `json:"exec-opts"`
 	StorageDriver      string   `json:"storage-driver"`
 	InsecureRegistries []string `json:"insecure-registries"`
 	RegistryMirrors    []string `json:"registry-mirrors"`
@@ -101,6 +102,7 @@ type dockerConfig struct {
 // DockerConfig returns the docker daemon.json.
 func DockerConfig(insecureRegistries, registryMirrors []string) (string, error) {
 	cfg := dockerConfig{
+		ExecOpts:           []string{"native.cgroupdriver=systemd"},
 		StorageDriver:      "overlay2",
 		InsecureRegistries: insecureRegistries,
 		RegistryMirrors:    registryMirrors,

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -58,7 +58,8 @@ const (
 --pod-infra-container-image={{ .PauseImage }} \
 {{- end }}
 --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
---system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi`
+--system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+--cgroup-driver=systemd`
 
 	kubeletSystemdUnitTpl = `[Unit]
 After=docker.service

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -39,7 +39,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
@@ -38,7 +38,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
@@ -39,7 +39,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-domain=cluster.local \
   --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
@@ -39,7 +39,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
@@ -38,7 +38,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
@@ -39,7 +39,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
@@ -39,7 +39,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
@@ -38,7 +38,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
@@ -38,7 +38,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
@@ -39,7 +39,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
@@ -38,7 +38,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
@@ -38,7 +38,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
@@ -37,7 +37,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cluster-dns=10.10.10.10 \
   --cluster-domain=cluster.local \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -225,7 +225,8 @@ write_files:
       --cluster-dns=10.10.10.10 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -310,7 +311,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -224,7 +224,8 @@ write_files:
       --cluster-dns=10.10.10.10 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -309,7 +310,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -224,7 +224,8 @@ write_files:
       --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -309,7 +310,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -226,7 +226,8 @@ write_files:
       --cluster-dns=10.10.10.10 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -311,7 +312,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -226,7 +226,8 @@ write_files:
       --cluster-dns=10.10.10.10 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -313,7 +314,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -226,7 +226,8 @@ write_files:
       --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -311,7 +312,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -224,7 +224,8 @@ write_files:
       --cluster-dns=10.10.10.10 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -309,7 +310,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -224,7 +224,8 @@ write_files:
       --cluster-dns=10.10.10.10 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -309,7 +310,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -223,7 +223,8 @@ write_files:
       --cluster-dns=10.10.10.10 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -308,7 +309,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -224,7 +224,8 @@ write_files:
       --cluster-dns=10.10.10.10 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -309,7 +310,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -237,7 +237,8 @@ write_files:
       --cluster-domain=cluster.local \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -324,7 +325,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":["https://registry.docker-cn.com"]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":["https://registry.docker-cn.com"]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -237,7 +237,8 @@ write_files:
       --cluster-domain=cluster.local \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -324,7 +325,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":["192.168.100.100:5000","10.0.0.1:5000"],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":["192.168.100.100:5000","10.0.0.1:5000"],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -227,7 +227,8 @@ write_files:
       --cluster-dns=10.10.10.10 \
       --cluster-domain=cluster.local \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --cgroup-driver=systemd
 
     [Install]
     WantedBy=multi-user.target
@@ -314,7 +315,7 @@ write_files:
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |
-    {"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","insecure-registries":[],"registry-mirrors":[]}
 
 - path: /etc/systemd/system/kubelet-healthcheck.service
   permissions: "0644"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the Docker daemon manifest (`/etc/docker/daemon.json`) to run Docker with the `systemd` cgroup driver. On some platforms, such as Ubuntu and CoreOS, the default driver is `cgroupfs`. However, as those systems use `systemd`, combining `systemd` and `cgroupfs` driver can make a node unstable and eventually crash it. The reason for that is that `systemd` and `cgroupfs` can see resources differently.

More about this can be found in the [Kubernetes documentation](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#cgroup-drivers).

```release-note
Run Docker with systemd cgroup driver
```

/assign @alvaroaleman 