### PR TITLE
Allow passing arbitrary data onto userdata plugin

### DIFF
--- a/pkg/userdata/manager/plugin.go
+++ b/pkg/userdata/manager/plugin.go
@@ -72,9 +72,7 @@ func (p *Plugin) UserData(req plugin.UserDataRequest) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cmd.Env = []string{
-		fmt.Sprintf("%s=%s", plugin.EnvUserDataRequest, string(reqj)),
-	}
+	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", plugin.EnvUserDataRequest, string(reqj)))
 	// Execute command.
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes the userdata manager to pass the whole env down to userdata plugins, allowing to pass down arbitrary values from the top-level env.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
