### PR TITLE
Add disk type and size to alicloud

### DIFF
--- a/examples/alibaba-machinedeployment.yaml
+++ b/examples/alibaba-machinedeployment.yaml
@@ -53,6 +53,8 @@ spec:
             instanceName: "alibaba-instance"
             regionID: eu-central-1
             imageID: "aliyun_2_1903_64_20G_alibase_20190829.vhd"
+            diskType: "cloud_efficiency"
+            diskSize: "40"
           operatingSystem: "ubuntu"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -69,8 +69,8 @@ type Config struct {
 	InternetMaxBandwidthOut string
 	Labels                  map[string]string
 	ZoneID                  string
-	DeskType                string
-	DeskSize                string
+	DiskType                string
+	DiskSize                string
 }
 
 type alibabaInstance struct {
@@ -138,11 +138,11 @@ func (p *provider) Validate(machineSpec v1alpha1.MachineSpec) error {
 	if err != nil {
 		return fmt.Errorf("invalid/not supported operating system specified %q: %v", pc.OperatingSystem, err)
 	}
-	if c.DeskType == "" {
-		return errors.New(" deskType is missing")
+	if c.DiskType == "" {
+		return errors.New(" DiskType is missing")
 	}
-	if c.DeskSize == "" {
-		return errors.New(" deskSize is missing")
+	if c.DiskSize == "" {
+		return errors.New(" DiskSize is missing")
 	}
 
 	return nil
@@ -223,13 +223,13 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 	createInstanceRequest.InternetMaxBandwidthOut = requests.Integer(c.InternetMaxBandwidthOut)
 	encodedUserData := base64.StdEncoding.EncodeToString([]byte(userdata))
 	createInstanceRequest.UserData = encodedUserData
-	createInstanceRequest.SystemDiskCategory = c.DeskType
+	createInstanceRequest.SystemDiskCategory = c.DiskType
 	createInstanceRequest.DataDisk = &[]ecs.CreateInstanceDataDisk{
 		{
-			Size: c.DeskSize,
+			Size: c.DiskSize,
 		},
 	}
-	createInstanceRequest.SystemDiskSize = requests.Integer(c.DeskSize)
+	createInstanceRequest.SystemDiskSize = requests.Integer(c.DiskSize)
 	createInstanceRequest.ZoneId = c.ZoneID
 	tag := ecs.CreateInstanceTag{
 		Key:   machineUIDTag,
@@ -385,6 +385,14 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		return nil, nil, fmt.Errorf("failed to get the value of \"internetMaxBandwidthOut\" field, error = %v", err)
 	}
 	c.Labels = rawConfig.Labels
+	c.DiskType, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.DiskType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get the value of \"diskType\" field, error = %v", err)
+	}
+	c.DiskSize, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.DiskSize)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get the value of \"diskType\" field, error = %v", err)
+	}
 	return &c, &pconfig, err
 }
 

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -139,10 +139,10 @@ func (p *provider) Validate(machineSpec v1alpha1.MachineSpec) error {
 		return fmt.Errorf("invalid/not supported operating system specified %q: %v", pc.OperatingSystem, err)
 	}
 	if c.DiskType == "" {
-		return errors.New(" DiskType is missing")
+		return errors.New("DiskType is missing")
 	}
 	if c.DiskSize == "" {
-		return errors.New(" DiskSize is missing")
+		return errors.New("DiskSize is missing")
 	}
 
 	return nil
@@ -391,7 +391,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	}
 	c.DiskSize, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.DiskSize)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get the value of \"diskType\" field, error = %v", err)
+		return nil, nil, fmt.Errorf("failed to get the value of \"diskSize\" field, error = %v", err)
 	}
 	return &c, &pconfig, err
 }

--- a/pkg/cloudprovider/provider/alibaba/types/types.go
+++ b/pkg/cloudprovider/provider/alibaba/types/types.go
@@ -30,4 +30,6 @@ type RawConfig struct {
 	InternetMaxBandwidthOut providerconfigtypes.ConfigVarString `json:"internetMaxBandwidthOut,omitempty"`
 	Labels                  map[string]string                   `json:"labels,omitempty"`
 	ZoneID                  providerconfigtypes.ConfigVarString `json:"zoneID,omitempty"`
+	DeskType                providerconfigtypes.ConfigVarString `json:"desk_type,omitempty"`
+	DeskSize                providerconfigtypes.ConfigVarString `json:"desk_size,omitempty"`
 }

