### PR TITLE
add redhat subscription manager

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -28,4 +28,5 @@ type RawConfig struct {
 	SourceURL        providerconfigtypes.ConfigVarString `json:"sourceURL,omitempty"`
 	PVCSize          providerconfigtypes.ConfigVarString `json:"pvcSize,omitempty"`
 	StorageClassName providerconfigtypes.ConfigVarString `json:"storageClassName,omitempty"`
+	RHSMOfflineToken providerconfigtypes.ConfigVarString `json:"rhsmOfflineToken,omitempty"`
 }

--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -35,8 +35,9 @@ type RawConfig struct {
 	DatastoreCluster providerconfigtypes.ConfigVarString `json:"datastoreCluster"`
 	Datastore        providerconfigtypes.ConfigVarString `json:"datastore"`
 
-	CPUs          int32                             `json:"cpus"`
-	MemoryMB      int64                             `json:"memoryMB"`
-	DiskSizeGB    *int64                            `json:"diskSizeGB,omitempty"`
-	AllowInsecure providerconfigtypes.ConfigVarBool `json:"allowInsecure"`
+	CPUs             int32                               `json:"cpus"`
+	MemoryMB         int64                               `json:"memoryMB"`
+	DiskSizeGB       *int64                              `json:"diskSizeGB,omitempty"`
+	AllowInsecure    providerconfigtypes.ConfigVarBool   `json:"allowInsecure"`
+	RHSMOfflineToken providerconfigtypes.ConfigVarString `json:"rhsmOfflineToken"`
 }

