### PR TITLE
Move deprecated kubelet flags into config file

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -244,12 +244,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -240,7 +240,7 @@ write_files:
     clusterDNS:
     {{- range .DNSIPs }}
       - "{{ . }}"
-    {{- end }}    
+    {{- end }}
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -259,7 +259,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -231,6 +231,40 @@ write_files:
   content: |
 {{ .Kubeconfig | indent 4 }}
 
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+    {{- range .DNSIPs }}
+      - "{{ . }}"
+    {{- end }}    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
+
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |
 {{ .KubernetesCACert | indent 4 }}

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -146,8 +146,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -182,7 +181,7 @@ write_files:
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
     clusterDomain: cluster.local
-    clusterDNS:    
+    clusterDNS:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -201,7 +200,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -134,31 +134,20 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns= \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -186,6 +175,37 @@ write_files:
       user:
         token: my-token
 
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -146,7 +146,9 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -185,12 +187,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -146,8 +146,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -182,7 +181,7 @@ write_files:
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
     clusterDomain: cluster.local
-    clusterDNS:    
+    clusterDNS:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -201,7 +200,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -134,31 +134,20 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns= \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -186,6 +175,37 @@ write_files:
       user:
         token: my-token
 
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -146,7 +146,9 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -185,12 +187,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -134,29 +134,18 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=external \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns= \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -184,6 +173,37 @@ write_files:
       user:
         token: my-token
 
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -144,8 +144,7 @@ write_files:
       --cloud-provider=external \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -180,7 +179,7 @@ write_files:
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
     clusterDomain: cluster.local
-    clusterDNS:    
+    clusterDNS:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -199,7 +198,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -144,7 +144,9 @@ write_files:
       --cloud-provider=external \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -183,12 +185,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -145,8 +145,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -181,7 +180,7 @@ write_files:
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
     clusterDomain: cluster.local
-    clusterDNS:    
+    clusterDNS:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -200,7 +199,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -145,7 +145,9 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -184,12 +186,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -134,30 +134,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns= \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -185,6 +174,37 @@ write_files:
       user:
         token: my-token
 
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -161,8 +161,10 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -201,12 +203,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -161,8 +161,8 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -197,7 +197,7 @@ write_files:
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
     clusterDomain: cluster.local
-    clusterDNS:    
+    clusterDNS:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -216,7 +216,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -149,32 +149,20 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns= \
-      --cluster-domain=cluster.local \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
 
     [Install]
     WantedBy=multi-user.target
@@ -202,6 +190,37 @@ write_files:
       user:
         token: my-token
 
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -161,8 +161,10 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -201,12 +203,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -161,8 +161,8 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -197,7 +197,7 @@ write_files:
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
     clusterDomain: cluster.local
-    clusterDNS:    
+    clusterDNS:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -216,7 +216,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -149,32 +149,20 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns= \
-      --cluster-domain=cluster.local \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
 
     [Install]
     WantedBy=multi-user.target
@@ -202,6 +190,37 @@ write_files:
       user:
         token: my-token
 
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -141,31 +141,20 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns= \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -193,6 +182,37 @@ write_files:
       user:
         token: my-token
 
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -153,8 +153,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -189,7 +188,7 @@ write_files:
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
     clusterDomain: cluster.local
-    clusterDNS:    
+    clusterDNS:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -208,7 +207,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -153,7 +153,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -192,12 +194,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -146,8 +146,7 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -182,7 +181,7 @@ write_files:
     apiVersion: kubelet.config.k8s.io/v1beta1
     cgroupDriver: systemd
     clusterDomain: cluster.local
-    clusterDNS:    
+    clusterDNS:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -201,7 +200,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -134,31 +134,20 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns= \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -186,6 +175,37 @@ write_files:
       user:
         token: my-token
 
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -146,7 +146,9 @@ write_files:
       --cloud-config=/etc/kubernetes/cloud-config \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -185,12 +187,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -287,12 +287,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -274,7 +274,7 @@ storage:
     - path: "/etc/kubernetes/kubelet.conf"
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |
           kind: KubeletConfiguration
           apiVersion: kubelet.config.k8s.io/v1beta1
@@ -283,7 +283,7 @@ storage:
           clusterDNS:
           {{- range .DNSIPs }}
             - "{{ . }}"