--- a/pkg/cloudprovider/provider/alibaba/types/types.go
+++ b/pkg/cloudprovider/provider/alibaba/types/types.go
@@ -30,6 +30,6 @@ type RawConfig struct {
 	InternetMaxBandwidthOut providerconfigtypes.ConfigVarString `json:"internetMaxBandwidthOut,omitempty"`
 	Labels                  map[string]string                   `json:"labels,omitempty"`
 	ZoneID                  providerconfigtypes.ConfigVarString `json:"zoneID,omitempty"`
-	DeskType                providerconfigtypes.ConfigVarString `json:"desk_type,omitempty"`
-	DeskSize                providerconfigtypes.ConfigVarString `json:"desk_size,omitempty"`
+	DiskType                providerconfigtypes.ConfigVarString `json:"diskType,omitempty"`
+	DiskSize                providerconfigtypes.ConfigVarString `json:"diskSize,omitempty"`
 }

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -273,11 +273,15 @@ write_files:
     {{- end }}
 
     # Update grub to include kernel command options to enable swap accounting.
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+    {{ if eq .CloudProviderName "alibaba" }}
     if grep -v -q swapaccount=1 /proc/cmdline
     then
+      echo "Reboot system if not alibaba cloud"
       update-grub
       touch /var/run/reboot-required
     fi
+    {{ end }}
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -163,11 +163,8 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade -y
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -162,11 +162,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -162,11 +162,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -164,11 +164,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -162,11 +162,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -162,11 +162,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -162,11 +162,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -162,11 +162,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -162,11 +162,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -162,11 +162,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -172,11 +172,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -172,11 +172,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -163,11 +163,8 @@ write_files:
     apt-mark hold docker-ce || true
 
     # Update grub to include kernel command options to enable swap accounting.
-    if grep -v -q swapaccount=1 /proc/cmdline
-    then
-      update-grub
-      touch /var/run/reboot-required
-    fi
+    # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682
+
     if [[ -e /var/run/reboot-required ]]; then
       reboot
     fi

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -312,7 +312,7 @@ func TestAlibabaProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, ALIBABA_ACCESS_KEY_SECRET environment variable cannot be empty")
 	}
 
-	excludeSelector := &scenarioSelector{osName: []string{"coreos", "rhel"}}
+	excludeSelector := &scenarioSelector{osName: []string{"coreos", "rhel", "sles"}}
 
 	// act
 	params := []string{

--- a/test/e2e/provisioning/testdata/machinedeployment-alibaba.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-alibaba.yaml
@@ -32,8 +32,8 @@ spec:
             vSwitchID: "vsw-gw8g8mn4ohmj483hsylmn"
             internetMaxBandwidthOut: 10
             zoneID: eu-central-1a
-            deskType: "cloud_efficiency"
-            deskSize: "40"
+            diskType: "cloud_efficiency"
+            diskSize: "40"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-alibaba.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-alibaba.yaml
@@ -26,12 +26,14 @@ spec:
           cloudProviderSpec:
             accessKeyID: << ALIBABA_ACCESS_KEY_ID >>
             accessKeySecret: << ALIBABA_ACCESS_KEY_SECRET >>
-            instanceType: "ecs.sn1ne.large"
+            instanceType: "ecs.c6.large"
             instanceName: "alibaba-instance"
             regionID: eu-central-1
             vSwitchID: "vsw-gw8g8mn4ohmj483hsylmn"
             internetMaxBandwidthOut: 10
             zoneID: eu-central-1a
+            deskType: "cloud_efficiency"
+            deskSize: "40"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false


### PR DESCRIPTION
**What this PR does / why we need it**:
The UI team has started to integrate alibaba cloud provider in the ui. The CentOS image name was not correct and the disk type and size was hard coded in the provider code. This PR fix these issues.

**Special notes for your reviewer**:
Please make sure that the testing job for alibaba cloud is passing before merging.

```release-note
None
```
