### PR TITLE
providerconfig: add omitempty for key in GlobaObjectKeySelector

### DIFF
--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -92,7 +92,7 @@ type Config struct {
 // because it is not cross namespace
 type GlobaObjectKeySelector struct {
 	v1.ObjectReference `json:",inline"`
-	Key                string `json:"key"`
+	Key                string `json:"key,omitempty"`
 }
 
 type GlobalSecretKeySelector GlobaObjectKeySelector


### PR DESCRIPTION
Or else would lead to:

```
      credentialsReference:
        key: ""
        name: credential-aws-sscdddgm5n
        namespace: kubermatic
```

```release-note
NONE
```

/assign @alvaroaleman 
