### PR TITLE
Restrict file system permissions for config files

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -222,10 +222,12 @@ write_files:
 {{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage | indent 4 }}
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 {{ .CloudConfig | indent 4 }}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
 {{ .Kubeconfig | indent 4 }}
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -163,10 +163,12 @@ write_files:
     WantedBy=multi-user.target
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     {aws-config:true}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -163,10 +163,12 @@ write_files:
     WantedBy=multi-user.target
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     {aws-config:true}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -161,10 +161,12 @@ write_files:
     WantedBy=multi-user.target
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     {aws-config:true}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -162,10 +162,12 @@ write_files:
     WantedBy=multi-user.target
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     {aws-config:true}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -179,10 +179,12 @@ write_files:
     WantedBy=multi-user.target
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     {config:true}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -179,10 +179,12 @@ write_files:
     WantedBy=multi-user.target
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     {config:true}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -170,10 +170,12 @@ write_files:
     WantedBy=multi-user.target
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     {config:true}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -163,10 +163,12 @@ write_files:
     WantedBy=multi-user.target
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     {aws-config:true}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -295,10 +295,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 {{ .CloudConfig | indent 4 }}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
 {{ .Kubeconfig | indent 4 }}
 

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -247,10 +247,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -246,10 +246,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -246,10 +246,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -248,10 +248,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -248,12 +248,14 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     custom
     cloud
     config
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -248,10 +248,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     {openstack-config:true}
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -246,10 +246,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -246,10 +246,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -245,10 +245,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -246,10 +246,12 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
 
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -259,12 +259,14 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     custom
     cloud
     config
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -259,12 +259,14 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     custom
     cloud
     config
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -249,12 +249,14 @@ write_files:
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
 - path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
   content: |
     custom
     cloud
     config
 
 - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
   content: |
     apiVersion: v1
     clusters:


### PR DESCRIPTION
**What this PR does / why we need it**:

Set mode for files with potentially sensitive information like cloud
credentials to 0600. This change is for CentOS and Ubuntu workers,
CoreOS already had proper permissions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

```release-note 
Limit cloud-config and bootstrap-kubelet.conf filesystem permissions
```
