### PR TITLE
vSphere: Remove tag-based handling for multiple machines with the same name

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/helper.go
+++ b/pkg/cloudprovider/provider/vsphere/helper.go
@@ -332,33 +332,6 @@ func removeFloppyDevice(ctx context.Context, virtualMachine *object.VirtualMachi
 	return nil
 }
 
-func getValueForField(ctx context.Context, vm *object.VirtualMachine, fieldName string) (string, error) {
-	var mvm mo.VirtualMachine
-	if err := vm.Properties(ctx, vm.Reference(), nil, &mvm); err != nil {
-		return "", fmt.Errorf("failed to get properties: %v", err)
-	}
-
-	var key int32
-	for _, availableField := range mvm.AvailableField {
-		if availableField.Name == fieldName {
-			key = availableField.Key
-			break
-		}
-	}
-
-	for _, value := range mvm.Value {
-		if value.GetCustomFieldValue().Key == key {
-			stringVal, ok := value.(*types.CustomFieldStringValue)
-			if ok {
-				return stringVal.Value, nil
-			}
-			break
-		}
-	}
-
-	return "", nil
-}
-
 func getDisksFromVM(ctx context.Context, vm *object.VirtualMachine) ([]*types.VirtualDisk, error) {
 	var props mo.VirtualMachine
 	if err := vm.Properties(ctx, vm.Reference(), nil, &props); err != nil {

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -296,43 +296,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Provi
 		return nil, fmt.Errorf("error when waiting for vm powerOn task: %v", err)
 	}
 
-	// Add a custom field to indicate to our Get that creation succeeded
-	// If the field is not set, Get will delete the instance
-	customFieldManager, err := object.GetCustomFieldsManager(session.Client.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get customFieldManager: %v", err)
-	}
-	machineUIDFieldKey, err := createOrGetFieldIndex(ctx, machineUIDFieldName, customFieldManager)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get field key for field %q: %v", machineUIDFieldName, err)
-	}
-	if err := customFieldManager.Set(ctx, virtualMachine.Reference(), machineUIDFieldKey, string(machine.UID)); err != nil {
-		return nil, fmt.Errorf("failed to set field %q to value %q: %v", machineUIDFieldKey, string(machine.UID), err)
-	}
-	creationCompleteFieldKey, err := createOrGetFieldIndex(ctx, creationCompleteFieldName, customFieldManager)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get field key for field %q: %v", creationCompleteFieldName, err)
-	}
-	if err := customFieldManager.Set(ctx, virtualMachine.Reference(), creationCompleteFieldKey, machine.Spec.Name); err != nil {
-		return nil, fmt.Errorf("failed to set field %q to value %q: %v", creationCompleteFieldName, machine.Spec.Name, err)
-	}
-
 	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value}, nil
-}
-
-func createOrGetFieldIndex(ctx context.Context, fieldName string, customFieldManager *object.CustomFieldsManager) (int32, error) {
-	key, err := customFieldManager.FindKey(ctx, fieldName)
-	if err != nil {
-		if !strings.Contains(err.Error(), "key name not found") {
-			return 0, fmt.Errorf("error trying to get field with key %q: %v", fieldName, err)
-		}
-		field, err := customFieldManager.Add(ctx, fieldName, "VirtualMachine", nil, nil)
-		if err != nil {
-			return 0, fmt.Errorf("failed to add field %q: %v", fieldName, err)
-		}
-		key = field.Key
-	}
-	return key, nil
 }
 
 func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
@@ -442,44 +406,10 @@ func (p *provider) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.Provi
 	}
 	defer session.Logout()
 
-	virtualMachineList, err := session.Finder.VirtualMachineList(ctx, machine.Spec.Name)
+	virtualMachine, err := p.get(ctx, machine, session.Finder)
 	if err != nil {
-		if err.Error() == fmt.Sprintf("vm '%s' not found", machine.Spec.Name) {
-			return nil, cloudprovidererrors.ErrInstanceNotFound
-		}
-		return nil, fmt.Errorf("failed to list virtual machines: %v", err)
-	}
-
-	var virtualMachine *object.VirtualMachine
-	for _, virtualMachineItem := range virtualMachineList {
-		// Check if the creationCompleteFieldName is set to machine.UID
-		// If that is not the case, the creation didn't complete successfully and
-		// we must delete the instance so it gets recreated
-		creationCompleteFieldValue, err := getValueForField(ctx,
-			virtualMachineItem, creationCompleteFieldName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get value for field: %v", err)
-		}
-		machineCreationCompletedSuccessfully := creationCompleteFieldValue == machine.Spec.Name
-		if !machineCreationCompletedSuccessfully {
-			klog.V(4).Infof("Cleaning up instance %q whose creation didn't complete", machine.Spec.Name)
-			if _, err := p.Cleanup(machine, data); err != nil {
-				return nil, fmt.Errorf("failed to delete instance whose creation didn't complete: %v", err)
-			}
-			continue
-		}
-
-		machineUIDFieldValue, err := getValueForField(ctx, virtualMachineItem, machineUIDFieldName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get value for field %q: %v", machineUIDFieldName, err)
-		}
-		if machineUIDFieldValue == string(machine.UID) {
-			virtualMachine = virtualMachineItem
-			break
-		}
-	}
-	if virtualMachine == nil {
-		return nil, cloudprovidererrors.ErrInstanceNotFound
+		// Must not wrap because we match on the error type
+		return nil, err
 	}
 
 	powerState, err := virtualMachine.PowerState(ctx)
