### PR TITLE
Aws optional public ip

### DIFF
--- a/examples/aws-machinedeployment.yaml
+++ b/examples/aws-machinedeployment.yaml
@@ -60,6 +60,8 @@ spec:
             diskType: "gp2"
             ## Only application if diskType = io1
             diskIops: 500
+            # Assign a public IP to this instance. Default: true
+            assignPublicIP: false
             tags:
               "KubernetesCluster": "6qsm86c2d"
           # Can be 'ubuntu', 'coreos' or 'centos'

--- a/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
@@ -39,6 +39,8 @@ spec:
             # you have to set this flag to real clusterID when running against our dev or prod
             # otherwise you might have issues with your nodes not joining the cluster
               "KubernetesCluster": "randomString"
+            # Disabling the public IP assignment requires a private subnet with internet access.
+            assignPublicIP: true
           # Can be 'ubuntu', 'coreos' or 'centos'
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the public IP assignment for AWS instances optional.

**Special notes for your reviewer**:
```release-note
NONE
```
