### PR TITLE
Add support for Hetzner Private Networks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -541,15 +541,15 @@
   revision = "6ff867650f40c632367411120275478876202233"
 
 [[projects]]
-  digest = "1:8b06854389693e9f6b6c4a21a1f94a39d2bf8ca1f9efb5673e6bd36dea6c89c9"
+  digest = "1:abd07caf39a97ff567f78f84ba45d1b6950d420bbf6a182e3ee64e385a7e715a"
   name = "github.com/hetznercloud/hcloud-go"
   packages = [
     "hcloud",
     "hcloud/schema",
   ]
   pruneopts = "NUT"
-  revision = "6ff899c25535e0712de9f8f19bafc9a5717603c3"
-  version = "v1.9.0"
+  revision = "70b166c92266125ee6a621dcc6089023a5f8d055"
+  version = "v1.15.1"
 
 [[projects]]
   digest = "1:f5db19d350bd0b542d17f7e7cf4e7068bac416c08adb6a129b3c6d1db8211051"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -102,7 +102,7 @@ required = [
 
 [[constraint]]
   name = "github.com/hetznercloud/hcloud-go"
-  version = "v1.9.*"
+  version = "v1.15.*"
 
 [[constraint]]
   name = "github.com/Azure/azure-sdk-for-go"

--- a/examples/hetzner-machinedeployment.yaml
+++ b/examples/hetzner-machinedeployment.yaml
@@ -49,7 +49,7 @@ spec:
             location: "fsn1"
             # Optional: network IDs or names
             networks:
-              - ""
+              - "<< YOUR_NETWORK >>"
             # Optional
             labels:
               my: label

--- a/examples/hetzner-machinedeployment.yaml
+++ b/examples/hetzner-machinedeployment.yaml
@@ -47,6 +47,9 @@ spec:
             # Optional
             datacenter: ""
             location: "fsn1"
+            # Optional: network IDs or names
+            networks:
+              - ""
             # Optional
             labels:
               my: label

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -164,7 +164,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	if len(c.Networks) != 0 {
 		for _, network := range c.Networks {
 			if _, _, err = client.Network.Get(ctx, network); err != nil {
-				return fmt.Errorf("failed to get network: %v", err)
+				return fmt.Errorf("failed to get network %q: %v", network, err)
 			}
 		}
 	}

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -414,6 +414,9 @@ func (s *hetznerServer) Addresses() []string {
 	for _, fips := range s.server.PublicNet.FloatingIPs {
 		addresses = append(addresses, fips.IP.String())
 	}
+	for _, privateNetwork := range s.server.PrivateNet {
+		addresses = append(addresses, privateNetwork.IP.String())
+	}
 
 	return append(addresses, s.server.PublicNet.IPv4.IP.String(), s.server.PublicNet.IPv6.IP.String())
 }

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -53,11 +53,12 @@ func New(configVarResolver *providerconfig.ConfigVarResolver) cloudprovidertypes
 }
 
 type RawConfig struct {
-	Token      providerconfig.ConfigVarString `json:"token,omitempty"`
-	ServerType providerconfig.ConfigVarString `json:"serverType"`
-	Datacenter providerconfig.ConfigVarString `json:"datacenter"`
-	Location   providerconfig.ConfigVarString `json:"location"`
-	Labels     map[string]string              `json:"labels,omitempty"`
+	Token      providerconfig.ConfigVarString   `json:"token,omitempty"`
+	ServerType providerconfig.ConfigVarString   `json:"serverType"`
+	Datacenter providerconfig.ConfigVarString   `json:"datacenter"`
+	Location   providerconfig.ConfigVarString   `json:"location"`
+	Networks   []providerconfig.ConfigVarString `json:"networks"`
+	Labels     map[string]string                `json:"labels,omitempty"`
 }
 
 type Config struct {
@@ -65,6 +66,7 @@ type Config struct {
 	ServerType string
 	Datacenter string
 	Location   string
+	Networks   []string
 	Labels     map[string]string
 }
 
@@ -114,6 +116,13 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfig.
 	if err != nil {
 		return nil, nil, err
 	}
+	for _, network := range rawConfig.Networks {
+		networkValue, err := p.configVarResolver.GetConfigVarStringValue(network)
+		if err != nil {
+			return nil, nil, err
+		}
+		c.Networks = append(c.Networks, networkValue)
+	}
 	c.Labels = rawConfig.Labels
 	return &c, &pconfig, err
 }
@@ -149,6 +158,14 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	if c.Datacenter != "" {
 		if _, _, err = client.Datacenter.Get(ctx, c.Datacenter); err != nil {
 			return fmt.Errorf("failed to get datacenter: %v", err)
+		}
+	}
+
+	if len(c.Networks) != 0 {
+		for _, network := range c.Networks {
+			if _, _, err = client.Network.Get(ctx, network); err != nil {
+				return fmt.Errorf("failed to get network: %v", err)
+			}
 		}
 	}
 
@@ -200,6 +217,17 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Provi
 		serverCreateOpts.Location, _, err = client.Location.Get(ctx, c.Location)
 		if err != nil {
 			return nil, hzErrorToTerminalError(err, "failed to get location")
+		}
+	}
+
+	if len(c.Networks) != 0 {
+		serverCreateOpts.Networks = []*hcloud.Network{}
+		for _, network := range c.Networks {
+			n, _, err := client.Network.Get(ctx, network)
+			if err != nil {
+				return nil, hzErrorToTerminalError(err, "failed to get network")
+			}
+			serverCreateOpts.Networks = append(serverCreateOpts.Networks, n)
 		}
 	}
 

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/datacenter.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/datacenter.go
@@ -29,7 +29,7 @@ type DatacenterClient struct {
 	client *Client
 }
 
