### PR TITLE
Remove yum update command on rhel userdata

### DIFF
--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -185,7 +185,6 @@ write_files:
     {{ end }}
     
     subscription-manager register --username='{{.OSConfig.RHELSubscriptionManagerUser}}' --password='{{.OSConfig.RHELSubscriptionManagerPassword}}' --auto-attach --force
-    yum update -y
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-3:18.09.1-3.el7 \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -70,7 +70,6 @@ write_files:
 
 
     subscription-manager register --username='' --password='' --auto-attach --force
-    yum update -y
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-3:18.09.1-3.el7 \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -70,7 +70,6 @@ write_files:
 
 
     subscription-manager register --username='' --password='' --auto-attach --force
-    yum update -y
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-3:18.09.1-3.el7 \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -70,7 +70,6 @@ write_files:
 
 
     subscription-manager register --username='' --password='' --auto-attach --force
-    yum update -y
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-3:18.09.1-3.el7 \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -70,7 +70,6 @@ write_files:
 
 
     subscription-manager register --username='' --password='' --auto-attach --force
-    yum update -y
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-3:18.09.1-3.el7 \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -82,7 +82,6 @@ write_files:
 
 
     subscription-manager register --username='' --password='' --auto-attach --force
-    yum update -y
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-3:18.09.1-3.el7 \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -82,7 +82,6 @@ write_files:
 
 
     subscription-manager register --username='' --password='' --auto-attach --force
-    yum update -y
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-3:18.09.1-3.el7 \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -74,7 +74,6 @@ write_files:
 
 
     subscription-manager register --username='' --password='' --auto-attach --force
-    yum update -y
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-3:18.09.1-3.el7 \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -70,7 +70,6 @@ write_files:
 
 
     subscription-manager register --username='' --password='' --auto-attach --force
-    yum update -y
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-3:18.09.1-3.el7 \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the userdata template for RHEL to remove a redundant global package update, that can be accomplished by specifying [OSConfig.DistUpgradeOnBoot](https://github.com/kubermatic/machine-controller/blob/master/pkg/userdata/rhel/provider.go#L117) in the MachineDeployment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
NONE
```
