### PR TITLE
Add support for EBS volume encryption

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,26 @@
+presubmits:
+  #########################################################
+  # unit tests
+  #########################################################
+
+  - name: pull-machine-controller-e2e-aws-ebs-encryption-enabled
+    always_run: true
+    decorate: true
+    error_on_eviction: true
+    clone_uri: 'ssh://git@github.com/kubermatic/machine-controller.git'
+    labels:
+      preset-aws: "true"
+      preset-hetzner: "true"
+      preset-e2e-ssh: "true"
+    spec:
+      containers:
+        # Uses go1.11.1
+        - image: quay.io/kubermatic/dep:0.5.4-2
+          command:
+            - "./hack/ci-e2e-test.sh"
+          args:
+            - "TestAWSProvisioningE2EWithEbsEncryptionEnabled"
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 500m

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,7 +1,4 @@
 presubmits:
-  #########################################################
-  # unit tests
-  #########################################################
 
   - name: pull-machine-controller-e2e-aws-ebs-encryption-enabled
     always_run: true

--- a/examples/aws-machinedeployment.yaml
+++ b/examples/aws-machinedeployment.yaml
@@ -58,6 +58,7 @@ spec:
             instanceProfile: "kubernetes-v1"
             diskSize: 50
             diskType: "gp2"
+            ebsVolumeEncrypted: false
             ## Only application if diskType = io1
             diskIops: 500
             # Assign a public IP to this instance. Default: true

--- a/pkg/cloudprovider/provider/aws/types/types.go
+++ b/pkg/cloudprovider/provider/aws/types/types.go
@@ -24,18 +24,19 @@ type RawConfig struct {
 	AccessKeyID     providerconfigtypes.ConfigVarString `json:"accessKeyId,omitempty"`
 	SecretAccessKey providerconfigtypes.ConfigVarString `json:"secretAccessKey,omitempty"`
 
-	Region           providerconfigtypes.ConfigVarString   `json:"region"`
-	AvailabilityZone providerconfigtypes.ConfigVarString   `json:"availabilityZone,omitempty"`
-	VpcID            providerconfigtypes.ConfigVarString   `json:"vpcId"`
-	SubnetID         providerconfigtypes.ConfigVarString   `json:"subnetId"`
-	SecurityGroupIDs []providerconfigtypes.ConfigVarString `json:"securityGroupIDs,omitempty"`
-	InstanceProfile  providerconfigtypes.ConfigVarString   `json:"instanceProfile,omitempty"`
-	IsSpotInstance   *bool                                 `json:"isSpotInstance,omitempty"`
-	InstanceType     providerconfigtypes.ConfigVarString   `json:"instanceType,omitempty"`
-	AMI              providerconfigtypes.ConfigVarString   `json:"ami,omitempty"`
-	DiskSize         int64                                 `json:"diskSize"`
-	DiskType         providerconfigtypes.ConfigVarString   `json:"diskType,omitempty"`
-	DiskIops         *int64                                `json:"diskIops,omitempty"`
-	Tags             map[string]string                     `json:"tags,omitempty"`
-	AssignPublicIP   *bool                                 `json:"assignPublicIP,omitempty"`
+	Region             providerconfigtypes.ConfigVarString   `json:"region"`
+	AvailabilityZone   providerconfigtypes.ConfigVarString   `json:"availabilityZone,omitempty"`
+	VpcID              providerconfigtypes.ConfigVarString   `json:"vpcId"`
+	SubnetID           providerconfigtypes.ConfigVarString   `json:"subnetId"`
+	SecurityGroupIDs   []providerconfigtypes.ConfigVarString `json:"securityGroupIDs,omitempty"`
+	InstanceProfile    providerconfigtypes.ConfigVarString   `json:"instanceProfile,omitempty"`
+	IsSpotInstance     *bool                                 `json:"isSpotInstance,omitempty"`
+	InstanceType       providerconfigtypes.ConfigVarString   `json:"instanceType,omitempty"`
+	AMI                providerconfigtypes.ConfigVarString   `json:"ami,omitempty"`
+	DiskSize           int64                                 `json:"diskSize"`
+	DiskType           providerconfigtypes.ConfigVarString   `json:"diskType,omitempty"`
+	DiskIops           *int64                                `json:"diskIops,omitempty"`
+	EBSVolumeEncrypted providerconfigtypes.ConfigVarBool     `json:"ebsVolumeEncrypted"`
+	Tags               map[string]string                     `json:"tags,omitempty"`
+	AssignPublicIP     *bool                                 `json:"assignPublicIP,omitempty"`
 }

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -37,14 +37,15 @@ func init() {
 }
 
 const (
-	DOManifest      = "./testdata/machinedeployment-digitalocean.yaml"
-	AWSManifest     = "./testdata/machinedeployment-aws.yaml"
-	AzureManifest   = "./testdata/machinedeployment-azure.yaml"
-	GCEManifest     = "./testdata/machinedeployment-gce.yaml"
-	HZManifest      = "./testdata/machinedeployment-hetzner.yaml"
-	PacketManifest  = "./testdata/machinedeployment-packet.yaml"
-	LinodeManifest  = "./testdata/machinedeployment-linode.yaml"
-	VSPhereManifest = "./testdata/machinedeployment-vsphere.yaml"
+	DOManifest              = "./testdata/machinedeployment-digitalocean.yaml"
+	AWSManifest             = "./testdata/machinedeployment-aws.yaml"
+	AWSEBSEncryptedManifest = "./testdata/machinedeployment-aws-ebs-encryption-enabled.yaml"
+	AzureManifest           = "./testdata/machinedeployment-azure.yaml"
+	GCEManifest             = "./testdata/machinedeployment-gce.yaml"
+	HZManifest              = "./testdata/machinedeployment-hetzner.yaml"
+	PacketManifest          = "./testdata/machinedeployment-packet.yaml"
+	LinodeManifest          = "./testdata/machinedeployment-linode.yaml"
+	VSPhereManifest         = "./testdata/machinedeployment-vsphere.yaml"
 	//	vssip_manifest         = "./testdata/machinedeployment-vsphere-static-ip.yaml"
 	OSManifest             = "./testdata/machinedeployment-openstack.yaml"
 	OSUpgradeManifest      = "./testdata/machinedeployment-openstack-upgrade.yml"
@@ -148,6 +149,33 @@ func TestAWSProvisioningE2E(t *testing.T) {
 		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),
 	}
 	runScenarios(t, nil, params, AWSManifest, fmt.Sprintf("aws-%s", *testRunIdentifier))