-          {{- end }}    
+          {{- end }}
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
@@ -302,7 +302,7 @@ storage:
           authentication:
             x509:
               clientCAFile: /etc/kubernetes/pki/ca.crt
-            webhook: 
+            webhook:
               enabled: true
             anonymous:
               enabled: false

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -240,6 +240,8 @@ systemd:
 {{ if semverCompare ">=1.17.0" .KubeletVersion }}{{ print "          kubelet \\\n" }}{{ end -}}
 {{ kubeletFlags .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints | indent 10 }}
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+        Restart=always
+        RestartSec=10
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -240,8 +240,6 @@ systemd:
 {{ if semverCompare ">=1.17.0" .KubeletVersion }}{{ print "          kubelet \\\n" }}{{ end -}}
 {{ kubeletFlags .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints | indent 10 }}
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
         [Install]
         WantedBy=multi-user.target
 
@@ -270,6 +268,43 @@ storage:
       contents:
         inline: |
 {{ journalDConfig | indent 10 }}
+    
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents: 
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+          {{- range .DNSIPs }}
+            - "{{ . }}"
+          {{- end }}    
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook: 
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -100,32 +100,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
           --cadvisor-port=0 \
-          --rotate-certificates=true \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
           --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --read-only-port=0 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -206,6 +194,43 @@ storage:
       contents:
         inline: |
           1
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+          {{- range .DNSIPs }}
+            - "{{ . }}"
+          {{- end }}
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /etc/kubernetes/bootstrap-kubelet.conf
       filesystem: root

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -140,6 +140,41 @@ storage:
           SystemMaxUse=5G
 
 
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
+
     - path: /opt/load-kernel-modules.sh
       filesystem: root
       mode: 0755
@@ -194,43 +229,6 @@ storage:
       contents:
         inline: |
           1
-
-    - path: "/etc/kubernetes/kubelet.conf"
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: |
-          kind: KubeletConfiguration
-          apiVersion: kubelet.config.k8s.io/v1beta1
-          cgroupDriver: systemd
-          clusterDomain: cluster.local
-          clusterDNS:
-          {{- range .DNSIPs }}
-            - "{{ . }}"
-          {{- end }}
-          rotateCertificates: true
-          podManifestPath: /etc/kubernetes/manifests
-          readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
-          featureGates:
-            RotateKubeletServerCertificate: true
-          serverTLSBootstrap: true
-          rotateCertificates: true
-          authorization:
-            mode: Webhook
-          authentication:
-            x509:
-              clientCAFile: /etc/kubernetes/pki/ca.crt
-            webhook:
-              enabled: true
-            anonymous:
-              enabled: false
-          protectKernelDefaults: true
 
     - path: /etc/kubernetes/bootstrap-kubelet.conf
       filesystem: root

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -113,7 +113,9 @@ systemd:
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -154,12 +156,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -113,7 +113,9 @@ systemd:
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -156,12 +158,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -140,6 +140,43 @@ storage:
           SystemMaxUse=5G
 
 
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+            - "10.10.10.11"
+            - "10.10.10.12"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
+
     - path: /opt/load-kernel-modules.sh
       filesystem: root
       mode: 0755

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -100,32 +100,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
           --cadvisor-port=0 \
-          --rotate-certificates=true \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
           --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --read-only-port=0 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -128,7 +128,7 @@ systemd:
           --cni-bin-dir=/opt/cni/bin \
           --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --cloud-provider=openstack \
+          --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
@@ -159,6 +159,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -120,32 +120,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
           --cadvisor-port=0 \
-          --rotate-certificates=true \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
-          --cloud-provider=vsphere \
+          --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --read-only-port=0 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -133,7 +133,9 @@ systemd:
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -174,12 +176,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -138,8 +138,10 @@ systemd:
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -191,12 +193,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -132,13 +132,13 @@ systemd:
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --cloud-provider=openstack \
+          --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
+          --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
           --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
@@ -176,6 +176,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -126,32 +126,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
-          --rotate-certificates=true \
+          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
-          --cloud-provider=vsphere \
+          --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --read-only-port=0 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -132,7 +132,9 @@ systemd:
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -173,12 +175,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -126,9 +126,8 @@ systemd:
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --cloud-provider=openstack \
+          --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
@@ -159,6 +158,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -120,31 +120,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
-          --rotate-certificates=true \
+          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
-          --cloud-provider=vsphere \
+          --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --read-only-port=0 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -138,8 +138,10 @@ systemd:
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -191,12 +193,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -132,13 +132,13 @@ systemd:
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --cloud-provider=openstack \
+          --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
+          --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
           --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
