### PR TITLE
Add machine controller kubeconfig env variable

### DIFF
--- a/hack/run-machine-controller.sh
+++ b/hack/run-machine-controller.sh
@@ -16,9 +16,13 @@
 
 set -e
 
+# Use a special env variable for machine-controller only
+MC_KUBECONFIG=${MC_KUBECONFIG:-$(dirname $0)/../.kubeconfig}
+# If you want to use the default kubeconfig `export MC_KUBECONFIG=$KUBECONFIG`
+
 make -C $(dirname $0)/.. machine-controller
 $(dirname $0)/../machine-controller \
-  -kubeconfig=$(dirname $0)/../.kubeconfig \
+  -kubeconfig=$MC_KUBECONFIG \
   -worker-count=50 \
   -logtostderr \
   -v=6 \


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an optional env variable to override kubeconfig location in the run script


```release-note
NONE
```
