### PR TITLE
Using systemd instead of cgroupfs in rhel

### DIFF
--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -72,6 +72,8 @@ write_files:
     subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+    mkdir /etc/docker
+
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
@@ -82,6 +84,20 @@ write_files:
       wget \
       curl \
       ipvsadm
+
+    cat > /etc/docker/daemon.json <<EOF
+    {
+      "exec-opts": ["native.cgroupdriver=systemd"],
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "100m"
+      },
+      "storage-driver": "overlay2",
+      "storage-opts": [
+        "overlay2.override_kernel_check=true"
+      ]
+    }
+    EOF
 
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -183,7 +199,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: cgroupfs
+    cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
     rotateCertificates: true

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -72,6 +72,8 @@ write_files:
     subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+    mkdir /etc/docker
+
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
@@ -82,6 +84,20 @@ write_files:
       wget \
       curl \
       ipvsadm
+
+    cat > /etc/docker/daemon.json <<EOF
+    {
+      "exec-opts": ["native.cgroupdriver=systemd"],
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "100m"
+      },
+      "storage-driver": "overlay2",
+      "storage-opts": [
+        "overlay2.override_kernel_check=true"
+      ]
+    }
+    EOF
 
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -183,7 +199,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: cgroupfs
+    cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
     rotateCertificates: true

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -72,6 +72,8 @@ write_files:
     subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+    mkdir /etc/docker
+
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
@@ -82,6 +84,20 @@ write_files:
       wget \
       curl \
       ipvsadm
+
+    cat > /etc/docker/daemon.json <<EOF
+    {
+      "exec-opts": ["native.cgroupdriver=systemd"],
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "100m"
+      },
+      "storage-driver": "overlay2",
+      "storage-opts": [
+        "overlay2.override_kernel_check=true"
+      ]
+    }
+    EOF
 
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -181,7 +197,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: cgroupfs
+    cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
     rotateCertificates: true

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -72,6 +72,8 @@ write_files:
     subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+    mkdir /etc/docker
+
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
@@ -82,6 +84,20 @@ write_files:
       wget \
       curl \
       ipvsadm
+
+    cat > /etc/docker/daemon.json <<EOF
+    {
+      "exec-opts": ["native.cgroupdriver=systemd"],
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "100m"
+      },
+      "storage-driver": "overlay2",
+      "storage-opts": [
+        "overlay2.override_kernel_check=true"
+      ]
+    }
+    EOF
 
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -182,7 +198,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: cgroupfs
+    cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
     rotateCertificates: true

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -84,6 +84,8 @@ write_files:
     subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+    mkdir /etc/docker
+
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
@@ -95,6 +97,20 @@ write_files:
       curl \
       ipvsadm \
       open-vm-tools
+
+    cat > /etc/docker/daemon.json <<EOF
+    {
+      "exec-opts": ["native.cgroupdriver=systemd"],
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "100m"
+      },
+      "storage-driver": "overlay2",
+      "storage-opts": [
+        "overlay2.override_kernel_check=true"
+      ]
+    }
+    EOF
 
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -199,7 +215,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: cgroupfs
+    cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
     rotateCertificates: true

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -84,6 +84,8 @@ write_files:
     subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+    mkdir /etc/docker
+
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
@@ -95,6 +97,20 @@ write_files:
       curl \
       ipvsadm \
       open-vm-tools
+
+    cat > /etc/docker/daemon.json <<EOF
+    {
+      "exec-opts": ["native.cgroupdriver=systemd"],
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "100m"
+      },
+      "storage-driver": "overlay2",
+      "storage-opts": [
+        "overlay2.override_kernel_check=true"
+      ]
+    }
+    EOF
 
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -199,7 +215,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: cgroupfs
+    cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
     rotateCertificates: true

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -76,6 +76,8 @@ write_files:
     subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+    mkdir /etc/docker
+
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
@@ -87,6 +89,20 @@ write_files:
       curl \
       ipvsadm \
       open-vm-tools
+
+    cat > /etc/docker/daemon.json <<EOF
+    {
+      "exec-opts": ["native.cgroupdriver=systemd"],
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "100m"
+      },
+      "storage-driver": "overlay2",
+      "storage-opts": [
+        "overlay2.override_kernel_check=true"
+      ]
+    }
+    EOF
 
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -190,7 +206,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: cgroupfs
+    cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
     rotateCertificates: true

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -72,6 +72,8 @@ write_files:
     subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
+    mkdir /etc/docker
+
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
@@ -82,6 +84,20 @@ write_files:
       wget \
       curl \
       ipvsadm
+
+    cat > /etc/docker/daemon.json <<EOF
+    {
+      "exec-opts": ["native.cgroupdriver=systemd"],
+      "log-driver": "json-file",
+      "log-opts": {
+        "max-size": "100m"
+      },
+      "storage-driver": "overlay2",
+      "storage-opts": [
+        "overlay2.override_kernel_check=true"
+      ]
+    }
+    EOF
 
     mkdir -p /opt/bin/
     mkdir -p /var/lib/calico
@@ -183,7 +199,7 @@ write_files:
   content: |
     kind: KubeletConfiguration
     apiVersion: kubelet.config.k8s.io/v1beta1
-    cgroupDriver: cgroupfs
+    cgroupDriver: systemd
     clusterDomain: cluster.local
     clusterDNS:
     rotateCertificates: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Using `systemd` as  a cgroup driver for both kubelet and docker instead of cgroupfs.  

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
None
```