@@ -176,6 +176,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -126,32 +126,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
-          --rotate-certificates=true \
+          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
-          --cloud-provider=vsphere \
+          --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --read-only-port=0 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -98,30 +98,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
+          --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
-          --rotate-certificates=true \
+          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
-          --cloud-provider=vsphere \
+          --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --read-only-port=0 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -109,7 +109,9 @@ systemd:
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -150,12 +152,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -100,13 +100,11 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
-          --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --cloud-provider=openstack \
+          --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
@@ -137,6 +135,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.17.0.yaml
+++ b/pkg/userdata/coreos/testdata/v1.17.0.yaml
@@ -132,7 +132,9 @@ systemd:
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -173,12 +175,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.17.0.yaml
+++ b/pkg/userdata/coreos/testdata/v1.17.0.yaml
@@ -121,30 +121,20 @@ systemd:
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           kubelet \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
+          --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
-          --rotate-certificates=true \
+          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
-          --cloud-provider=vsphere \
+          --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --read-only-port=0 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.17.0.yaml
+++ b/pkg/userdata/coreos/testdata/v1.17.0.yaml
@@ -123,13 +123,11 @@ systemd:
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
-          --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --cloud-provider=openstack \
+          --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
@@ -160,6 +158,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -112,9 +112,7 @@ systemd:
           --cni-bin-dir=/opt/cni/bin \
           --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --cloud-provider=openstack \
-          --cloud-config=/etc/kubernetes/cloud-config \
-          --hostname-override=node1 \
+          --cloud-provider=external \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock
@@ -143,6 +141,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -115,7 +115,9 @@ systemd:
           --cloud-provider=external \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -156,12 +158,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -104,30 +104,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
           --cadvisor-port=0 \
-          --rotate-certificates=true \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
-          --cloud-provider=external \
-          --read-only-port=0 \
+          --cloud-provider=openstack \
+          --cloud-config=/etc/kubernetes/cloud-config \
+          --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -116,9 +116,10 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --pod-infra-container-image=
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
+        Restart=always
+        RestartSec=10
         [Install]
         WantedBy=multi-user.target
 
@@ -145,14 +146,14 @@ storage:
     - path: "/etc/kubernetes/kubelet.conf"
       filesystem: root
       mode: 0644
-      contents: 
+      contents:
         inline: |
           kind: KubeletConfiguration
           apiVersion: kubelet.config.k8s.io/v1beta1
           cgroupDriver: systemd
           clusterDomain: cluster.local
           clusterDNS:
-            - "10.10.10.10"    
+            - "10.10.10.10"
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
@@ -171,7 +172,7 @@ storage:
           authentication:
             x509:
               clientCAFile: /etc/kubernetes/pki/ca.crt
-            webhook: 
+            webhook:
               enabled: true
             anonymous:
               enabled: false

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -116,7 +116,9 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -157,12 +159,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -104,34 +104,21 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
           --cadvisor-port=0 \
-          --rotate-certificates=true \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --read-only-port=0 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --pod-infra-container-image=
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
         [Install]
         WantedBy=multi-user.target
 
@@ -154,6 +141,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents: 
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"    
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook: 
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -114,7 +114,9 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -155,12 +157,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -102,31 +102,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
           --cadvisor-port=0 \
-          --rotate-certificates=true \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
-          --cloud-provider=aws \
+          --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --read-only-port=0 \
+          --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -110,9 +110,8 @@ systemd:
           --cni-bin-dir=/opt/cni/bin \
           --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --cloud-provider=openstack \
+          --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock
@@ -141,6 +140,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -114,7 +114,9 @@ systemd:
           --cloud-config=/etc/kubernetes/cloud-config \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock
+          --lock-file=/tmp/kubelet.lock \
+          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -155,12 +157,6 @@ storage:
           rotateCertificates: true
           podManifestPath: /etc/kubernetes/manifests
           readOnlyPort: 0