--- a/pkg/cloudprovider/rhsm/subscription_manager.go
+++ b/pkg/cloudprovider/rhsm/subscription_manager.go
@@ -1,0 +1,228 @@
+package rhsm
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"k8s.io/klog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// RedHatSubscriptionManager is responsible for removing redhat subscriptions.
+type RedHatSubscriptionManager interface {
+	UnregisterInstance(machineName string) error
+}
+
+type pagination struct {
+	Offset int `json:"offset"`
+	Limit  int `json:"limit"`
+	Count  int `json:"count"`
+}
+
+type body struct {
+	Name string `json:"name"`
+	UUID string `json:"uuid"`
+}
+
+type systemsResponse struct {
+	Pagination pagination `json:"pagination"`
+	Body       []*body    `json:"body"`
+}
+
+type credentials struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+type defaultRedHatSubscriptionManager struct {
+	offlineToken string
+	authUrl      string
+	apiUrl       string
+	client       *http.Client
+	credentials  *credentials
+}
+
+var unauthenticatedRequestError = errors.New("unauthenticated")
+
+func NewRedHatSubscriptionManager(offlineToken string) (RedHatSubscriptionManager, error) {
+	if offlineToken == "" {
+		return nil, errors.New("offline token, authURL, or apiPath cannot be empty")
+	}
+
+	token, err := base64.StdEncoding.DecodeString(offlineToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed decoding offline token: %v", err)
+	}
+
+	return &defaultRedHatSubscriptionManager{
+		client:       &http.Client{},
+		authUrl:      "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
+		apiUrl:       "https://api.access.redhat.com/management/v1/systems",
+		offlineToken: string(token),
+	}, nil
+}
+
+func (d *defaultRedHatSubscriptionManager) UnregisterInstance(machineName string) error {
+	if d.credentials == nil {
+		klog.Info("access token has been expired, refreshing token")
+		if err := d.refreshToken(); err != nil {
+			return fmt.Errorf("failed to refresh offline token")
+		}
+	}
+
+	var (
+		retries    = 0
+		maxRetries = 15
+	)
+
+	for retries < maxRetries {
+		machineUUID, err := d.findSystemsProfile(machineName)
+		if err != nil {
+			if err == unauthenticatedRequestError {
+				if err := d.refreshToken(); err != nil {
+					klog.Errorf("failed to refresh offline token: %v", err)
+					continue
+				}
+			}
+			return fmt.Errorf("failed to find system profile: %v", err)
+		}
+
+		if machineUUID == "" {
+			klog.Infof("machine uuid %s is not found", machineUUID)
+			return nil
+		}
+
+		err = d.deleteSubscription(machineUUID)
+		if err == nil {
+			klog.Infof("subscription for vm %v has been deleted successfully", machineUUID)
+			return nil
+		}
+
+		if err == unauthenticatedRequestError {
+			if err := d.refreshToken(); err != nil {
+				klog.Errorf("failed to refresh offline token: %v", err)
+				continue
+			}
+		}
+		klog.Errorf("failed to delete subscription for system: %s due to: %v", machineUUID, err)
+		time.Sleep(2 * time.Second)
+		retries++
+	}
+
+	return errors.New("failed to delete system profile after max retires number has been reached")
+}
+
+func (d *defaultRedHatSubscriptionManager) refreshToken() error {
+	payload := url.Values{}
+	payload.Add("grant_type", "refresh_token")
+	payload.Add("client_id", "rhsm-api")
+	payload.Add("refresh_token", d.offlineToken)
+
+	req, err := http.NewRequest("POST", d.authUrl, strings.NewReader(payload.Encode()))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+
+	var creds = &credentials{}
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed while reading response: %v", err)
+	}
+
+	if res.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(data, creds); err != nil {
+			return fmt.Errorf("failed while unmarshalling data: %v", err)
+		}
+		d.credentials = creds
+
+		return nil
+	}
+
+	return fmt.Errorf("error while exeucting request with status code: %v and message: %s", res.StatusCode, string(data))
+}
+
+func (d *defaultRedHatSubscriptionManager) findSystemsProfile(name string) (string, error) {
+	req, err := http.NewRequest("GET", d.apiUrl, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create fecth systems request: %v", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.credentials.AccessToken))
+
+	res, err := d.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed executing fetch systems request: %v", err)
+	}
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed while reading response: %v", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		if res.StatusCode == http.StatusUnauthorized {
+			return "", unauthenticatedRequestError
+		}
+		return "", fmt.Errorf("error while exeucting request with status code: %v and message: %s", res.StatusCode, string(data))
+	}
+
+	var fetchedSystems = &systemsResponse{}
+	if err := json.Unmarshal(data, fetchedSystems); err != nil {
+		return "", fmt.Errorf("failed while unmarshalling data: %v", err)
+	}
+
+	// TODO(MQ): add logic to iterate over all pages.
+	for _, system := range fetchedSystems.Body {
+		if system.Name == name {
+			return system.UUID, nil
+		}
+	}
+
+	klog.Infof("no machine name %s is found", name)
+	return "", nil
+}
+
+func (d *defaultRedHatSubscriptionManager) deleteSubscription(uuid string) error {
+	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/%s", d.apiUrl, uuid), nil)
+	if err != nil {
+		return fmt.Errorf("failed to create delete system request: %v", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", d.credentials.AccessToken))
+
+	res, err := d.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("faild to delete systsem profile: %v", err)
+	}
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("failed while reading response: %v", err)
+	}
+
+	if res.StatusCode != http.StatusNoContent {
+		if res.StatusCode == http.StatusUnauthorized {
+			return unauthenticatedRequestError
+		}
+
+		return fmt.Errorf("error while exeucting request with status code: %v and message: %s", res.StatusCode, string(data))
+	}
+
+	return nil
+}

