### PR TITLE
vSphere: Use absolute path when trying to find vms

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -550,7 +550,7 @@ func (p *provider) get(ctx context.Context, folder string, spec v1alpha1.Machine
 	path := fmt.Sprintf("%s/%s", folder, spec.Name)
 	virtualMachineList, err := datacenterFinder.VirtualMachineList(ctx, path)
 	if err != nil {
-		if err.Error() == fmt.Sprintf("vm '%s' not found", spec.Name) {
+		if err.Error() == fmt.Sprintf("vm '%s' not found", path) {
 			return nil, cloudprovidererrors.ErrInstanceNotFound
 		}
 		return nil, fmt.Errorf("failed to list virtual machines: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the vSphere provider use absolute paths when trying to find vms to avoid ambiguity. Also adds validation for the folder and that there is no vm yet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
none
```
