### PR TITLE
Fix upgrade test

### DIFF
--- a/test/tools/integration/provision_master.sh
+++ b/test/tools/integration/provision_master.sh
@@ -97,6 +97,11 @@ if [[ "${1:-deploy_machine_controller}"  == "do-not-deploy-machine-controller" ]
 fi
 if ! ls machine-controller-deployed; then
   docker build -t kubermatic/machine-controller:latest .
+  # The 10 minute window given by default for the node to appear is too short
+  # when we upgrade the instance during the upgrade test
+  if [[ ${JOB_NAME} = "pull-machine-controller-e2e-ubuntu-upgrade" ]]; then
+    sed -i '/.*join-cluster-timeout=.*/d' examples/machine-controller.yaml
+  fi
   sed -i -e 's/-worker-count=5/-worker-count=50/g' examples/machine-controller.yaml
   make deploy
   touch machine-controller-deployed


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the `pull-machine-controller-e2e-ubuntu-upgrade` test by disabling the `join-cluster-timeout` for it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
