### PR TITLE
Azure: Use standard usernames for SSH

### DIFF
--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -44,7 +44,6 @@ import (
 
 const (
 	machineUIDTag = "Machine-UID"
-	adminUserName = "kubermatic"
 
 	finalizerPublicIP = "kubermatic.io/cleanup-azure-public-ip"
 	finalizerNIC      = "kubermatic.io/cleanup-azure-nic"
@@ -408,6 +407,12 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 		tags[k] = to.StringPtr(v)
 	}
 	tags[machineUIDTag] = to.StringPtr(string(machine.UID))
+
+	adminUserName := string(providerCfg.OperatingSystem)
+	if adminUserName == "coreos" {
+		// CoreOS uses core by default everywhere, so we adhere to that
+		adminUserName = "core"
+	}
 
 	vmSpec := compute.VirtualMachine{
 		Location: &config.Location,


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we use `kubermatic` as SSH username, which is impossible to figure out without reading the code. This PR changes that to use centos/ubuntu for centos or ubuntu and core for coreos, as that is what is the default of the cloud image and what is done almost everywhere else.

Also the current approach is problematic for whitelabeling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
The SSH username on Azure is now ubuntu for Ubuntu, centos for CentOS and core for CoreOS
```