+}
+
+// TestAWSProvisioningE2EWithEbsEncryptionEnabled - a test suite that exercises AWS provider with ebs encryption enabled
+// by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
+func TestAWSProvisioningE2EWithEbsEncryptionEnabled(t *testing.T) {
+	t.Parallel()
+
+	// test data
+	awsKeyID := os.Getenv("AWS_E2E_TESTS_KEY_ID")
+	awsSecret := os.Getenv("AWS_E2E_TESTS_SECRET")
+	if len(awsKeyID) == 0 || len(awsSecret) == 0 {
+		t.Fatal("unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
+	}
+
+	// act
+	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
+		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),
+	}
+
+	scenario := scenario{
+		name:              "Ubuntu",
+		osName:            "ubuntu",
+		containerRuntime:  "docker",
+		kubernetesVersion: "v1.15.6",
+		executor:          verifyCreateAndDelete,
+	}
+	testScenario(t, scenario, fmt.Sprintf("aws-%s", *testRunIdentifier), params, AWSEBSEncryptedManifest, false)
 }
 
 // TestAzureProvisioningE2E - a test suite that exercises Azure provider

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-ebs-encryption-enabled.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-ebs-encryption-enabled.yaml
@@ -33,7 +33,7 @@ spec:
             instanceProfile: "kubernetes-v1"
             diskSize: 50
             diskType: "gp2"
-            ebsVolumeEncrypted: false
+            ebsVolumeEncrypted: true
             securityGroupIDs:
             - "sg-a2c195ca"
             tags:


### PR DESCRIPTION
**What this PR does / why we need it**:
This indicates whether the encryption state of an EBS volume is changed while being restored from a backing snapshot. 

**Which issue(s) this PR fixes** 
Fixes #

```release-note
None
```