-// GetByID retrieves a datacenter by its ID.
+// GetByID retrieves a datacenter by its ID. If the datacenter does not exist, nil is returned.
 func (c *DatacenterClient) GetByID(ctx context.Context, id int) (*Datacenter, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/datacenters/%d", id), nil)
 	if err != nil {
@@ -47,27 +47,17 @@ func (c *DatacenterClient) GetByID(ctx context.Context, id int) (*Datacenter, *R
 	return DatacenterFromSchema(body.Datacenter), resp, nil
 }
 
-// GetByName retrieves an datacenter by its name.
+// GetByName retrieves an datacenter by its name. If the datacenter does not exist, nil is returned.
 func (c *DatacenterClient) GetByName(ctx context.Context, name string) (*Datacenter, *Response, error) {
-	path := "/datacenters?name=" + url.QueryEscape(name)
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
+	datacenters, response, err := c.List(ctx, DatacenterListOpts{Name: name})
+	if len(datacenters) == 0 {
+		return nil, response, err
 	}
-
-	var body schema.DatacenterListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if len(body.Datacenters) == 0 {
-		return nil, resp, nil
-	}
-	return DatacenterFromSchema(body.Datacenters[0]), resp, nil
+	return datacenters[0], response, err
 }
 
-// Get retrieves a datacenter by its ID if the input can be parsed as an integer, otherwise it retrieves a datacenter by its name.
+// Get retrieves a datacenter by its ID if the input can be parsed as an integer, otherwise it
+// retrieves a datacenter by its name. If the datacenter does not exist, nil is returned.
 func (c *DatacenterClient) Get(ctx context.Context, idOrName string) (*Datacenter, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
 		return c.GetByID(ctx, int(id))
@@ -78,11 +68,20 @@ func (c *DatacenterClient) Get(ctx context.Context, idOrName string) (*Datacente
 // DatacenterListOpts specifies options for listing datacenters.
 type DatacenterListOpts struct {
 	ListOpts
+	Name string
+}
+
+func (l DatacenterListOpts) values() url.Values {
+	vals := l.ListOpts.values()
+	if l.Name != "" {
+		vals.Add("name", l.Name)
+	}
+	return vals
 }
 
 // List returns a list of datacenters for a specific page.
 func (c *DatacenterClient) List(ctx context.Context, opts DatacenterListOpts) ([]*Datacenter, *Response, error) {
-	path := "/datacenters?" + valuesForListOpts(opts.ListOpts).Encode()
+	path := "/datacenters?" + opts.values().Encode()
 	req, err := c.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/error.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/error.go
@@ -7,11 +7,21 @@ type ErrorCode string
 
 // Error codes returned from the API.
 const (
-	ErrorCodeServiceError      ErrorCode = "service_error"       // Generic server error
-	ErrorCodeRateLimitExceeded ErrorCode = "rate_limit_exceeded" // Rate limit exceeded
-	ErrorCodeUnknownError      ErrorCode = "unknown_error"       // Unknown error
-	ErrorCodeNotFound          ErrorCode = "not_found"           // Resource not found
-	ErrorCodeInvalidInput      ErrorCode = "invalid_input"       // Validation error
+	ErrorCodeServiceError          ErrorCode = "service_error"           // Generic service error
+	ErrorCodeRateLimitExceeded     ErrorCode = "rate_limit_exceeded"     // Rate limit exceeded
+	ErrorCodeUnknownError          ErrorCode = "unknown_error"           // Unknown error
+	ErrorCodeNotFound              ErrorCode = "not_found"               // Resource not found
+	ErrorCodeInvalidInput          ErrorCode = "invalid_input"           // Validation error
+	ErrorCodeForbidden             ErrorCode = "forbidden"               // Insufficient permissions
+	ErrorCodeJSONError             ErrorCode = "json_error"              // Invalid JSON in request
+	ErrorCodeLocked                ErrorCode = "locked"                  // Item is locked (Another action is running)
+	ErrorCodeResourceLimitExceeded ErrorCode = "resource_limit_exceeded" // Resource limit exceeded
+	ErrorCodeResourceUnavailable   ErrorCode = "resource_unavailable"    // Resource currently unavailable
+	ErrorCodeUniquenessError       ErrorCode = "uniqueness_error"        // One or more fields must be unique
+	ErrorCodeProtected             ErrorCode = "protected"               // The actions you are trying is protected
+	ErrorCodeMaintenance           ErrorCode = "maintenance"             // Cannot perform operation due to maintenance
+	ErrorCodeConflict              ErrorCode = "conflict"                // The resource has changed during the request, please retry
+	ErrorCodeServerAlreadyAttached ErrorCode = "server_already_attached" // The server is already attached to the resource
 
 	// Deprecated error codes
 

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/floating_ip.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/floating_ip.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
+	"time"
 
 	"github.com/hetznercloud/hcloud-go/hcloud/schema"
 )
@@ -15,6 +17,7 @@ import (
 type FloatingIP struct {
 	ID           int
 	Description  string
+	Created      time.Time
 	IP           net.IP
 	Network      *net.IPNet
 	Type         FloatingIPType
@@ -50,7 +53,8 @@ type FloatingIPClient struct {
 	client *Client
 }
 
-// GetByID retrieves a Floating IP by its ID.
+// GetByID retrieves a Floating IP by its ID. If the Floating IP does not exist,
+// nil is returned.
 func (c *FloatingIPClient) GetByID(ctx context.Context, id int) (*FloatingIP, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/floating_ips/%d", id), nil)
 	if err != nil {
@@ -73,9 +77,13 @@ type FloatingIPListOpts struct {
 	ListOpts
 }
 
+func (l FloatingIPListOpts) values() url.Values {
+	return l.ListOpts.values()
+}
+
 // List returns a list of Floating IPs for a specific page.
 func (c *FloatingIPClient) List(ctx context.Context, opts FloatingIPListOpts) ([]*FloatingIP, *Response, error) {
-	path := "/floating_ips?" + valuesForListOpts(opts.ListOpts).Encode()
+	path := "/floating_ips?" + opts.values().Encode()
 	req, err := c.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/hcloud.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/hcloud.go
@@ -2,4 +2,4 @@
 package hcloud
 
 // Version is the library's version following Semantic Versioning.
-const Version = "1.9.0"
+const Version = "1.15.1"

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/image.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/image.go
@@ -71,7 +71,7 @@ type ImageClient struct {
 	client *Client
 }
 
-// GetByID retrieves an image by its ID.
+// GetByID retrieves an image by its ID. If the image does not exist, nil is returned.
 func (c *ImageClient) GetByID(ctx context.Context, id int) (*Image, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/images/%d", id), nil)
 	if err != nil {
@@ -89,27 +89,17 @@ func (c *ImageClient) GetByID(ctx context.Context, id int) (*Image, *Response, e
 	return ImageFromSchema(body.Image), resp, nil
 }
 
-// GetByName retrieves an image by its name.
+// GetByName retrieves an image by its name. If the image does not exist, nil is returned.
 func (c *ImageClient) GetByName(ctx context.Context, name string) (*Image, *Response, error) {
-	path := "/images?name=" + url.QueryEscape(name)
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
+	images, response, err := c.List(ctx, ImageListOpts{Name: name})
+	if len(images) == 0 {
+		return nil, response, err
 	}
-
-	var body schema.ImageListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if len(body.Images) == 0 {
-		return nil, resp, nil
-	}
-	return ImageFromSchema(body.Images[0]), resp, nil
+	return images[0], response, err
 }
 
-// Get retrieves an image by its ID if the input can be parsed as an integer, otherwise it retrieves an image by its name.
+// Get retrieves an image by its ID if the input can be parsed as an integer, otherwise it
+// retrieves an image by its name. If the image does not exist, nil is returned.
 func (c *ImageClient) Get(ctx context.Context, idOrName string) (*Image, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
 		return c.GetByID(ctx, int(id))
@@ -120,11 +110,36 @@ func (c *ImageClient) Get(ctx context.Context, idOrName string) (*Image, *Respon
 // ImageListOpts specifies options for listing images.
 type ImageListOpts struct {
 	ListOpts
+	Type    []ImageType
+	BoundTo *Server
+	Name    string
+	Sort    []string
+	Status  []ImageStatus
+}
+
+func (l ImageListOpts) values() url.Values {
+	vals := l.ListOpts.values()
+	for _, typ := range l.Type {
+		vals.Add("type", string(typ))
+	}
+	if l.BoundTo != nil {
+		vals.Add("bound_to", strconv.Itoa(l.BoundTo.ID))
+	}
+	if l.Name != "" {
+		vals.Add("name", l.Name)
+	}
+	for _, sort := range l.Sort {
+		vals.Add("sort", sort)
+	}
+	for _, status := range l.Status {
+		vals.Add("status", string(status))
+	}
+	return vals
 }
 
 // List returns a list of images for a specific page.
 func (c *ImageClient) List(ctx context.Context, opts ImageListOpts) ([]*Image, *Response, error) {
-	path := "/images?" + valuesForListOpts(opts.ListOpts).Encode()
+	path := "/images?" + opts.values().Encode()
 	req, err := c.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
@@ -144,7 +159,7 @@ func (c *ImageClient) List(ctx context.Context, opts ImageListOpts) ([]*Image, *
 
 // All returns all images.
 func (c *ImageClient) All(ctx context.Context) ([]*Image, error) {
-	return c.AllWithOpts(ctx, ImageListOpts{ListOpts{PerPage: 50}})
+	return c.AllWithOpts(ctx, ImageListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
 
 // AllWithOpts returns all images for the given options.

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/location.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/location.go
@@ -18,6 +18,7 @@ type Location struct {
 	City        string
 	Latitude    float64
 	Longitude   float64
+	NetworkZone NetworkZone
 }
 
 // LocationClient is a client for the location API.
@@ -25,7 +26,7 @@ type LocationClient struct {
 	client *Client
 }
 
-// GetByID retrieves a location by its ID.
+// GetByID retrieves a location by its ID. If the location does not exist, nil is returned.
 func (c *LocationClient) GetByID(ctx context.Context, id int) (*Location, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/locations/%d", id), nil)
 	if err != nil {
@@ -43,27 +44,17 @@ func (c *LocationClient) GetByID(ctx context.Context, id int) (*Location, *Respo
 	return LocationFromSchema(body.Location), resp, nil
 }
 
-// GetByName retrieves an location by its name.
+// GetByName retrieves an location by its name. If the location does not exist, nil is returned.
 func (c *LocationClient) GetByName(ctx context.Context, name string) (*Location, *Response, error) {
-	path := "/locations?name=" + url.QueryEscape(name)
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
+	locations, response, err := c.List(ctx, LocationListOpts{Name: name})
+	if len(locations) == 0 {
+		return nil, response, err
 	}
-
-	var body schema.LocationListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if len(body.Locations) == 0 {
-		return nil, resp, nil
-	}
-	return LocationFromSchema(body.Locations[0]), resp, nil
+	return locations[0], response, err
 }
 
-// Get retrieves a location by its ID if the input can be parsed as an integer, otherwise it retrieves a location by its name.
+// Get retrieves a location by its ID if the input can be parsed as an integer, otherwise it
+// retrieves a location by its name. If the location does not exist, nil is returned.
 func (c *LocationClient) Get(ctx context.Context, idOrName string) (*Location, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
 		return c.GetByID(ctx, int(id))
@@ -74,11 +65,20 @@ func (c *LocationClient) Get(ctx context.Context, idOrName string) (*Location, *
 // LocationListOpts specifies options for listing location.
 type LocationListOpts struct {
 	ListOpts
+	Name string
+}
+
+func (l LocationListOpts) values() url.Values {
+	vals := l.ListOpts.values()
+	if l.Name != "" {
+		vals.Add("name", l.Name)
+	}
+	return vals
 }
 
 // List returns a list of locations for a specific page.
 func (c *LocationClient) List(ctx context.Context, opts LocationListOpts) ([]*Location, *Response, error) {
-	path := "/locations?" + valuesForListOpts(opts.ListOpts).Encode()
+	path := "/locations?" + opts.values().Encode()
 	req, err := c.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/network.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/network.go
@@ -1,0 +1,445 @@
+package hcloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/hetznercloud/hcloud-go/hcloud/schema"
+)
+
+// NetworkZone specifies a network zone.
+type NetworkZone string
+
+// List of available Network Zones.
+const (
+	NetworkZoneEUCentral NetworkZone = "eu-central"
+)
+
+// NetworkSubnetType specifies a type of a subnet.
+type NetworkSubnetType string
+
+// List of available network subnet types.
+const (
+	NetworkSubnetTypeServer NetworkSubnetType = "server"
+)
+
+// Network represents a network in the Hetzner Cloud.
+type Network struct {
+	ID         int
+	Name       string
+	Created    time.Time
+	IPRange    *net.IPNet
+	Subnets    []NetworkSubnet
+	Routes     []NetworkRoute
+	Servers    []*Server
+	Protection NetworkProtection
+	Labels     map[string]string
+}
+
+// NetworkSubnet represents a subnet of a network in the Hetzner Cloud.
+type NetworkSubnet struct {
+	Type        NetworkSubnetType
+	IPRange     *net.IPNet
+	NetworkZone NetworkZone
+	Gateway     net.IP
+}
+
+// NetworkRoute represents a route of a network.
+type NetworkRoute struct {
+	Destination *net.IPNet
+	Gateway     net.IP
+}
+
+// NetworkProtection represents the protection level of a network.
+type NetworkProtection struct {
+	Delete bool
+}
+
+// NetworkClient is a client for the network API.
+type NetworkClient struct {
+	client *Client
+}
+
+// GetByID retrieves a network by its ID. If the network does not exist, nil is returned.
+func (c *NetworkClient) GetByID(ctx context.Context, id int) (*Network, *Response, error) {
+	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/networks/%d", id), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var body schema.NetworkGetResponse
+	resp, err := c.client.Do(req, &body)
+	if err != nil {
+		if IsError(err, ErrorCodeNotFound) {
+			return nil, resp, nil
+		}
+		return nil, nil, err
+	}
+	return NetworkFromSchema(body.Network), resp, nil
+}
+
+// GetByName retrieves a network by its name. If the network does not exist, nil is returned.
+func (c *NetworkClient) GetByName(ctx context.Context, name string) (*Network, *Response, error) {
+	Networks, response, err := c.List(ctx, NetworkListOpts{Name: name})
+	if len(Networks) == 0 {
+		return nil, response, err
+	}
+	return Networks[0], response, err
+}
+
+// Get retrieves a network by its ID if the input can be parsed as an integer, otherwise it
+// retrieves a network by its name. If the network does not exist, nil is returned.
+func (c *NetworkClient) Get(ctx context.Context, idOrName string) (*Network, *Response, error) {
+	if id, err := strconv.Atoi(idOrName); err == nil {
+		return c.GetByID(ctx, int(id))
+	}
+	return c.GetByName(ctx, idOrName)
+}
+
+// NetworkListOpts specifies options for listing networks.
+type NetworkListOpts struct {
+	ListOpts
+	Name string
+}
+
+func (l NetworkListOpts) values() url.Values {
+	vals := l.ListOpts.values()
+	if l.Name != "" {
+		vals.Add("name", l.Name)
+	}
+	return vals
+}
+
+// List returns a list of networks for a specific page.
+func (c *NetworkClient) List(ctx context.Context, opts NetworkListOpts) ([]*Network, *Response, error) {
+	path := "/networks?" + opts.values().Encode()
+	req, err := c.client.NewRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var body schema.NetworkListResponse
+	resp, err := c.client.Do(req, &body)
+	if err != nil {
+		return nil, nil, err
+	}
+	Networks := make([]*Network, 0, len(body.Networks))
+	for _, s := range body.Networks {
+		Networks = append(Networks, NetworkFromSchema(s))
+	}
+	return Networks, resp, nil
+}
+
+// All returns all networks.
+func (c *NetworkClient) All(ctx context.Context) ([]*Network, error) {
+	return c.AllWithOpts(ctx, NetworkListOpts{ListOpts: ListOpts{PerPage: 50}})
+}
+
+// AllWithOpts returns all networks for the given options.
+func (c *NetworkClient) AllWithOpts(ctx context.Context, opts NetworkListOpts) ([]*Network, error) {
+	var allNetworks []*Network
+
+	_, err := c.client.all(func(page int) (*Response, error) {
+		opts.Page = page
+		Networks, resp, err := c.List(ctx, opts)
+		if err != nil {
+			return resp, err
+		}
+		allNetworks = append(allNetworks, Networks...)
+		return resp, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return allNetworks, nil
+}
+
+// Delete deletes a network.
+func (c *NetworkClient) Delete(ctx context.Context, network *Network) (*Response, error) {
+	req, err := c.client.NewRequest(ctx, "DELETE", fmt.Sprintf("/networks/%d", network.ID), nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.client.Do(req, nil)
+}
+
+// NetworkUpdateOpts specifies options for updating a network.
+type NetworkUpdateOpts struct {
+	Name   string
+	Labels map[string]string
+}
+
+// Update updates a network.
+func (c *NetworkClient) Update(ctx context.Context, network *Network, opts NetworkUpdateOpts) (*Network, *Response, error) {
+	reqBody := schema.NetworkUpdateRequest{
+		Name: opts.Name,
+	}
+	if opts.Labels != nil {
+		reqBody.Labels = &opts.Labels
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/networks/%d", network.ID)
+	req, err := c.client.NewRequest(ctx, "PUT", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.NetworkUpdateResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return NetworkFromSchema(respBody.Network), resp, nil
+}
+
+// NetworkCreateOpts specifies options for creating a new network.
+type NetworkCreateOpts struct {
+	Name    string
+	IPRange *net.IPNet
+	Subnets []NetworkSubnet
+	Routes  []NetworkRoute
+	Labels  map[string]string
+}
+
+// Validate checks if options are valid.
+func (o NetworkCreateOpts) Validate() error {
+	if o.Name == "" {
+		return errors.New("missing name")
+	}
+	if o.IPRange == nil || o.IPRange.String() == "" {
+		return errors.New("missing IP range")
+	}
+	return nil
+}
+
+// Create creates a new network.
+func (c *NetworkClient) Create(ctx context.Context, opts NetworkCreateOpts) (*Network, *Response, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, nil, err
+	}
+	reqBody := schema.NetworkCreateRequest{
+		Name:    opts.Name,
+		IPRange: opts.IPRange.String(),
+	}
+	for _, subnet := range opts.Subnets {
+		reqBody.Subnets = append(reqBody.Subnets, schema.NetworkSubnet{
+			Type:        string(subnet.Type),
+			IPRange:     subnet.IPRange.String(),
+			NetworkZone: string(subnet.NetworkZone),
+		})
+	}
+	for _, route := range opts.Routes {
+		reqBody.Routes = append(reqBody.Routes, schema.NetworkRoute{
+			Destination: route.Destination.String(),
+			Gateway:     route.Gateway.String(),
+		})
+	}
+	if opts.Labels != nil {
+		reqBody.Labels = &opts.Labels
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := c.client.NewRequest(ctx, "POST", "/networks", bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.NetworkCreateResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return NetworkFromSchema(respBody.Network), resp, nil
+}
+
+// NetworkChangeIPRangeOpts specifies options for changing the IP range of a network.
+type NetworkChangeIPRangeOpts struct {
+	IPRange *net.IPNet
+}
+
+// ChangeIPRange changes the IP range of a network.
+func (c *NetworkClient) ChangeIPRange(ctx context.Context, network *Network, opts NetworkChangeIPRangeOpts) (*Action, *Response, error) {
+	reqBody := schema.NetworkActionChangeIPRangeRequest{
+		IPRange: opts.IPRange.String(),
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/networks/%d/actions/change_ip_range", network.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.NetworkActionChangeIPRangeResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
+}
+
+// NetworkAddSubnetOpts specifies options for adding a subnet to a network.
+type NetworkAddSubnetOpts struct {
+	Subnet NetworkSubnet
+}
+
+// AddSubnet adds a subnet to a network.
+func (c *NetworkClient) AddSubnet(ctx context.Context, network *Network, opts NetworkAddSubnetOpts) (*Action, *Response, error) {
+	reqBody := schema.NetworkActionAddSubnetRequest{
+		Type:        string(opts.Subnet.Type),
+		IPRange:     opts.Subnet.IPRange.String(),
+		NetworkZone: string(opts.Subnet.NetworkZone),
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/networks/%d/actions/add_subnet", network.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.NetworkActionAddSubnetResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
+}
+
+// NetworkDeleteSubnetOpts specifies options for deleting a subnet from a network.
+type NetworkDeleteSubnetOpts struct {
+	Subnet NetworkSubnet
+}
+
+// DeleteSubnet deletes a subnet from a network.
+func (c *NetworkClient) DeleteSubnet(ctx context.Context, network *Network, opts NetworkDeleteSubnetOpts) (*Action, *Response, error) {
+	reqBody := schema.NetworkActionDeleteSubnetRequest{
+		IPRange: opts.Subnet.IPRange.String(),
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/networks/%d/actions/delete_subnet", network.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.NetworkActionDeleteSubnetResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
+}
+
+// NetworkAddRouteOpts specifies options for adding a route to a network.
+type NetworkAddRouteOpts struct {
+	Route NetworkRoute
+}
+
+// AddRoute adds a route to a network.
+func (c *NetworkClient) AddRoute(ctx context.Context, network *Network, opts NetworkAddRouteOpts) (*Action, *Response, error) {
+	reqBody := schema.NetworkActionAddRouteRequest{
+		Destination: opts.Route.Destination.String(),
+		Gateway:     opts.Route.Gateway.String(),
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/networks/%d/actions/add_route", network.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.NetworkActionAddSubnetResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
+}
+
+// NetworkDeleteRouteOpts specifies options for deleting a route from a network.
+type NetworkDeleteRouteOpts struct {
+	Route NetworkRoute
+}
+
+// DeleteRoute deletes a route from a network.
+func (c *NetworkClient) DeleteRoute(ctx context.Context, network *Network, opts NetworkDeleteRouteOpts) (*Action, *Response, error) {
+	reqBody := schema.NetworkActionDeleteRouteRequest{
+		Destination: opts.Route.Destination.String(),
+		Gateway:     opts.Route.Gateway.String(),
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/networks/%d/actions/delete_route", network.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.NetworkActionDeleteSubnetResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
+}
+
+// NetworkChangeProtectionOpts specifies options for changing the resource protection level of a network.
+type NetworkChangeProtectionOpts struct {
+	Delete *bool
+}
+
+// ChangeProtection changes the resource protection level of a network.
+func (c *NetworkClient) ChangeProtection(ctx context.Context, network *Network, opts NetworkChangeProtectionOpts) (*Action, *Response, error) {
+	reqBody := schema.NetworkActionChangeProtectionRequest{
+		Delete: opts.Delete,
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/networks/%d/actions/change_protection", network.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.NetworkActionChangeProtectionResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, err
+}

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/floating_ip.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/floating_ip.go
@@ -1,9 +1,12 @@
 package schema
 
+import "time"
+
 // FloatingIP defines the schema of a Floating IP.
 type FloatingIP struct {
 	ID           int                  `json:"id"`
 	Description  *string              `json:"description"`
+	Created      time.Time            `json:"created"`
 	IP           string               `json:"ip"`
 	Type         string               `json:"type"`
 	Server       *int                 `json:"server"`

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/location.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/location.go
@@ -9,6 +9,7 @@ type Location struct {
 	City        string  `json:"city"`
 	Latitude    float64 `json:"latitude"`
 	Longitude   float64 `json:"longitude"`
+	NetworkZone string  `json:"network_zone"`
 }
 
 // LocationGetResponse defines the schema of the response when retrieving a single location.

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/network.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/network.go
@@ -1,0 +1,150 @@
+package schema
+
+import "time"
+
+// Network defines the schema of a network.
+type Network struct {
+	ID         int               `json:"id"`
+	Name       string            `json:"name"`
+	Created    time.Time         `json:"created"`
+	IPRange    string            `json:"ip_range"`
+	Subnets    []NetworkSubnet   `json:"subnets"`
+	Routes     []NetworkRoute    `json:"routes"`
+	Servers    []int             `json:"servers"`
+	Protection NetworkProtection `json:"protection"`
+	Labels     map[string]string `json:"labels"`
+}
+
+// NetworkSubnet represents a subnet of a network.
+type NetworkSubnet struct {
+	Type        string `json:"type"`
+	IPRange     string `json:"ip_range"`
+	NetworkZone string `json:"network_zone"`
+	Gateway     string `json:"gateway"`
+}
+
+// NetworkRoute represents a route of a network.
+type NetworkRoute struct {
+	Destination string `json:"destination"`
+	Gateway     string `json:"gateway"`
+}
+
+// NetworkProtection represents the protection level of a network.
+type NetworkProtection struct {
+	Delete bool `json:"delete"`
+}
+
+// NetworkUpdateRequest defines the schema of the request to update a network.
+type NetworkUpdateRequest struct {
+	Name   string             `json:"name,omitempty"`
+	Labels *map[string]string `json:"labels,omitempty"`
+}
+
+// NetworkUpdateResponse defines the schema of the response when updating a network.
+type NetworkUpdateResponse struct {
+	Network Network `json:"network"`
+}
+
+// NetworkListResponse defines the schema of the response when
+// listing networks.
+type NetworkListResponse struct {
+	Networks []Network `json:"networks"`
+}
+
+// NetworkGetResponse defines the schema of the response when
+// retrieving a single network.
+type NetworkGetResponse struct {
+	Network Network `json:"network"`
+}
+
+// NetworkCreateRequest defines the schema of the request to create a network.
+type NetworkCreateRequest struct {
+	Name    string             `json:"name"`
+	IPRange string             `json:"ip_range"`
+	Subnets []NetworkSubnet    `json:"subnets,omitempty"`
+	Routes  []NetworkRoute     `json:"routes,omitempty"`
+	Labels  *map[string]string `json:"labels,omitempty"`
+}
+
+// NetworkCreateResponse defines the schema of the response when
+// creating a network.
+type NetworkCreateResponse struct {
+	Network Network `json:"network"`
+}
+
+// NetworkActionChangeIPRangeRequest defines the schema of the request to
+// change the IP range of a network.
+type NetworkActionChangeIPRangeRequest struct {
+	IPRange string `json:"ip_range"`
+}
+
+// NetworkActionChangeIPRangeResponse defines the schema of the response when
+// changing the IP range of a network.
+type NetworkActionChangeIPRangeResponse struct {
+	Action Action `json:"action"`
+}
+
+// NetworkActionAddSubnetRequest defines the schema of the request to
+// add a subnet to a network.
+type NetworkActionAddSubnetRequest struct {
+	Type        string `json:"type"`
+	IPRange     string `json:"ip_range,omitempty"`
+	NetworkZone string `json:"network_zone"`
+	Gateway     string `json:"gateway"`
+}
+
+// NetworkActionAddSubnetResponse defines the schema of the response when
+// adding a subnet to a network.
+type NetworkActionAddSubnetResponse struct {
+	Action Action `json:"action"`
+}
+
+// NetworkActionDeleteSubnetRequest defines the schema of the request to
+// delete a subnet from a network.
+type NetworkActionDeleteSubnetRequest struct {
+	IPRange string `json:"ip_range"`
+}
+
+// NetworkActionDeleteSubnetResponse defines the schema of the response when
+// deleting a subnet from a network.
+type NetworkActionDeleteSubnetResponse struct {
+	Action Action `json:"action"`
+}
+
+// NetworkActionAddRouteRequest defines the schema of the request to
+// add a route to a network.
+type NetworkActionAddRouteRequest struct {
+	Destination string `json:"destination"`
+	Gateway     string `json:"gateway"`
+}
+
+// NetworkActionAddRouteResponse defines the schema of the response when
+// adding a route to a network.
+type NetworkActionAddRouteResponse struct {
+	Action Action `json:"action"`
+}
+
+// NetworkActionDeleteRouteRequest defines the schema of the request to
+// delete a route from a network.
+type NetworkActionDeleteRouteRequest struct {
+	Destination string `json:"destination"`
+	Gateway     string `json:"gateway"`
+}
+
+// NetworkActionDeleteRouteResponse defines the schema of the response when
+// deleting a route from a network.
+type NetworkActionDeleteRouteResponse struct {
+	Action Action `json:"action"`
+}
+
+// NetworkActionChangeProtectionRequest defines the schema of the request to
+// change the resource protection of a network.
+type NetworkActionChangeProtectionRequest struct {
+	Delete *bool `json:"delete,omitempty"`
+}
+
+// NetworkActionChangeProtectionResponse defines the schema of the response when
+// changing the resource protection of a network.
+type NetworkActionChangeProtectionResponse struct {
+	Action Action `json:"action"`
+}

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/server.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/server.go
@@ -4,23 +4,25 @@ import "time"
 
 // Server defines the schema of a server.
 type Server struct {
-	ID              int               `json:"id"`
-	Name            string            `json:"name"`
-	Status          string            `json:"status"`
-	Created         time.Time         `json:"created"`
-	PublicNet       ServerPublicNet   `json:"public_net"`
-	ServerType      ServerType        `json:"server_type"`
-	IncludedTraffic uint64            `json:"included_traffic"`
-	OutgoingTraffic *uint64           `json:"outgoing_traffic"`
-	IngoingTraffic  *uint64           `json:"ingoing_traffic"`
-	BackupWindow    *string           `json:"backup_window"`
-	RescueEnabled   bool              `json:"rescue_enabled"`
-	ISO             *ISO              `json:"iso"`
-	Locked          bool              `json:"locked"`
-	Datacenter      Datacenter        `json:"datacenter"`
-	Image           *Image            `json:"image"`
-	Protection      ServerProtection  `json:"protection"`
-	Labels          map[string]string `json:"labels"`
+	ID              int                `json:"id"`
+	Name            string             `json:"name"`
+	Status          string             `json:"status"`
+	Created         time.Time          `json:"created"`
+	PublicNet       ServerPublicNet    `json:"public_net"`
+	PrivateNet      []ServerPrivateNet `json:"private_net"`
+	ServerType      ServerType         `json:"server_type"`
+	IncludedTraffic uint64             `json:"included_traffic"`
+	OutgoingTraffic *uint64            `json:"outgoing_traffic"`
+	IngoingTraffic  *uint64            `json:"ingoing_traffic"`
+	BackupWindow    *string            `json:"backup_window"`
+	RescueEnabled   bool               `json:"rescue_enabled"`
+	ISO             *ISO               `json:"iso"`
+	Locked          bool               `json:"locked"`
+	Datacenter      Datacenter         `json:"datacenter"`
+	Image           *Image             `json:"image"`
+	Protection      ServerProtection   `json:"protection"`
+	Labels          map[string]string  `json:"labels"`
+	Volumes         []int              `json:"volumes"`
 }
 
 // ServerProtection defines the schema of a server's resource protection.
@@ -60,6 +62,14 @@ type ServerPublicNetIPv6DNSPtr struct {
 	DNSPtr string `json:"dns_ptr"`
 }
 
+// ServerPrivateNet defines the schema of a server's private network information.
+type ServerPrivateNet struct {
+	Network    int      `json:"network"`
+	IP         string   `json:"ip"`
+	AliasIPs   []string `json:"alias_ips"`
+	MACAddress string   `json:"mac_address"`
+}
+
 // ServerGetResponse defines the schema of the response when
 // retrieving a single server.
 type ServerGetResponse struct {
@@ -84,14 +94,18 @@ type ServerCreateRequest struct {
 	UserData         string             `json:"user_data,omitempty"`
 	StartAfterCreate *bool              `json:"start_after_create,omitempty"`
 	Labels           *map[string]string `json:"labels,omitempty"`
+	Automount        *bool              `json:"automount,omitempty"`
+	Volumes          []int              `json:"volumes,omitempty"`
+	Networks         []int              `json:"networks,omitempty"`
 }
 
 // ServerCreateResponse defines the schema of the response when
 // creating a server.
 type ServerCreateResponse struct {
-	Server       Server  `json:"server"`
-	Action       Action  `json:"action"`
-	RootPassword *string `json:"root_password"`
+	Server       Server   `json:"server"`
+	Action       Action   `json:"action"`
+	RootPassword *string  `json:"root_password"`
+	NextActions  []Action `json:"next_actions"`
 }
 
 // ServerUpdateRequest defines the schema of the request to update a server.
@@ -287,13 +301,54 @@ type ServerActionChangeDNSPtrResponse struct {
 	Action Action `json:"action"`
 }
 
-// ServerActionChangeProtectionRequest defines the schema of the request to change the resource protection of a server.
+// ServerActionChangeProtectionRequest defines the schema of the request to
+// change the resource protection of a server.
 type ServerActionChangeProtectionRequest struct {
 	Rebuild *bool `json:"rebuild,omitempty"`
 	Delete  *bool `json:"delete,omitempty"`
 }
 
-// ServerActionChangeProtectionResponse defines the schema of the response when changing the resource protection of a server.
+// ServerActionChangeProtectionResponse defines the schema of the response when
+// changing the resource protection of a server.
 type ServerActionChangeProtectionResponse struct {
+	Action Action `json:"action"`
+}
+
+// ServerActionAttachToNetworkRequest defines the schema for the request to
+// attach a network to a server.
+type ServerActionAttachToNetworkRequest struct {
+	Network  int       `json:"network"`
+	IP       *string   `json:"ip,omitempty"`
+	AliasIPs []*string `json:"alias_ips,omitempty"`
+}
+
+// ServerActionAttachToNetworkResponse defines the schema of the response when
+// creating an attach_to_network server action.
+type ServerActionAttachToNetworkResponse struct {
+	Action Action `json:"action"`
+}
+
+// ServerActionDetachFromNetworkRequest defines the schema for the request to
+// detach a network from a server.
+type ServerActionDetachFromNetworkRequest struct {
+	Network int `json:"network"`
+}
+
+// ServerActionDetachFromNetworkResponse defines the schema of the response when
+// creating a detach_from_network server action.
+type ServerActionDetachFromNetworkResponse struct {
+	Action Action `json:"action"`
+}
+
+// ServerActionChangeAliasIPsRequest defines the schema for the request to
+// change a server's alias IPs in a network.
+type ServerActionChangeAliasIPsRequest struct {
+	Network  int      `json:"network"`
+	AliasIPs []string `json:"alias_ips"`
+}
+
+// ServerActionChangeAliasIPsResponse defines the schema of the response when
+// creating an change_alias_ips server action.
+type ServerActionChangeAliasIPsResponse struct {
 	Action Action `json:"action"`
 }

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/volume.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/schema/volume.go
@@ -1,0 +1,109 @@
+package schema
+
+import "time"
+
+// Volume defines the schema of a volume.
+type Volume struct {
+	ID          int               `json:"id"`
+	Name        string            `json:"name"`
+	Server      *int              `json:"server"`
+	Location    Location          `json:"location"`
+	Size        int               `json:"size"`
+	Protection  VolumeProtection  `json:"protection"`
+	Labels      map[string]string `json:"labels"`
+	LinuxDevice string            `json:"linux_device"`
+	Created     time.Time         `json:"created"`
+}
+
+// VolumeCreateRequest defines the schema of the request
+// to create a volume.
+type VolumeCreateRequest struct {
+	Name      string             `json:"name"`
+	Size      int                `json:"size"`
+	Server    *int               `json:"server,omitempty"`
+	Location  interface{}        `json:"location,omitempty"` // int, string, or nil
+	Labels    *map[string]string `json:"labels,omitempty"`
+	Automount *bool              `json:"automount,omitempty"`
+	Format    *string            `json:"format,omitempty"`
+}
+
+// VolumeCreateResponse defines the schema of the response
+// when creating a volume.
+type VolumeCreateResponse struct {
+	Volume      Volume   `json:"volume"`
+	Action      *Action  `json:"action"`
+	NextActions []Action `json:"next_actions"`
+}
+
+// VolumeListResponse defines the schema of the response
+// when listing volumes.
+type VolumeListResponse struct {
+	Volumes []Volume `json:"volumes"`
+}
+
+// VolumeGetResponse defines the schema of the response
+// when retrieving a single volume.
+type VolumeGetResponse struct {
+	Volume Volume `json:"volume"`
+}
+
+// VolumeUpdateRequest defines the schema of the request to update a volume.
+type VolumeUpdateRequest struct {
+	Name   string             `json:"name,omitempty"`
+	Labels *map[string]string `json:"labels,omitempty"`
+}
+
+// VolumeUpdateResponse defines the schema of the response when updating a volume.
+type VolumeUpdateResponse struct {
+	Volume Volume `json:"volume"`
+}
+
+// VolumeProtection defines the schema of a volume's resource protection.
+type VolumeProtection struct {
+	Delete bool `json:"delete"`
+}
+
+// VolumeActionChangeProtectionRequest defines the schema of the request to
+// change the resource protection of a volume.
+type VolumeActionChangeProtectionRequest struct {
+	Delete *bool `json:"delete,omitempty"`
+}
+
+// VolumeActionChangeProtectionResponse defines the schema of the response when
+// changing the resource protection of a volume.
+type VolumeActionChangeProtectionResponse struct {
+	Action Action `json:"action"`
+}
+
+// VolumeActionAttachVolumeRequest defines the schema of the request to
+// attach a volume to a server.
+type VolumeActionAttachVolumeRequest struct {
+	Server    int   `json:"server"`
+	Automount *bool `json:"automount,omitempty"`
+}
+
+// VolumeActionAttachVolumeResponse defines the schema of the response when
+// attaching a volume to a server.
+type VolumeActionAttachVolumeResponse struct {
+	Action Action `json:"action"`
+}
+
+// VolumeActionDetachVolumeRequest defines the schema of the request to
+// create an detach volume action.
+type VolumeActionDetachVolumeRequest struct{}
+
+// VolumeActionDetachVolumeResponse defines the schema of the response when
+// creating an detach volume action.
+type VolumeActionDetachVolumeResponse struct {
+	Action Action `json:"action"`
+}
+
+// VolumeActionResizeVolumeRequest defines the schema of the request to resize a volume.
+type VolumeActionResizeVolumeRequest struct {
+	Size int `json:"size"`
+}
+
+// VolumeActionResizeVolumeResponse defines the schema of the response when resizing a volume.
+type VolumeActionResizeVolumeResponse struct {
+	Action Action `json:"action"`
+}

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/server.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/server.go
@@ -21,6 +21,7 @@ type Server struct {
 	Status          ServerStatus
 	Created         time.Time
 	PublicNet       ServerPublicNet
+	PrivateNet      []ServerPrivateNet
 	ServerType      *ServerType
 	Datacenter      *Datacenter
 	IncludedTraffic uint64
@@ -33,6 +34,7 @@ type Server struct {
 	Image           *Image
 	Protection      ServerProtection
 	Labels          map[string]string
+	Volumes         []*Volume
 }
 
 // ServerProtection represents the protection level of a server.
@@ -52,6 +54,24 @@ const (
 
 	// ServerStatusRunning is the status when a server is running.
 	ServerStatusRunning ServerStatus = "running"
+
+	// ServerStatusStarting is the status when a server is being started.
+	ServerStatusStarting ServerStatus = "starting"
+
+	// ServerStatusStopping is the status when a server is being stopped.
+	ServerStatusStopping ServerStatus = "stopping"
+
+	// ServerStatusMigrating is the status when a server is being migrated.
+	ServerStatusMigrating ServerStatus = "migrating"
+
+	// ServerStatusRebuilding is the status when a server is being rebuilt.
+	ServerStatusRebuilding ServerStatus = "rebuilding"
+
+	// ServerStatusDeleting is the status when a server is being deleted.
+	ServerStatusDeleting ServerStatus = "deleting"
+
+	// ServerStatusUnknown is the status when a server's state is unknown.
+	ServerStatusUnknown ServerStatus = "unknown"
 )
 
 // ServerPublicNet represents a server's public network.
@@ -76,6 +96,14 @@ type ServerPublicNetIPv6 struct {
 	DNSPtr  map[string]string
 }
 
+// ServerPrivateNet defines the schema of a server's private network information.
+type ServerPrivateNet struct {
+	Network    *Network
+	IP         net.IP
+	Aliases    []net.IP
+	MACAddress string
+}
+
 // DNSPtrForIP returns the reverse dns pointer of the ip address.
 func (s *ServerPublicNetIPv6) DNSPtrForIP(ip net.IP) string {
 	return s.DNSPtr[ip.String()]
@@ -96,7 +124,7 @@ type ServerClient struct {
 	client *Client
 }
 
-// GetByID retrieves a server by its ID.
+// GetByID retrieves a server by its ID. If the server does not exist, nil is returned.
 func (c *ServerClient) GetByID(ctx context.Context, id int) (*Server, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/servers/%d", id), nil)
 	if err != nil {
@@ -114,27 +142,17 @@ func (c *ServerClient) GetByID(ctx context.Context, id int) (*Server, *Response,
 	return ServerFromSchema(body.Server), resp, nil
 }
 
-// GetByName retreives a server by its name.
+// GetByName retrieves a server by its name. If the server does not exist, nil is returned.
 func (c *ServerClient) GetByName(ctx context.Context, name string) (*Server, *Response, error) {
-	path := "/servers?name=" + url.QueryEscape(name)
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
+	servers, response, err := c.List(ctx, ServerListOpts{Name: name})
+	if len(servers) == 0 {
+		return nil, response, err
 	}
-
-	var body schema.ServerListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if len(body.Servers) == 0 {
-		return nil, resp, nil
-	}
-	return ServerFromSchema(body.Servers[0]), resp, nil
+	return servers[0], response, err
 }
 
-// Get retrieves a server by its ID if the input can be parsed as an integer, otherwise it retrieves a server by its name.
+// Get retrieves a server by its ID if the input can be parsed as an integer, otherwise it
+// retrieves a server by its name. If the server does not exist, nil is returned.
 func (c *ServerClient) Get(ctx context.Context, idOrName string) (*Server, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
 		return c.GetByID(ctx, int(id))
@@ -145,11 +163,24 @@ func (c *ServerClient) Get(ctx context.Context, idOrName string) (*Server, *Resp
 // ServerListOpts specifies options for listing servers.
 type ServerListOpts struct {
 	ListOpts
+	Name   string
+	Status []ServerStatus
+}
+
+func (l ServerListOpts) values() url.Values {
+	vals := l.ListOpts.values()
+	if l.Name != "" {
+		vals.Add("name", l.Name)
+	}
+	for _, status := range l.Status {
+		vals.Add("status", string(status))
+	}
+	return vals
 }
 
 // List returns a list of servers for a specific page.
 func (c *ServerClient) List(ctx context.Context, opts ServerListOpts) ([]*Server, *Response, error) {
-	path := "/servers?" + valuesForListOpts(opts.ListOpts).Encode()
+	path := "/servers?" + opts.values().Encode()
 	req, err := c.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
@@ -169,7 +200,7 @@ func (c *ServerClient) List(ctx context.Context, opts ServerListOpts) ([]*Server
 
 // All returns all servers.
 func (c *ServerClient) All(ctx context.Context) ([]*Server, error) {
-	return c.AllWithOpts(ctx, ServerListOpts{ListOpts{PerPage: 50}})
+	return c.AllWithOpts(ctx, ServerListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
 
 // AllWithOpts returns all servers for the given options.
@@ -203,6 +234,9 @@ type ServerCreateOpts struct {
 	UserData         string
 	StartAfterCreate *bool
 	Labels           map[string]string
+	Automount        *bool
+	Volumes          []*Volume
+	Networks         []*Network
 }
 
 // Validate checks if options are valid.
@@ -227,6 +261,7 @@ type ServerCreateResult struct {
 	Server       *Server
 	Action       *Action
 	RootPassword string
+	NextActions  []*Action
 }
 
 // Create creates a new server.
@@ -238,6 +273,7 @@ func (c *ServerClient) Create(ctx context.Context, opts ServerCreateOpts) (Serve
 	var reqBody schema.ServerCreateRequest
 	reqBody.UserData = opts.UserData
 	reqBody.Name = opts.Name
+	reqBody.Automount = opts.Automount
 	reqBody.StartAfterCreate = opts.StartAfterCreate
 	if opts.ServerType.ID != 0 {
 		reqBody.ServerType = opts.ServerType.ID
@@ -255,6 +291,13 @@ func (c *ServerClient) Create(ctx context.Context, opts ServerCreateOpts) (Serve
 	for _, sshKey := range opts.SSHKeys {
 		reqBody.SSHKeys = append(reqBody.SSHKeys, sshKey.ID)
 	}
+	for _, volume := range opts.Volumes {
+		reqBody.Volumes = append(reqBody.Volumes, volume.ID)
+	}
+	for _, network := range opts.Networks {
+		reqBody.Networks = append(reqBody.Networks, network.ID)
+	}
+
 	if opts.Location != nil {
 		if opts.Location.ID != 0 {
 			reqBody.Location = strconv.Itoa(opts.Location.ID)
@@ -285,8 +328,9 @@ func (c *ServerClient) Create(ctx context.Context, opts ServerCreateOpts) (Serve
 		return ServerCreateResult{}, resp, err
 	}
 	result := ServerCreateResult{
-		Server: ServerFromSchema(respBody.Server),
-		Action: ActionFromSchema(respBody.Action),
+		Server:      ServerFromSchema(respBody.Server),
+		Action:      ActionFromSchema(respBody.Action),
+		NextActions: ActionsFromSchema(respBody.NextActions),
 	}
 	if respBody.RootPassword != nil {
 		result.RootPassword = *respBody.RootPassword
@@ -752,7 +796,7 @@ type ServerChangeProtectionOpts struct {
 }
 
 // ChangeProtection changes the resource protection level of a server.
-func (c *ServerClient) ChangeProtection(ctx context.Context, image *Server, opts ServerChangeProtectionOpts) (*Action, *Response, error) {
+func (c *ServerClient) ChangeProtection(ctx context.Context, server *Server, opts ServerChangeProtectionOpts) (*Action, *Response, error) {
 	reqBody := schema.ServerActionChangeProtectionRequest{
 		Rebuild: opts.Rebuild,
 		Delete:  opts.Delete,
@@ -762,13 +806,112 @@ func (c *ServerClient) ChangeProtection(ctx context.Context, image *Server, opts
 		return nil, nil, err
 	}
 
-	path := fmt.Sprintf("/servers/%d/actions/change_protection", image.ID)
+	path := fmt.Sprintf("/servers/%d/actions/change_protection", server.ID)
 	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
 	if err != nil {
 		return nil, nil, err
 	}
 
 	respBody := schema.ServerActionChangeProtectionResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, err
+}
+
+// ServerAttachToNetworkOpts specifies options for attaching a server to a network.
+type ServerAttachToNetworkOpts struct {
+	Network  *Network
+	IP       net.IP
+	AliasIPs []net.IP
+}
+
+// AttachToNetwork attaches a server to a network.
+func (c *ServerClient) AttachToNetwork(ctx context.Context, server *Server, opts ServerAttachToNetworkOpts) (*Action, *Response, error) {
+	reqBody := schema.ServerActionAttachToNetworkRequest{
+		Network: opts.Network.ID,
+	}
+	if opts.IP != nil {
+		reqBody.IP = String(opts.IP.String())
+	}
+	for _, aliasIP := range opts.AliasIPs {
+		reqBody.AliasIPs = append(reqBody.AliasIPs, String(aliasIP.String()))
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/servers/%d/actions/attach_to_network", server.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.ServerActionAttachToNetworkResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, err
+}
+
+// ServerDetachFromNetworkOpts specifies options for detaching a server from a network.
+type ServerDetachFromNetworkOpts struct {
+	Network *Network
+}
+
+// DetachFromNetwork detaches a server from a network.
+func (c *ServerClient) DetachFromNetwork(ctx context.Context, server *Server, opts ServerDetachFromNetworkOpts) (*Action, *Response, error) {
+	reqBody := schema.ServerActionDetachFromNetworkRequest{
+		Network: opts.Network.ID,
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/servers/%d/actions/detach_from_network", server.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.ServerActionDetachFromNetworkResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, err
+}
+
+// ServerChangeAliasIPsOpts specifies options for changing the alias ips of an already attached network.
+type ServerChangeAliasIPsOpts struct {
+	Network  *Network
+	AliasIPs []net.IP
+}
+
+// ChangeAliasIPs changes a server's alias IPs in a network.
+func (c *ServerClient) ChangeAliasIPs(ctx context.Context, server *Server, opts ServerChangeAliasIPsOpts) (*Action, *Response, error) {
+	reqBody := schema.ServerActionChangeAliasIPsRequest{
+		Network:  opts.Network.ID,
+		AliasIPs: []string{},
+	}
+	for _, aliasIP := range opts.AliasIPs {
+		reqBody.AliasIPs = append(reqBody.AliasIPs, aliasIP.String())
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+	path := fmt.Sprintf("/servers/%d/actions/change_alias_ips", server.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.ServerActionDetachFromNetworkResponse{}
 	resp, err := c.client.Do(req, &respBody)
 	if err != nil {
 		return nil, resp, err

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/ssh_key.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/ssh_key.go
@@ -26,7 +26,7 @@ type SSHKeyClient struct {
 	client *Client
 }
 
-// GetByID retrieves a SSH key by its ID.
+// GetByID retrieves a SSH key by its ID. If the SSH key does not exist, nil is returned.
 func (c *SSHKeyClient) GetByID(ctx context.Context, id int) (*SSHKey, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/ssh_keys/%d", id), nil)
 	if err != nil {
@@ -44,47 +44,26 @@ func (c *SSHKeyClient) GetByID(ctx context.Context, id int) (*SSHKey, *Response,
 	return SSHKeyFromSchema(body.SSHKey), resp, nil
 }
 
-// GetByName retrieves a SSH key by its name.
+// GetByName retrieves a SSH key by its name. If the SSH key does not exist, nil is returned.
 func (c *SSHKeyClient) GetByName(ctx context.Context, name string) (*SSHKey, *Response, error) {
-	path := "/ssh_keys?name=" + url.QueryEscape(name)
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
+	sshKeys, response, err := c.List(ctx, SSHKeyListOpts{Name: name})
+	if len(sshKeys) == 0 {
+		return nil, response, err
 	}
-
-	var body schema.SSHKeyListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if len(body.SSHKeys) == 0 {
-		return nil, resp, nil
-	}
-	return SSHKeyFromSchema(body.SSHKeys[0]), resp, nil
+	return sshKeys[0], response, err
 }
 
-// GetByFingerprint retreives a SSH key by its fingerprint.
+// GetByFingerprint retreives a SSH key by its fingerprint. If the SSH key does not exist, nil is returned.
 func (c *SSHKeyClient) GetByFingerprint(ctx context.Context, fingerprint string) (*SSHKey, *Response, error) {
-	path := "/ssh_keys?fingerprint=" + url.QueryEscape(fingerprint)
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
+	sshKeys, response, err := c.List(ctx, SSHKeyListOpts{Fingerprint: fingerprint})
+	if len(sshKeys) == 0 {
+		return nil, response, err
 	}
-
-	var body schema.SSHKeyListResponse
-	resp, err := c.client.Do(req, &body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if len(body.SSHKeys) == 0 {
-		return nil, resp, nil
-	}
-	return SSHKeyFromSchema(body.SSHKeys[0]), resp, nil
+	return sshKeys[0], response, err
 }
 
-// Get retrieves a SSH key by its ID if the input can be parsed as an integer, otherwise it retrieves a SSH key by its name.
+// Get retrieves a SSH key by its ID if the input can be parsed as an integer, otherwise it
+// retrieves a SSH key by its name. If the SSH key does not exist, nil is returned.
 func (c *SSHKeyClient) Get(ctx context.Context, idOrName string) (*SSHKey, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
 		return c.GetByID(ctx, int(id))
@@ -95,11 +74,24 @@ func (c *SSHKeyClient) Get(ctx context.Context, idOrName string) (*SSHKey, *Resp
 // SSHKeyListOpts specifies options for listing SSH keys.
 type SSHKeyListOpts struct {
 	ListOpts
+	Name        string
+	Fingerprint string
+}
+
+func (l SSHKeyListOpts) values() url.Values {
+	vals := l.ListOpts.values()
+	if l.Name != "" {
+		vals.Add("name", l.Name)
+	}
+	if l.Fingerprint != "" {
+		vals.Add("fingerprint", l.Fingerprint)
+	}
+	return vals
 }
 
 // List returns a list of SSH keys for a specific page.
 func (c *SSHKeyClient) List(ctx context.Context, opts SSHKeyListOpts) ([]*SSHKey, *Response, error) {
-	path := "/ssh_keys?" + valuesForListOpts(opts.ListOpts).Encode()
+	path := "/ssh_keys?" + opts.values().Encode()
 	req, err := c.client.NewRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return nil, nil, err
@@ -119,7 +111,7 @@ func (c *SSHKeyClient) List(ctx context.Context, opts SSHKeyListOpts) ([]*SSHKey
 
 // All returns all SSH keys.
 func (c *SSHKeyClient) All(ctx context.Context) ([]*SSHKey, error) {
-	return c.AllWithOpts(ctx, SSHKeyListOpts{ListOpts{PerPage: 50}})
+	return c.AllWithOpts(ctx, SSHKeyListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
 
 // AllWithOpts returns all SSH keys with the given options.

--- a/vendor/github.com/hetznercloud/hcloud-go/hcloud/volume.go
+++ b/vendor/github.com/hetznercloud/hcloud-go/hcloud/volume.go
@@ -1,0 +1,392 @@
+package hcloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/hetznercloud/hcloud-go/hcloud/schema"
+)
+
+// Volume represents a volume in the Hetzner Cloud.
+type Volume struct {
+	ID          int
+	Name        string
+	Server      *Server
+	Location    *Location
+	Size        int
+	Protection  VolumeProtection
+	Labels      map[string]string
+	LinuxDevice string
+	Created     time.Time
+}
+
+// VolumeProtection represents the protection level of a volume.
+type VolumeProtection struct {
+	Delete bool
+}
+
+// VolumeClient is a client for the volume API.
+type VolumeClient struct {
+	client *Client
+}
+
+// VolumeStatus specifies a volume's status.
+type VolumeStatus string
+
+const (
+	// VolumeStatusCreating is the status when a volume is being created.
+	VolumeStatusCreating VolumeStatus = "creating"
+
+	// VolumeStatusAvailable is the status when a volume is available.
+	VolumeStatusAvailable VolumeStatus = "available"
+)
+
+// GetByID retrieves a volume by its ID. If the volume does not exist, nil is returned.
+func (c *VolumeClient) GetByID(ctx context.Context, id int) (*Volume, *Response, error) {
+	req, err := c.client.NewRequest(ctx, "GET", fmt.Sprintf("/volumes/%d", id), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var body schema.VolumeGetResponse
+	resp, err := c.client.Do(req, &body)
+	if err != nil {
+		if IsError(err, ErrorCodeNotFound) {
+			return nil, resp, nil
+		}
+		return nil, nil, err
+	}
+	return VolumeFromSchema(body.Volume), resp, nil
+}
+
+// GetByName retrieves a volume by its name. If the volume does not exist, nil is returned.
+func (c *VolumeClient) GetByName(ctx context.Context, name string) (*Volume, *Response, error) {
+	volumes, response, err := c.List(ctx, VolumeListOpts{Name: name})
+	if len(volumes) == 0 {
+		return nil, response, err
+	}
+	return volumes[0], response, err
+}
+
+// Get retrieves a volume by its ID if the input can be parsed as an integer, otherwise it
+// retrieves a volume by its name. If the volume does not exist, nil is returned.
+func (c *VolumeClient) Get(ctx context.Context, idOrName string) (*Volume, *Response, error) {
+	if id, err := strconv.Atoi(idOrName); err == nil {
+		return c.GetByID(ctx, int(id))
+	}
+	return c.GetByName(ctx, idOrName)
+}
+
+// VolumeListOpts specifies options for listing volumes.
+type VolumeListOpts struct {
+	ListOpts
+	Name   string
+	Status []VolumeStatus
+}
+
+func (l VolumeListOpts) values() url.Values {
+	vals := l.ListOpts.values()
+	if l.Name != "" {
+		vals.Add("name", l.Name)
+	}
+	for _, status := range l.Status {
+		vals.Add("status", string(status))
+	}
+	return vals
+}
+
+// List returns a list of volumes for a specific page.
+func (c *VolumeClient) List(ctx context.Context, opts VolumeListOpts) ([]*Volume, *Response, error) {
+	path := "/volumes?" + opts.values().Encode()
+	req, err := c.client.NewRequest(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var body schema.VolumeListResponse
+	resp, err := c.client.Do(req, &body)
+	if err != nil {
+		return nil, nil, err
+	}
+	volumes := make([]*Volume, 0, len(body.Volumes))
+	for _, s := range body.Volumes {
+		volumes = append(volumes, VolumeFromSchema(s))
+	}
+	return volumes, resp, nil
+}
+
+// All returns all volumes.
+func (c *VolumeClient) All(ctx context.Context) ([]*Volume, error) {
+	return c.AllWithOpts(ctx, VolumeListOpts{ListOpts: ListOpts{PerPage: 50}})
+}
+
+// AllWithOpts returns all volumes with the given options.
+func (c *VolumeClient) AllWithOpts(ctx context.Context, opts VolumeListOpts) ([]*Volume, error) {
+	allVolumes := []*Volume{}
+
+	_, err := c.client.all(func(page int) (*Response, error) {
+		opts.Page = page
+		volumes, resp, err := c.List(ctx, opts)
+		if err != nil {
+			return resp, err
+		}
+		allVolumes = append(allVolumes, volumes...)
+		return resp, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return allVolumes, nil
+}
+
+// VolumeCreateOpts specifies parameters for creating a volume.
+type VolumeCreateOpts struct {
+	Name      string
+	Size      int
+	Server    *Server
+	Location  *Location
+	Labels    map[string]string
+	Automount *bool
+	Format    *string
+}
+
+// Validate checks if options are valid.
+func (o VolumeCreateOpts) Validate() error {
+	if o.Name == "" {
+		return errors.New("missing name")
+	}
+	if o.Size <= 0 {
+		return errors.New("size must be greater than 0")
+	}
+	if o.Server == nil && o.Location == nil {
+		return errors.New("one of server or location must be provided")
+	}
+	if o.Server != nil && o.Location != nil {
+		return errors.New("only one of server or location must be provided")
+	}
+	if o.Server == nil && (o.Automount != nil && *o.Automount) {
+		return errors.New("server must be provided when automount is true")
+	}
+	return nil
+}
+
+// VolumeCreateResult is the result of creating a volume.
+type VolumeCreateResult struct {
+	Volume      *Volume
+	Action      *Action
+	NextActions []*Action
+}
+
+// Create creates a new volume with the given options.
+func (c *VolumeClient) Create(ctx context.Context, opts VolumeCreateOpts) (VolumeCreateResult, *Response, error) {
+	if err := opts.Validate(); err != nil {
+		return VolumeCreateResult{}, nil, err
+	}
+	reqBody := schema.VolumeCreateRequest{
+		Name:      opts.Name,
+		Size:      opts.Size,
+		Automount: opts.Automount,
+		Format:    opts.Format,
+	}
+	if opts.Labels != nil {
+		reqBody.Labels = &opts.Labels
+	}
+	if opts.Server != nil {
+		reqBody.Server = Int(opts.Server.ID)
+	}
+	if opts.Location != nil {
+		if opts.Location.ID != 0 {
+			reqBody.Location = opts.Location.ID
+		} else {
+			reqBody.Location = opts.Location.Name
+		}
+	}
+
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return VolumeCreateResult{}, nil, err
+	}
+
+	req, err := c.client.NewRequest(ctx, "POST", "/volumes", bytes.NewReader(reqBodyData))
+	if err != nil {
+		return VolumeCreateResult{}, nil, err
+	}
+
+	var respBody schema.VolumeCreateResponse
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return VolumeCreateResult{}, resp, err
+	}
+
+	var action *Action
+	if respBody.Action != nil {
+		action = ActionFromSchema(*respBody.Action)
+	}
+
+	return VolumeCreateResult{
+		Volume:      VolumeFromSchema(respBody.Volume),
+		Action:      action,
+		NextActions: ActionsFromSchema(respBody.NextActions),
+	}, resp, nil
+}
+
+// Delete deletes a volume.
+func (c *VolumeClient) Delete(ctx context.Context, volume *Volume) (*Response, error) {
+	req, err := c.client.NewRequest(ctx, "DELETE", fmt.Sprintf("/volumes/%d", volume.ID), nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.client.Do(req, nil)
+}
+
+// VolumeUpdateOpts specifies options for updating a volume.
+type VolumeUpdateOpts struct {
+	Name   string
+	Labels map[string]string
+}
+
+// Update updates a volume.
+func (c *VolumeClient) Update(ctx context.Context, volume *Volume, opts VolumeUpdateOpts) (*Volume, *Response, error) {
+	reqBody := schema.VolumeUpdateRequest{
+		Name: opts.Name,
+	}
+	if opts.Labels != nil {
+		reqBody.Labels = &opts.Labels
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/volumes/%d", volume.ID)
+	req, err := c.client.NewRequest(ctx, "PUT", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.VolumeUpdateResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return VolumeFromSchema(respBody.Volume), resp, nil
+}
+
+// VolumeAttachOpts specifies options for attaching a volume.
+type VolumeAttachOpts struct {
+	Server    *Server
+	Automount *bool
+}
+
+// AttachWithOpts attaches a volume to a server.
+func (c *VolumeClient) AttachWithOpts(ctx context.Context, volume *Volume, opts VolumeAttachOpts) (*Action, *Response, error) {
+	reqBody := schema.VolumeActionAttachVolumeRequest{
+		Server:    opts.Server.ID,
+		Automount: opts.Automount,
+	}
+
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/volumes/%d/actions/attach", volume.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var respBody schema.VolumeActionAttachVolumeResponse
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
+}
+
+// Attach attaches a volume to a server.
+func (c *VolumeClient) Attach(ctx context.Context, volume *Volume, server *Server) (*Action, *Response, error) {
+	return c.AttachWithOpts(ctx, volume, VolumeAttachOpts{Server: server})
+}
+
+// Detach detaches a volume from a server.
+func (c *VolumeClient) Detach(ctx context.Context, volume *Volume) (*Action, *Response, error) {
+	var reqBody schema.VolumeActionDetachVolumeRequest
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/volumes/%d/actions/detach", volume.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var respBody schema.VolumeActionDetachVolumeResponse
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
+}
+
+// VolumeChangeProtectionOpts specifies options for changing the resource protection level of a volume.
+type VolumeChangeProtectionOpts struct {
+	Delete *bool
+}
+
+// ChangeProtection changes the resource protection level of a volume.
+func (c *VolumeClient) ChangeProtection(ctx context.Context, volume *Volume, opts VolumeChangeProtectionOpts) (*Action, *Response, error) {
+	reqBody := schema.VolumeActionChangeProtectionRequest{
+		Delete: opts.Delete,
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/volumes/%d/actions/change_protection", volume.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.VolumeActionChangeProtectionResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, err
+}
+
+// Resize changes the size of a volume.
+func (c *VolumeClient) Resize(ctx context.Context, volume *Volume, size int) (*Action, *Response, error) {
+	reqBody := schema.VolumeActionResizeVolumeRequest{
+		Size: size,
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/volumes/%d/actions/resize", volume.ID)
+	req, err := c.client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	respBody := schema.VolumeActionResizeVolumeResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR implements support for Hetzner Private Networks. A new optional field is added to the Hetzner spec called `network` that consumes a network ID or name. It is expected that the network already exists, i.e. that it's created by the user.

To make this work I had to vendor the latest version of the `hcloud-go` library which includes support for networks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #599 

```release-note
Add support for Hetzner Private Networks
```