@@ -529,38 +459,6 @@ func (p *provider) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.Provi
 }
 
 func (p *provider) MigrateUID(machine *v1alpha1.Machine, new ktypes.UID) error {
-	ctx := context.Background()
-
-	config, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
-	if err != nil {
-		return fmt.Errorf("failed to parse config: %v", err)
-	}
-
-	session, err := NewSession(ctx, config)
-	if err != nil {
-		return fmt.Errorf("failed to create vCenter session: %v", err)
-	}
-	defer session.Logout()
-
-	virtualMachine, err := p.get(ctx, machine, session.Finder)
-	if err != nil {
-		if cloudprovidererrors.IsNotFound(err) {
-			return nil
-		}
-		return fmt.Errorf("failed to get instance from vSphere: %v", err)
-	}
-
-	customFieldManager, err := object.GetCustomFieldsManager(session.Client.Client)
-	if err != nil {
-		return fmt.Errorf("failed to get customFieldManager: %v", err)
-	}
-	machineUIDFieldKey, err := createOrGetFieldIndex(ctx, machineUIDFieldName, customFieldManager)
-	if err != nil {
-		return fmt.Errorf("failed to get field key for field %q: %v", machineUIDFieldName, err)
-	}
-	if err := customFieldManager.Set(ctx, virtualMachine.Reference(), machineUIDFieldKey, string(new)); err != nil {
-		return fmt.Errorf("failed to set field %q to value %q: %v", machineUIDFieldKey, string(new), err)
-	}
 	return nil
 }
 
@@ -647,15 +545,11 @@ func (p *provider) get(ctx context.Context, machine *v1alpha1.Machine, datacente
 		return nil, fmt.Errorf("failed to list virtual machines: %v", err)
 	}
 
-	for _, virtualMachine := range virtualMachineList {
-		machineUIDFieldValue, err := getValueForField(ctx, virtualMachine, machineUIDFieldName)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get value for field %q: %v", machineUIDFieldName, err)
-		}
-		if machineUIDFieldValue == string(machine.UID) {
-			return virtualMachine, nil
-		}
+	if len(virtualMachineList) == 0 {
+		return nil, cloudprovidererrors.ErrInstanceNotFound
 	}
-
-	return nil, cloudprovidererrors.ErrInstanceNotFound
+	if n := len(virtualMachineList); n > 1 {
+		return nil, fmt.Errorf("expected to find at most one vm for name %q, got %d", machine.Spec.Name, n)
+	}
+	return virtualMachineList[0], nil
 }

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -45,16 +45,6 @@ import (
 	"k8s.io/klog"
 )
 
-const (
-	// We set this field on the virtual machine to the name of
-	// the machine to indicate creation succeeded.
-	// If this is not set correctly, .Get will delete the instance
-	creationCompleteFieldName = "kubernetes-worker-complete"
-	// machineUIDFieldName is the name of the field in which we
-	// store the machines UID
-	machineUIDFieldName = "kubernetes-machine-uid"
-)
-
 type provider struct {
 	configVarResolver *providerconfig.ConfigVarResolver
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

* Removes the tag-based handling for multiple machines with the same name, as vsphere doesn't seem to support that anyways, seen e.G. in https://github.com/kubermatic/machine-controller/issues/636
* Replaces the tag-based marker used to indicate if creation was successful with a wrapper around the `Create` that will call `Cleanup` if there was an error. This is backwards-compatible (using an annotation or sth would result in all vsphere machines prior to this change getting re-created), more intuitive (no-one expects a function called GET to mutate things) and removes the need for the machine-controller to have permissions to manage tags

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
