### PR TITLE
set a dynamic config snapshot directory

### DIFF
--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -149,6 +149,7 @@ write_files:
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -149,6 +149,7 @@ write_files:
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -147,6 +147,7 @@ write_files:
       --authentication-token-webhook=true \
       --cloud-provider=external \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -148,6 +148,7 @@ write_files:
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -164,6 +164,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -164,6 +164,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -156,6 +156,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -149,6 +149,7 @@ write_files:
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -116,6 +116,7 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -116,6 +116,7 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -136,6 +136,7 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -141,6 +141,7 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -135,6 +135,7 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -141,6 +141,7 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -112,6 +112,7 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.17.0.yaml
+++ b/pkg/userdata/coreos/testdata/v1.17.0.yaml
@@ -135,6 +135,7 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -118,6 +118,7 @@ systemd:
           --authentication-token-webhook=true \
           --cloud-provider=external \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -119,6 +119,7 @@ systemd:
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -117,6 +117,7 @@ systemd:
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -117,6 +117,7 @@ systemd:
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
           --read-only-port=0 \
+          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --anonymous-auth=false \

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -48,6 +48,7 @@ const (
 --hostname-override={{ .Hostname }} \
 {{- end }}
 --read-only-port=0 \
+--dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
 --exit-on-lock-contention \
 --lock-file=/tmp/kubelet.lock \
 --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -33,6 +33,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-provider=aws \
   --cloud-config=/etc/kubernetes/cloud-config \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
@@ -32,6 +32,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --authentication-token-webhook=true \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
@@ -32,6 +32,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-provider=aws \
   --cloud-config=/etc/kubernetes/cloud-config \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
@@ -33,6 +33,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-provider=external \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
@@ -32,6 +32,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --authentication-token-webhook=true \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
@@ -33,6 +33,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-provider=external \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
@@ -33,6 +33,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-provider=external \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
@@ -32,6 +32,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --authentication-token-webhook=true \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
@@ -32,6 +32,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --authentication-token-webhook=true \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
@@ -33,6 +33,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-provider=external \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
@@ -32,6 +32,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --authentication-token-webhook=true \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
@@ -32,6 +32,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-provider=external \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
@@ -31,6 +31,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --authentication-token-webhook=true \
   --hostname-override=some-test-node \
   --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -228,6 +228,7 @@ write_files:
       --authentication-token-webhook=true \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -227,6 +227,7 @@ write_files:
       --authentication-token-webhook=true \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -227,6 +227,7 @@ write_files:
       --authentication-token-webhook=true \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -229,6 +229,7 @@ write_files:
       --authentication-token-webhook=true \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -229,6 +229,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -229,6 +229,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -227,6 +227,7 @@ write_files:
       --authentication-token-webhook=true \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -227,6 +227,7 @@ write_files:
       --authentication-token-webhook=true \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -226,6 +226,7 @@ write_files:
       --authentication-token-webhook=true \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -227,6 +227,7 @@ write_files:
       --authentication-token-webhook=true \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -239,6 +239,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -239,6 +239,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -230,6 +230,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
       --read-only-port=0 \
+      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --anonymous-auth=false \


### PR DESCRIPTION
**What this PR does / why we need it**:
Step towards kubermatic/kubermatic#3494

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
Machines can now use dynamic kubelet config if a `configSource` is provided in their spec.
```