-          systemReserved:
-            cpu: 500m
-            memory: 500Mi
-          kubeReserved:
-            cpu: 500m
-            memory: 500Mi
           featureGates:
             RotateKubeletServerCertificate: true
           serverTLSBootstrap: true

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -102,31 +102,20 @@ systemd:
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-          --kubeconfig=/etc/kubernetes/kubelet.conf \
-          --pod-manifest-path=/etc/kubernetes/manifests \
+          --kubeconfig=/var/lib/kubelet/kubeconfig \
+          --config=/etc/kubernetes/kubelet.conf \
           --allow-privileged=true \
           --network-plugin=cni \
           --cni-conf-dir=/etc/cni/net.d \
           --cni-bin-dir=/opt/cni/bin \
-          --authorization-mode=Webhook \
-          --client-ca-file=/etc/kubernetes/pki/ca.crt \
           --cadvisor-port=0 \
-          --rotate-certificates=true \
           --cert-dir=/etc/kubernetes/pki \
-          --authentication-token-webhook=true \
-          --cloud-provider=aws \
+          --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --read-only-port=0 \
+          --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
-          --lock-file=/tmp/kubelet.lock \
-          --anonymous-auth=false \
-          --protect-kernel-defaults=true \
-          --cluster-dns=10.10.10.10 \
-          --cluster-domain=cluster.local \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --cgroup-driver=systemd
+          --lock-file=/tmp/kubelet.lock
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -110,9 +110,8 @@ systemd:
           --cni-bin-dir=/opt/cni/bin \
           --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
-          --cloud-provider=openstack \
+          --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --hostname-override=node1 \
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock
@@ -141,6 +140,41 @@ storage:
           [Journal]
           SystemMaxUse=5G
 
