### PR TITLE
Enable CentOS support for GCE

### DIFF
--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -41,12 +41,14 @@ const (
 
 // imageProjects maps the OS to the Google Cloud image projects
 var imageProjects = map[providerconfig.OperatingSystem]string{
+	providerconfig.OperatingSystemCentOS: "centos-cloud",
 	providerconfig.OperatingSystemCoreos: "coreos-cloud",
 	providerconfig.OperatingSystemUbuntu: "ubuntu-os-cloud",
 }
 
 // imageFamilies maps the OS to the Google Cloud image projects
 var imageFamilies = map[providerconfig.OperatingSystem]string{
+	providerconfig.OperatingSystemCentOS: "centos-7",
 	providerconfig.OperatingSystemCoreos: "coreos-stable",
 	providerconfig.OperatingSystemUbuntu: "ubuntu-1804-lts",
 }

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -189,8 +189,7 @@ func TestGCEProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, GOOGLE_SERVICE_ACCOUNT environment variable cannot be empty")
 	}
 
-	// Act. GCE does not support CentOS.
-	excludeSelector := &scenarioSelector{osName: []string{"centos"}}
+	excludeSelector := &scenarioSelector{}
 	params := []string{
 		fmt.Sprintf("<< GOOGLE_SERVICE_ACCOUNT >>=%s", googleServiceAccount),
 	}


### PR DESCRIPTION
Signed-off-by: Frank Mueller <mail@themue.dev>

**What this PR does / why we need it**:

GCE supports CentOS since June. So adding the support to the GCE cloud provider.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #598 

**Special notes for your reviewer**:

```release-note
Supporting CentOS on GCE.
```