--- a/pkg/cloudprovider/rhsm/subscription_manager.go
+++ b/pkg/cloudprovider/rhsm/subscription_manager.go
@@ -71,7 +71,7 @@ func NewRedHatSubscriptionManager(offlineToken string) (RedHatSubscriptionManage
 
 	return &defaultRedHatSubscriptionManager{
 		client: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: 10 * time.Second,
 		},
 		authURL:      "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token",
 		apiURL:       "https://api.access.redhat.com/management/v1/systems",

--- a/pkg/cloudprovider/rhsm/subscription_manager_test.go
+++ b/pkg/cloudprovider/rhsm/subscription_manager_test.go
@@ -65,7 +65,7 @@ func createTestingServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case authPath:
-			fmt.Fprintln(w, "{\"access_token\":\"test-access-token\", \"expires_in\":900}")
+			fmt.Fprintln(w, "{\"access_token\":\"test-access-token\"}")
 		case apiPath:
 			fmt.Fprintln(w, "{\"pagination\": {\"offset\": 0, \"limit\": 100,\"count\": 1}, \"body\": ["+
 				"{\"name\": \"test-machine-mqasim\", \"uuid\": \""+machineUUID+"\"}]}")

--- a/pkg/cloudprovider/rhsm/subscription_manager_test.go
+++ b/pkg/cloudprovider/rhsm/subscription_manager_test.go
@@ -1,0 +1,61 @@
+package rhsm
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var (
+	authPath    = "/auth/"
+	apiPath     = "/systems"
+	machineUUID = "4a3ee8d7-337d-4cef-a20c-dda011f28f95"
+)
+
+func TestDefaultRedHatSubscriptionManager_UnregisterInstance(t *testing.T) {
+	testCases := []struct {
+		name          string
+		offlineToken  string
+		testingServer *httptest.Server
+	}{
+		{
+			name:          "execute redhat system unregister instance",
+			offlineToken:  "test_token",
+			testingServer: createTestingServer(),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				tt.testingServer.Close()
+			}()
+			manager, err := NewRedHatSubscriptionManager(tt.offlineToken)
+			if err != nil {
+				t.Fatalf("failed executing test: %v", err)
+			}
+			manager.(*defaultRedHatSubscriptionManager).apiUrl = tt.testingServer.URL + apiPath
+			manager.(*defaultRedHatSubscriptionManager).authUrl = tt.testingServer.URL + authPath
+
+			if err := manager.UnregisterInstance("test-machine-mqasim"); err != nil {
+				t.Fatalf("failed executing test: %v", err)
+			}
+		})
+	}
+}
+
+func createTestingServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case authPath:
+			fmt.Fprintln(w, "{\"access_token\":\"test-access-token\", \"expires_in\":900}")
+		case apiPath:
+			fmt.Fprintln(w, "{\"pagination\": {\"offset\": 0, \"limit\": 100,\"count\": 1}, \"body\": ["+
+				"{\"name\": \"test-machine-mqasim\", \"uuid\": \""+machineUUID+"\"}]}")
+		case apiPath + "/" + machineUUID:
+			w.WriteHeader(http.StatusNoContent)
+			fmt.Fprint(w, "success")
+		}
+	}))
+}