+
+    - path: "/etc/kubernetes/kubelet.conf"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          clusterDNS:
+            - "10.10.10.10"
+          rotateCertificates: true
+          podManifestPath: /etc/kubernetes/manifests
+          readOnlyPort: 0
+          systemReserved:
+            cpu: 500m
+            memory: 500Mi
+          kubeReserved:
+            cpu: 500m
+            memory: 500Mi
+          featureGates:
+            RotateKubeletServerCertificate: true
+          serverTLSBootstrap: true
+          rotateCertificates: true
+          authorization:
+            mode: Webhook
+          authentication:
+            x509:
+              clientCAFile: /etc/kubernetes/pki/ca.crt
+            webhook:
+              enabled: true
+            anonymous:
+              enabled: false
+          protectKernelDefaults: true
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -48,13 +48,15 @@ const (
 {{- end }}
 --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
 --exit-on-lock-contention \
+--lock-file=/tmp/kubelet.lock \
 {{- if .PauseImage }}
---pod-infra-container-image={{ .PauseImage }}
+--pod-infra-container-image={{ .PauseImage }} \
 {{- end }}
 {{- if .InitialTaints }}
 --register-with-taints={{- .InitialTaints }} \
 {{- end }}
---lock-file=/tmp/kubelet.lock`
+--kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+--system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi`
 
 	kubeletSystemdUnitTpl = `[Unit]
 After=docker.service

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -28,45 +28,33 @@ import (
 
 const (
 	kubeletFlagsTpl = `--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
---kubeconfig=/etc/kubernetes/kubelet.conf \
---pod-manifest-path=/etc/kubernetes/manifests \
+--kubeconfig=/var/lib/kubelet/kubeconfig \
+--config=/etc/kubernetes/kubelet.conf \
 {{- if semverCompare "<1.15.0-0" .KubeletVersion }}
 --allow-privileged=true \
 {{- end }}
 --network-plugin=cni \
 --cni-conf-dir=/etc/cni/net.d \
 --cni-bin-dir=/opt/cni/bin \
---authorization-mode=Webhook \
---client-ca-file=/etc/kubernetes/pki/ca.crt \
 {{- if semverCompare "<1.12.0-0" .KubeletVersion }}
 --cadvisor-port=0 \
 {{- end }}
---rotate-certificates=true \
 --cert-dir=/etc/kubernetes/pki \
---authentication-token-webhook=true \
 {{- if or (.CloudProvider) (.IsExternal) }}
 {{ cloudProviderFlags .CloudProvider .IsExternal }} \
 {{- end }}
 {{- if and (.Hostname) (ne .CloudProvider "aws") }}
 --hostname-override={{ .Hostname }} \
 {{- end }}
---read-only-port=0 \
 --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
 --exit-on-lock-contention \
 --lock-file=/tmp/kubelet.lock \
---anonymous-auth=false \
---protect-kernel-defaults=true \
---cluster-dns={{ .ClusterDNSIPs | join "," }} \
---cluster-domain=cluster.local \
 {{- if .PauseImage }}
---pod-infra-container-image={{ .PauseImage }} \
 {{- end }}
 {{- if .InitialTaints }}
 --register-with-taints={{- .InitialTaints }} \
 {{- end }}
---kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
---system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
---cgroup-driver=systemd`
+--pod-infra-container-image={{ .PauseImage }}`
 
 	kubeletSystemdUnitTpl = `[Unit]
 After=docker.service

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -48,13 +48,13 @@ const (
 {{- end }}
 --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
 --exit-on-lock-contention \
---lock-file=/tmp/kubelet.lock \
 {{- if .PauseImage }}
+--pod-infra-container-image={{ .PauseImage }}
 {{- end }}
 {{- if .InitialTaints }}
 --register-with-taints={{- .InitialTaints }} \
 {{- end }}
---pod-infra-container-image={{ .PauseImage }}`
+--lock-file=/tmp/kubelet.lock`
 
 	kubeletSystemdUnitTpl = `[Unit]
 After=docker.service

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -18,31 +18,20 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --cloud-provider=aws \
   --cloud-config=/etc/kubernetes/cloud-config \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -30,7 +30,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-config=/etc/kubernetes/cloud-config \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -30,8 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-config=/etc/kubernetes/cloud-config \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
@@ -18,30 +18,19 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
@@ -29,7 +29,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
@@ -29,8 +29,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
@@ -29,8 +29,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-config=/etc/kubernetes/cloud-config \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
   --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
@@ -29,8 +29,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-config=/etc/kubernetes/cloud-config \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
@@ -18,31 +18,19 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --cloud-provider=aws \
   --cloud-config=/etc/kubernetes/cloud-config \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
@@ -29,9 +29,8 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-config=/etc/kubernetes/cloud-config \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
   --register-with-taints=key1=value1:NoSchedule,key2=value2:NoExecute \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
@@ -18,31 +18,20 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --cloud-provider=aws \
   --cloud-config=/etc/kubernetes/cloud-config \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
   --register-with-taints=key1=value1:NoSchedule,key2=value2:NoExecute \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
@@ -29,8 +29,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cloud-config=/etc/kubernetes/cloud-config \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
+  --lock-file=/tmp/kubelet.lock \
   --register-with-taints=key1=value1:NoSchedule,key2=value2:NoExecute \
-  --lock-file=/tmp/kubelet.lock
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
@@ -30,8 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
@@ -30,7 +30,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
@@ -18,31 +18,20 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
@@ -29,7 +29,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
@@ -29,8 +29,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
@@ -18,30 +18,19 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
@@ -30,8 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
@@ -30,7 +30,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
@@ -18,31 +18,20 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
@@ -30,8 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
@@ -30,7 +30,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
@@ -18,31 +18,20 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
@@ -29,7 +29,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
@@ -29,8 +29,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
@@ -18,30 +18,19 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
@@ -29,7 +29,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
@@ -29,8 +29,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
@@ -18,30 +18,19 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
@@ -30,8 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
@@ -30,7 +30,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
@@ -18,31 +18,20 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
@@ -29,7 +29,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
@@ -29,8 +29,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
@@ -18,30 +18,19 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
   --cadvisor-port=0 \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
@@ -29,7 +29,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
@@ -18,30 +18,19 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
@@ -29,8 +29,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
@@ -28,8 +28,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock \
-  --pod-infra-container-image=
+  --lock-file=/tmp/kubelet.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
@@ -28,7 +28,9 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --hostname-override=some-test-node \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
-  --lock-file=/tmp/kubelet.lock
+  --lock-file=/tmp/kubelet.lock \
+  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
@@ -18,29 +18,18 @@ EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
 ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-  --kubeconfig=/etc/kubernetes/kubelet.conf \
-  --pod-manifest-path=/etc/kubernetes/manifests \
+  --kubeconfig=/var/lib/kubelet/kubeconfig \
+  --config=/etc/kubernetes/kubelet.conf \
   --allow-privileged=true \
   --network-plugin=cni \
   --cni-conf-dir=/etc/cni/net.d \
   --cni-bin-dir=/opt/cni/bin \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt \
-  --rotate-certificates=true \
   --cert-dir=/etc/kubernetes/pki \
-  --authentication-token-webhook=true \
   --hostname-override=some-test-node \
-  --read-only-port=0 \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --anonymous-auth=false \
-  --protect-kernel-defaults=true \
-  --cluster-dns=10.10.10.10 \
-  --cluster-domain=cluster.local \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --cgroup-driver=systemd
+  --pod-infra-container-image=
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -122,30 +122,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -133,7 +133,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -133,8 +133,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -121,30 +121,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -132,8 +132,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -132,7 +132,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -121,30 +121,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -132,8 +132,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -132,7 +132,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -123,30 +123,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -134,7 +134,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -134,8 +134,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -121,32 +121,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -134,7 +134,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -134,8 +134,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -134,7 +134,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -121,32 +121,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -134,8 +134,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.10.10.yaml
@@ -121,30 +121,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.10.10.yaml
@@ -132,8 +132,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.10.10.yaml
@@ -132,7 +132,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.11.3.yaml
@@ -121,30 +121,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.11.3.yaml
@@ -132,8 +132,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.11.3.yaml
@@ -132,7 +132,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.12.1.yaml
@@ -121,29 +121,18 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.12.1.yaml
@@ -131,7 +131,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.12.1.yaml
@@ -131,8 +131,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.9.10.yaml
@@ -121,30 +121,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.9.10.yaml
@@ -132,8 +132,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.9.10.yaml
@@ -132,7 +132,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -131,33 +131,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -144,8 +144,8 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -144,8 +144,10 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -131,33 +131,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -144,8 +144,8 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -144,8 +144,10 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -135,7 +135,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -122,32 +122,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -135,8 +135,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -338,7 +338,7 @@ write_files:
     clusterDNS:
     {{- range .DNSIPs }}
       - "{{ . }}"
-    {{- end }}    
+    {{- end }}
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -357,7 +357,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -329,6 +329,40 @@ write_files:
   content: |
     export PATH="/opt/bin:$PATH"
 
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+    {{- range .DNSIPs }}
+      - "{{ . }}"
+    {{- end }}    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
+
 - path: /etc/docker/daemon.json
   permissions: "0644"
   content: |

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -342,12 +342,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -214,30 +214,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -320,6 +309,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -225,7 +225,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -320,12 +322,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -225,8 +225,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -317,7 +316,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -336,7 +335,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -224,7 +224,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -319,12 +321,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -213,30 +213,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -319,6 +308,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -224,8 +224,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -316,7 +315,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -335,7 +334,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -213,30 +213,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -319,6 +308,40 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"
+      - "10.10.10.11"
+      - "10.10.10.12"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -224,7 +224,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -321,12 +323,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -224,8 +224,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -318,7 +317,7 @@ write_files:
     clusterDNS:
       - "10.10.10.10"
       - "10.10.10.11"
-      - "10.10.10.12"    
+      - "10.10.10.12"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -337,7 +336,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -215,30 +215,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -321,6 +310,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -226,8 +226,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -318,7 +317,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -337,7 +336,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -226,7 +226,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -321,12 +323,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -226,7 +226,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -323,12 +325,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -226,8 +226,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -320,7 +319,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -339,7 +338,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -213,32 +213,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -323,6 +312,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -213,32 +213,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10,10.10.10.11,10.10.10.12 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -321,6 +310,40 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"
+      - "10.10.10.11"
+      - "10.10.10.12"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -226,7 +226,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -323,12 +325,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -226,8 +226,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -320,7 +319,7 @@ write_files:
     clusterDNS:
       - "10.10.10.10"
       - "10.10.10.11"
-      - "10.10.10.12"    
+      - "10.10.10.12"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -339,7 +338,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -224,7 +224,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -319,12 +321,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -213,30 +213,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -319,6 +308,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -224,8 +224,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -316,7 +315,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -335,7 +334,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -224,7 +224,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -319,12 +321,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -213,30 +213,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -319,6 +308,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -224,8 +224,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -316,7 +315,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -335,7 +334,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -213,29 +213,18 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -318,6 +307,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -223,8 +223,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -315,7 +314,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -334,7 +333,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -223,7 +223,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -318,12 +320,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -224,7 +224,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -319,12 +321,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -213,30 +213,19 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -319,6 +308,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -224,8 +224,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -316,7 +315,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -335,7 +334,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -236,8 +236,10 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -334,12 +336,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -236,8 +236,8 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -330,7 +330,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -349,7 +349,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -223,33 +223,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
 
     [Install]
     WantedBy=multi-user.target
@@ -334,6 +322,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -236,8 +236,10 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -334,12 +336,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -236,8 +236,8 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -330,7 +330,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -349,7 +349,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -223,33 +223,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1
 
     [Install]
     WantedBy=multi-user.target
@@ -334,6 +322,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -227,8 +227,7 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock \
-      --pod-infra-container-image=
+      --lock-file=/tmp/kubelet.lock
 
     [Install]
     WantedBy=multi-user.target
@@ -321,7 +320,7 @@ write_files:
     cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
-      - "10.10.10.10"    
+      - "10.10.10.10"
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
@@ -340,7 +339,7 @@ write_files:
     authentication:
       x509:
         clientCAFile: /etc/kubernetes/pki/ca.crt
-      webhook: 
+      webhook:
         enabled: true
       anonymous:
         enabled: false

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -227,7 +227,9 @@ write_files:
       --hostname-override=node1 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
-      --lock-file=/tmp/kubelet.lock
+      --lock-file=/tmp/kubelet.lock \
+      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
+      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 
     [Install]
     WantedBy=multi-user.target
@@ -324,12 +326,6 @@ write_files:
     rotateCertificates: true
     podManifestPath: /etc/kubernetes/manifests
     readOnlyPort: 0
-    systemReserved:
-      cpu: 500m
-      memory: 500Mi
-    kubeReserved:
-      cpu: 500m
-      memory: 500Mi
     featureGates:
       RotateKubeletServerCertificate: true
     serverTLSBootstrap: true

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -214,32 +214,21 @@ write_files:
     ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
     ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
       --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-      --kubeconfig=/etc/kubernetes/kubelet.conf \
-      --pod-manifest-path=/etc/kubernetes/manifests \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
       --allow-privileged=true \
       --network-plugin=cni \
       --cni-conf-dir=/etc/cni/net.d \
       --cni-bin-dir=/opt/cni/bin \
-      --authorization-mode=Webhook \
-      --client-ca-file=/etc/kubernetes/pki/ca.crt \
       --cadvisor-port=0 \
-      --rotate-certificates=true \
       --cert-dir=/etc/kubernetes/pki \
-      --authentication-token-webhook=true \
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --read-only-port=0 \
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --anonymous-auth=false \
-      --protect-kernel-defaults=true \
-      --cluster-dns=10.10.10.10 \
-      --cluster-domain=cluster.local \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --cgroup-driver=systemd
+      --pod-infra-container-image=
 
     [Install]
     WantedBy=multi-user.target
@@ -324,6 +313,38 @@ write_files:
   permissions: "0644"
   content: |
     export PATH="/opt/bin:$PATH"
+
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    kind: KubeletConfiguration
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    clusterDNS:
+      - "10.10.10.10"    
+    rotateCertificates: true
+    podManifestPath: /etc/kubernetes/manifests
+    readOnlyPort: 0
+    systemReserved:
+      cpu: 500m
+      memory: 500Mi
+    kubeReserved:
+      cpu: 500m
+      memory: 500Mi
+    featureGates:
+      RotateKubeletServerCertificate: true
+    serverTLSBootstrap: true
+    rotateCertificates: true
+    authorization:
+      mode: Webhook
+    authentication:
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+      webhook: 
+        enabled: true
+      anonymous:
+        enabled: false
+    protectKernelDefaults: true
 
 - path: /etc/docker/daemon.json
   permissions: "0644"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates a `kubelet.conf` file, which is used to configure kubelet in three os that the machine-controller supports: `ubuntu, centos, and coreos`. In addition, it moves all the deprecated feature flags into the config file plus activating the server rotate certificate for kubelet.  

**Which issue(s) this PR fixes** 
Fixes kubermatic/kubermatic#4947

and a follow-up for kubermatic/kubermatic#4301

**Special notes for your reviewer**:
The tester should validate that:
- All the machines have a verified certificate from the api-server
- A csr object is created and approved

```release-note
None
```
