### PR TITLE
vSphere: extract disk handling

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/disk.go
+++ b/pkg/cloudprovider/provider/vsphere/disk.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+func validateDiskResize(devices object.VirtualDeviceList, diskSize int64) error {
+	disks := devices.SelectByType((*types.VirtualDisk)(nil))
+	if len(disks) != 1 {
+		return fmt.Errorf("invalid disk count: %d. Resizing is only allowed when using 1 disk", len(disks))
+	}
+
+	disk := disks[0].(*types.VirtualDisk)
+	requestedCapacity := diskSize * int64(math.Pow(1024, 2))
+	if requestedCapacity < disk.CapacityInKB {
+		attachedDiskSizeInGiB := disk.CapacityInKB / int64(math.Pow(1024, 2))
+		return fmt.Errorf("requested diskSizeGB %d is smaller than size of attached disk(%dGiB)", diskSize, attachedDiskSizeInGiB)
+	}
+
+	return nil
+}
+
+func getDiskSpec(devices object.VirtualDeviceList, diskSize int64) (types.BaseVirtualDeviceConfigSpec, error) {
+	disks := devices.SelectByType((*types.VirtualDisk)(nil))
+	if len(disks) != 1 {
+		return nil, fmt.Errorf("invalid disk count: %d. Resizing is only allowed when using 1 disk", len(disks))
+	}
+
+	disk := disks[0].(*types.VirtualDisk)
+	disk.CapacityInKB = diskSize * int64(math.Pow(1024, 2))
+
+	return &types.VirtualDeviceConfigSpec{
+		Operation: types.VirtualDeviceConfigSpecOperationEdit,
+		Device:    disk,
+	}, nil
+}

--- a/pkg/cloudprovider/provider/vsphere/helper.go
+++ b/pkg/cloudprovider/provider/vsphere/helper.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"os"
 	"os/exec"
 	"text/template"
@@ -168,21 +167,11 @@ func createClonedVM(ctx context.Context, vmName string, config *Config, session 
 
 	var deviceSpecs []types.BaseVirtualDeviceConfigSpec
 	if config.DiskSizeGB != nil {
-		disks, err := getDisksFromVM(ctx, virtualMachine)
+		diskSpec, err := getDiskSpec(vmDevices, *config.DiskSizeGB)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get disks from VM: %v", err)
+			return nil, fmt.Errorf("failed to get disk specification: %v", err)
 		}
-		// If this is wrong, the resulting error is `Invalid operation for device '0`
-		// so verify again this is legit
-		if err := validateDiskResizing(disks, *config.DiskSizeGB); err != nil {
-			return nil, err
-		}
-
-		glog.V(4).Infof("Increasing disk size to %d GB", *config.DiskSizeGB)
-		disk := disks[0]
-		disk.CapacityInBytes = *config.DiskSizeGB * int64(math.Pow(1024, 3))
-		diskspec := &types.VirtualDeviceConfigSpec{Operation: types.VirtualDeviceConfigSpecOperationEdit, Device: disk}
-		deviceSpecs = append(deviceSpecs, diskspec)
+		deviceSpecs = append(deviceSpecs, diskSpec)
 	}
 
 	if config.VMNetName != "" {
@@ -359,33 +348,4 @@ func getValueForField(ctx context.Context, vm *object.VirtualMachine, fieldName 
 	}
 
 	return "", nil
-}
-
-func getDisksFromVM(ctx context.Context, vm *object.VirtualMachine) ([]*types.VirtualDisk, error) {
-	var props mo.VirtualMachine
-	if err := vm.Properties(ctx, vm.Reference(), nil, &props); err != nil {
-		return nil, fmt.Errorf("error getting VM template reference: %v", err)
-	}
-	l := object.VirtualDeviceList(props.Config.Hardware.Device)
-	disks := l.SelectByType((*types.VirtualDisk)(nil))
-
-	var result []*types.VirtualDisk
-	for _, disk := range disks {
-		if assertedDisk := disk.(*types.VirtualDisk); assertedDisk != nil {
-			result = append(result, assertedDisk)
-		}
-	}
-	return result, nil
-}
-
-func validateDiskResizing(disks []*types.VirtualDisk, requestedSize int64) error {
-	if diskLen := len(disks); diskLen != 1 {
-		return fmt.Errorf("expected vm to have exactly one disk, got %d", diskLen)
-	}
-	requestedCapacityInBytes := requestedSize * int64(math.Pow(1024, 3))
-	if requestedCapacityInBytes < disks[0].CapacityInBytes {
-		attachedDiskSizeInGiB := disks[0].CapacityInBytes / int64(math.Pow(1024, 3))
-		return fmt.Errorf("requested diskSizeGB %d is smaller than size of attached disk(%dGiB)", requestedSize, attachedDiskSizeInGiB)
-	}
-	return nil
 }

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -224,16 +224,13 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to get template vm %q: %v", config.TemplateVMName, err)
 	}
 
-	disks, err := getDisksFromVM(ctx, templateVM)
+	vmDevices, err := templateVM.Device(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get disks from VM: %v", err)
-	}
-	if diskLen := len(disks); diskLen != 1 {
-		return fmt.Errorf("expected vm to have exactly one disk, had %d", diskLen)
+		return fmt.Errorf("failed to list devices of template VM: %v", err)
 	}
 
 	if config.DiskSizeGB != nil {
-		if err := validateDiskResizing(disks, *config.DiskSizeGB); err != nil {
+		if err := validateDiskResize(vmDevices, *config.DiskSizeGB); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This just reduces the size of the helper.go & provider.go by putting the disk related code into a dedicated file.

**Special notes for your reviewer**:

```release-note
NONE
```
