### PR TITLE
using cgroupfs instead of systemd for kubelet

### DIFF
--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -175,6 +175,7 @@ write_files:
 
 {{ downloadBinariesScript .KubeletVersion true | indent 4 }}
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json 
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -232,7 +233,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
     {{- range .DNSIPs }}

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -175,7 +175,7 @@ write_files:
 
 {{ downloadBinariesScript .KubeletVersion true | indent 4 }}
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -175,7 +175,7 @@ write_files:
 
 {{ downloadBinariesScript .KubeletVersion true | indent 4 }}
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -86,7 +86,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -86,6 +86,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -218,7 +219,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -85,6 +85,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -217,7 +218,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -85,7 +85,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -85,6 +85,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -217,7 +218,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -85,7 +85,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -87,6 +87,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -219,7 +220,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -87,7 +87,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -85,7 +85,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -85,6 +85,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -221,7 +222,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -85,7 +85,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -85,6 +85,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -219,7 +220,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.10.10.yaml
@@ -85,6 +85,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -217,7 +218,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.10.10.yaml
@@ -85,7 +85,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.11.3.yaml
@@ -85,6 +85,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -217,7 +218,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.11.3.yaml
@@ -85,7 +85,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.12.1.yaml
@@ -85,6 +85,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -216,7 +217,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.12.1.yaml
@@ -85,7 +85,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.9.10.yaml
@@ -85,6 +85,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -217,7 +218,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.9.10.yaml
@@ -85,7 +85,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -95,6 +95,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -232,7 +233,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -95,7 +95,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -95,6 +95,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -232,7 +233,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -95,7 +95,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -86,6 +86,7 @@ write_files:
     fi
 
 
+    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
@@ -222,7 +223,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: systemd
+    cgroupDriver: cgroupfs
     clusterDomain: cluster.local
     clusterDNS:
       - "10.10.10.10"

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -86,7 +86,7 @@ write_files:
     fi
 
 
-    sed -i 's/systemd/cgroupfs/g' /etc/docker/daemon.json
+    sed -i 's/cgroupdriver=systemd/cgroupdriver=cgroupfs/g' /etc/docker/daemon.json
     systemctl enable --now docker
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service


### PR DESCRIPTION
**What this PR does / why we need it**:
When running kubelet with cgroupDriver=`systemd` we get this error: 

`Error while processing event ("/sys/fs/cgroup/pids/libcontainer_18160_systemd_test_default.slice": 0x40000100 == IN_CREATE|IN_ISDIR): inotify_add_watch /sys/fs/cgroup/pids/libcontainer_18160_systemd_test_default.slice: no such file or directory`


**Special notes for your reviewer**:

```release-note
None
```
