### PR TITLE
Documenting the coreos image which is used in Kubevirt cloud provider 

### DIFF
--- a/docs/kubevirt.md
+++ b/docs/kubevirt.md
@@ -10,3 +10,5 @@ are some things you need to keep in mind:
 avoid collisions, use one namespace per cluster that runs the `machine-controller`
 * Service CIDR range: The CIDR ranges of the cluster that runs Kubevirt and the cluster that hosts the machine-controller must not overlap, otherwise routing of services that run in the kubevirt cluster
  wont work anymore. THis is especially important for the DNS ClusterIP.
+* In order to create VirtualMachineInstances deployed with CoreOS, you should use `coreos_production_qemu_image.img.bz2`, which can be found in the stable releases
+[here](https://stable.release.core-os.net/amd64-usr/).


### PR DESCRIPTION
**What this PR does / why we need it**:
Documenting the image name which should be used for deploying machines that run CoreOS.  

```release-note
None
```
