### PR TITLE
Add coreos support to kubevirt

### DIFF
--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -81,11 +81,8 @@ func TestKubevirtProvisioningE2E(t *testing.T) {
 		t.Fatalf("Unable to run kubevirt tests, KUBEVIRT_E2E_TESTS_KUBECONFIG must be set")
 	}
 
-	// Provisioning coreos images via kubevirt does not work, needs investigation
-	excludeSelector := &scenarioSelector{osName: []string{"coreos"}}
-
 	params := []string{fmt.Sprintf("<< KUBECONFIG >>=%s", kubevirtKubeconfig)}
-	runScenarios(t, excludeSelector, params, kubevirtManifest, fmt.Sprintf("kubevirt-%s", *testRunIdentifier))
+	runScenarios(t, nil, params, kubevirtManifest, fmt.Sprintf("kubevirt-%s", *testRunIdentifier))
 }
 
 func TestOpenstackProvisioningE2E(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
In the past, CoreOS was not supported by the machine-controller for Kubevirt cloud provider due to some Kubevirt limitation. Since the release of Kubevirt 0.15 it supports CoreOS and Ignition.

**Which issue(s) this PR fixes** 
Fixes #422

**Special notes for your reviewer**:

```release-note
None
```
