### PR TITLE
Fix typo in the GlobalObjectKeySelector type name

### DIFF
--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -88,15 +88,15 @@ type Config struct {
 	OverwriteCloudConfig *string `json:"overwriteCloudConfig,omitempty"`
 }
 
-// GlobaObjectKeySelector is needed as we can not use v1.SecretKeySelector
+// GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector
 // because it is not cross namespace
-type GlobaObjectKeySelector struct {
+type GlobalObjectKeySelector struct {
 	v1.ObjectReference `json:",inline"`
 	Key                string `json:"key"`
 }
 
-type GlobalSecretKeySelector GlobaObjectKeySelector
-type GlobalConfigMapKeySelector GlobaObjectKeySelector
+type GlobalSecretKeySelector GlobalObjectKeySelector
+type GlobalConfigMapKeySelector GlobalObjectKeySelector
 
 type ConfigVarString struct {
 	Value           string                     `json:"value,omitempty"`


### PR DESCRIPTION
Generates swagger.json with the typo in kubermatic :P 

/assign @alvaroaleman 

```release-note
NONE
```
