### PR TITLE
Add a note about signing-off existing commits to the contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,12 @@ Signed-off-by: Joe Example <joe@example.com>
 
 This can easily be done with the `--signoff` option to `git commit`.
 
+Note that we're requiring all commits in a PR to be signed-off. If you already created a PR, you can sign-off all existing commits by rebasing with the `--signoff` flag.
+
+```
+git rebase --signoff origin/master
+```
+
 By doing this you state that you can certify the following (from https://developercertificate.org/):
 
 ## Email and Chat


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a note to the contributing guidelines that we require all commits in a PR to be signed off and how to retroactively signoff commits.

**Special notes for your reviewer**:
```release-note
NONE
```

/assign @alvaroaleman @nikhita 