### PR TITLE
kubelet sets intial machine taints via --register-with-taints

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -219,7 +219,7 @@ write_files:
 
 - path: "/etc/systemd/system/kubelet.service"
   content: |
-{{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage | indent 4 }}
+{{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints | indent 4 }}
 
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -238,7 +238,7 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
 {{ if semverCompare ">=1.17.0" .KubeletVersion }}{{ print "          kubelet \\\n" }}{{ end -}}
-{{ kubeletFlags .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage | indent 10 }}
+{{ kubeletFlags .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints | indent 10 }}
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -20,7 +20,10 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"strings"
 	"text/template"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -58,6 +61,9 @@ const (
 {{- if .PauseImage }}
 --pod-infra-container-image={{ .PauseImage }} \
 {{- end }}
+{{- if .InitialTaints }}
+--register-with-taints={{- .InitialTaints }} \
+{{- end }}
 --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
 --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
 --cgroup-driver=systemd`
@@ -81,7 +87,7 @@ EnvironmentFile=-/etc/environment
 
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
-{{ kubeletFlags .KubeletVersion .CloudProvider .Hostname .ClusterDNSIPs .IsExternal .PauseImage | indent 2 }}
+{{ kubeletFlags .KubeletVersion .CloudProvider .Hostname .ClusterDNSIPs .IsExternal .PauseImage .InitialTaints | indent 2 }}
 
 [Install]
 WantedBy=multi-user.target`
@@ -103,7 +109,7 @@ func CloudProviderFlags(cpName string, external bool) (string, error) {
 }
 
 // KubeletSystemdUnit returns the systemd unit for the kubelet
-func KubeletSystemdUnit(kubeletVersion, cloudProvider, hostname string, dnsIPs []net.IP, external bool, pauseImage string) (string, error) {
+func KubeletSystemdUnit(kubeletVersion, cloudProvider, hostname string, dnsIPs []net.IP, external bool, pauseImage string, initialTaints []corev1.Taint) (string, error) {
 	tmpl, err := template.New("kubelet-systemd-unit").Funcs(TxtFuncMap()).Parse(kubeletSystemdUnitTpl)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse kubelet-systemd-unit template: %v", err)
@@ -116,6 +122,7 @@ func KubeletSystemdUnit(kubeletVersion, cloudProvider, hostname string, dnsIPs [
 		ClusterDNSIPs  []net.IP
 		IsExternal     bool
 		PauseImage     string
+		InitialTaints  []corev1.Taint
 	}{
 		KubeletVersion: kubeletVersion,
 		CloudProvider:  cloudProvider,
@@ -123,6 +130,7 @@ func KubeletSystemdUnit(kubeletVersion, cloudProvider, hostname string, dnsIPs [
 		ClusterDNSIPs:  dnsIPs,
 		IsExternal:     external,
 		PauseImage:     pauseImage,
+		InitialTaints:  initialTaints,
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -134,10 +142,15 @@ func KubeletSystemdUnit(kubeletVersion, cloudProvider, hostname string, dnsIPs [
 }
 
 // KubeletFlags returns the kubelet flags
-func KubeletFlags(version, cloudProvider, hostname string, dnsIPs []net.IP, external bool, pauseImage string) (string, error) {
+func KubeletFlags(version, cloudProvider, hostname string, dnsIPs []net.IP, external bool, pauseImage string, initialTaints []corev1.Taint) (string, error) {
 	tmpl, err := template.New("kubelet-flags").Funcs(TxtFuncMap()).Parse(kubeletFlagsTpl)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse kubelet-flags template: %v", err)
+	}
+
+	initialTaintsArgs := []string{}
+	for _, taint := range initialTaints {
+		initialTaintsArgs = append(initialTaintsArgs, fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect))
 	}
 
 	data := struct {
@@ -147,6 +160,7 @@ func KubeletFlags(version, cloudProvider, hostname string, dnsIPs []net.IP, exte
 		KubeletVersion string
 		IsExternal     bool
 		PauseImage     string
+		InitialTaints  string
 	}{
 		CloudProvider:  cloudProvider,
 		Hostname:       hostname,
@@ -154,6 +168,7 @@ func KubeletFlags(version, cloudProvider, hostname string, dnsIPs []net.IP, exte
 		KubeletVersion: version,
 		IsExternal:     external,
 		PauseImage:     pauseImage,
+		InitialTaints:  strings.Join(initialTaintsArgs, ","),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/pkg/userdata/helper/kubelet_test.go
+++ b/pkg/userdata/helper/kubelet_test.go
@@ -21,6 +21,8 @@ import (
 	"net"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+
 	testhelper "github.com/kubermatic/machine-controller/pkg/test"
 
 	"github.com/Masterminds/semver"
@@ -34,6 +36,7 @@ type kubeletFlagTestCase struct {
 	cloudProvider string
 	external      bool
 	pauseImage    string
+	initialTaints []corev1.Taint
 }
 
 func TestKubeletSystemdUnit(t *testing.T) {
@@ -81,6 +84,25 @@ func TestKubeletSystemdUnit(t *testing.T) {
 			cloudProvider: "aws",
 			pauseImage:    "192.168.100.100:5000/kubernetes/pause:v3.1",
 		},
+		{
+			name:          "taints-set",
+			version:       semver.MustParse("v1.13.5"),
+			dnsIPs:        []net.IP{net.ParseIP("10.10.10.10")},
+			hostname:      "some-test-node",
+			cloudProvider: "aws",
+			initialTaints: []corev1.Taint{
+				{
+					Key:    "key1",
+					Value:  "value1",
+					Effect: corev1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "key2",
+					Value:  "value2",
+					Effect: corev1.TaintEffectNoExecute,
+				},
+			},
+		},
 	}...)
 
 	for _, test := range tests {
@@ -93,6 +115,7 @@ func TestKubeletSystemdUnit(t *testing.T) {
 				test.dnsIPs,
 				test.external,
 				test.pauseImage,
+				test.initialTaints,
 			)
 			if err != nil {
 				t.Error(err)

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
@@ -1,0 +1,48 @@
+[Unit]
+After=docker.service
+Requires=docker.service
+
+Description=kubelet: The Kubernetes Node Agent
+Documentation=https://kubernetes.io/docs/home/
+
+[Service]
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+CPUAccounting=true
+MemoryAccounting=true
+
+Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+EnvironmentFile=-/etc/environment
+
+ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
+ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
+  --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
+  --kubeconfig=/etc/kubernetes/kubelet.conf \
+  --pod-manifest-path=/etc/kubernetes/manifests \
+  --allow-privileged=true \
+  --network-plugin=cni \
+  --cni-conf-dir=/etc/cni/net.d \
+  --cni-bin-dir=/opt/cni/bin \
+  --authorization-mode=Webhook \
+  --client-ca-file=/etc/kubernetes/pki/ca.crt \
+  --rotate-certificates=true \
+  --cert-dir=/etc/kubernetes/pki \
+  --authentication-token-webhook=true \
+  --cloud-provider=aws \
+  --cloud-config=/etc/kubernetes/cloud-config \
+  --read-only-port=0 \
+  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --exit-on-lock-contention \
+  --lock-file=/tmp/kubelet.lock \
+  --anonymous-auth=false \
+  --protect-kernel-defaults=true \
+  --cluster-dns=10.10.10.10 \
+  --cluster-domain=cluster.local \
+  --register-with-taints=key1=value1:NoSchedule,key2=value2:NoExecute \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --cgroup-driver=systemd
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -191,7 +191,7 @@ write_files:
 
 - path: "/etc/systemd/system/kubelet.service"
   content: |
-{{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage | indent 4 }}
+{{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints | indent 4 }}
 
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -287,7 +287,7 @@ write_files:
 
 - path: "/etc/systemd/system/kubelet.service"
   content: |
-{{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage | indent 4 }}
+{{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints | indent 4 }}
 
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |


### PR DESCRIPTION
Signed-off-by: Olaf Klischat <o.klischat@syseleven.de>

**What this PR does / why we need it**:

If the machine spec of a machine being created contains taints, this adds a corresponding `--register-with-taints` option to the machine's kubelet invocation, which means the taints will be set on the node resource from the start. Without this patch, the taints would only be added asynchronously during the first reconcile loop after the node has come up. At that point pods that don't tolerate the taints may already have been scheduled, and they won't be removed again (unless the taint's effect is NoExecute), leading to a permanently misscheduled pod. This can be easily reproduced with DaemonSet pods.

**Special notes for your reviewer**:

```release-note
kubelet sets intial machine taints via --register-with-taints
```