--- a/pkg/cloudprovider/rhsm/subscription_manager_test.go
+++ b/pkg/cloudprovider/rhsm/subscription_manager_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package rhsm
 
 import (
@@ -8,9 +24,8 @@ import (
 )
 
 var (
-	authPath    = "/auth/"
-	apiPath     = "/systems"
-	machineUUID = "4a3ee8d7-337d-4cef-a20c-dda011f28f95"
+	authPath = "/auth/"
+	apiPath  = "/systems"
 )
 
 func TestDefaultRedHatSubscriptionManager_UnregisterInstance(t *testing.T) {
@@ -35,8 +50,8 @@ func TestDefaultRedHatSubscriptionManager_UnregisterInstance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed executing test: %v", err)
 			}
-			manager.(*defaultRedHatSubscriptionManager).apiUrl = tt.testingServer.URL + apiPath
-			manager.(*defaultRedHatSubscriptionManager).authUrl = tt.testingServer.URL + authPath
+			manager.(*defaultRedHatSubscriptionManager).apiURL = tt.testingServer.URL + apiPath
+			manager.(*defaultRedHatSubscriptionManager).authURL = tt.testingServer.URL + authPath
 
 			if err := manager.UnregisterInstance("test-machine-mqasim"); err != nil {
 				t.Fatalf("failed executing test: %v", err)
@@ -46,6 +61,7 @@ func TestDefaultRedHatSubscriptionManager_UnregisterInstance(t *testing.T) {
 }
 
 func createTestingServer() *httptest.Server {
+	machineUUID := "4a3ee8d7-337d-4cef-a20c-dda011f28f95"
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case authPath:

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -83,7 +83,7 @@ func TestKubevirtProvisioningE2E(t *testing.T) {
 	rhelSubscriptionManagerPassword := os.Getenv("RHEL_SUBSCRIPTION_MANAGER_PASSWORD")
 	rhsmOfflineToken := os.Getenv("REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
 
-	if kubevirtKubeconfig == "" || rhelSubscriptionManagerUser == "" || rhelSubscriptionManagerPassword == "" {
+	if kubevirtKubeconfig == "" || rhelSubscriptionManagerUser == "" || rhelSubscriptionManagerPassword == "" || rhsmOfflineToken == "" {
 		t.Fatalf("Unable to run kubevirt tests, KUBEVIRT_E2E_TESTS_KUBECONFIG, RHEL_SUBSCRIPTION_MANAGER_USER, " +
 			"and RHEL_SUBSCRIPTION_MANAGER_PASSWORD must be set")
 	}
@@ -360,9 +360,10 @@ func getVSphereTestParams(t *testing.T) []string {
 
 	rhelSubscriptionManagerUser := os.Getenv("RHEL_SUBSCRIPTION_MANAGER_USER")
 	rhelSubscriptionManagerPassword := os.Getenv("RHEL_SUBSCRIPTION_MANAGER_PASSWORD")
+	rhsmOfflineToken := os.Getenv("REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
 
 	if vsPassword == "" || vsUsername == "" || vsAddress == "" || vsCluster == "" ||
-		rhelSubscriptionManagerUser == "" || rhelSubscriptionManagerPassword == "" {
+		rhelSubscriptionManagerUser == "" || rhelSubscriptionManagerPassword == "" || rhsmOfflineToken == "" {
 		t.Fatal("unable to run the test suite, VSPHERE_E2E_PASSWORD, VSPHERE_E2E_USERNAME, VSPHERE_E2E_CLUSTER " +
 			"RHEL_SUBSCRIPTION_MANAGER_USER, RHEL_SUBSCRIPTION_MANAGER_PASSWORD or VSPHERE_E2E_ADDRESS environment variables cannot be empty")
 	}
@@ -374,6 +375,7 @@ func getVSphereTestParams(t *testing.T) []string {
 		fmt.Sprintf("<< VSPHERE_CLUSTER >>=%s", vsCluster),
 		fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_USER >>=%s", rhelSubscriptionManagerUser),
 		fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>=%s", rhelSubscriptionManagerPassword),
+		fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", rhsmOfflineToken),
 	}
 	return params
 }

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -81,6 +81,7 @@ func TestKubevirtProvisioningE2E(t *testing.T) {
 	kubevirtKubeconfig := os.Getenv("KUBEVIRT_E2E_TESTS_KUBECONFIG")
 	rhelSubscriptionManagerUser := os.Getenv("RHEL_SUBSCRIPTION_MANAGER_USER")
 	rhelSubscriptionManagerPassword := os.Getenv("RHEL_SUBSCRIPTION_MANAGER_PASSWORD")
+	rhsmOfflineToken := os.Getenv("REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
 
 	if kubevirtKubeconfig == "" || rhelSubscriptionManagerUser == "" || rhelSubscriptionManagerPassword == "" {
 		t.Fatalf("Unable to run kubevirt tests, KUBEVIRT_E2E_TESTS_KUBECONFIG, RHEL_SUBSCRIPTION_MANAGER_USER, " +
@@ -92,6 +93,7 @@ func TestKubevirtProvisioningE2E(t *testing.T) {
 		fmt.Sprintf("<< KUBECONFIG >>=%s", kubevirtKubeconfig),
 		fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_USER >>=%s", rhelSubscriptionManagerUser),
 		fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>=%s", rhelSubscriptionManagerPassword),
+		fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", rhsmOfflineToken),
 	}
 
 	runScenarios(t, excludeSelector, params, kubevirtManifest, fmt.Sprintf("kubevirt-%s", *testRunIdentifier))

--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
@@ -34,6 +34,7 @@ spec:
             kubeconfig:
               value: '<< KUBECONFIG >>'
             namespace: kube-system
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
@@ -36,6 +36,7 @@ spec:
             cpus: 2
             MemoryMB: 2048
             diskSizeGB: 50
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -36,6 +36,7 @@ spec:
             allowInsecure: true
             cpus: 2
             MemoryMB: 2048
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -36,6 +36,7 @@ spec:
             cpus: 2
             MemoryMB: 2048
             diskSizeGB: 50
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment all the machines which are created by the machine controller in the cloud provider that supports rhel create redhat subscriptions. However, when those machines are deleted the subscriptions are not deleted automatically. This PR adds the functionality to delete those subscriptions(optionally) whenever those machines are deleted.
 
**Which issue(s) this PR fixes** 
Fixes #

**Special notes for your reviewer**:
At the moment this functionality is only supported in the Kubevirt and Vsphere cloud providers since they are the only cloud providers that supports rhel for the time being. However, rhel will be integrated with all cloud providers in the next steps.

```release-note
None
```
