### PR TITLE
support rhel in aws cloud provider

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -223,17 +223,21 @@ func getDefaultAMIID(client *ec2.EC2, os providerconfigtypes.OperatingSystem, re
 }
 
 func getDefaultRootDevicePath(os providerconfigtypes.OperatingSystem) (string, error) {
+	const (
+		rootDevicePathUbuntuCentOSRHEL = "/dev/sda1"
+		rootDevicePathCoreOSSLES       = "/dev/xvda"
+	)
 	switch os {
 	case providerconfigtypes.OperatingSystemUbuntu:
-		return "/dev/sda1", nil
+		return rootDevicePathUbuntuCentOSRHEL, nil
 	case providerconfigtypes.OperatingSystemCentOS:
-		return "/dev/sda1", nil
+		return rootDevicePathUbuntuCentOSRHEL, nil
 	case providerconfigtypes.OperatingSystemCoreos:
-		return "/dev/xvda", nil
+		return rootDevicePathCoreOSSLES, nil
 	case providerconfigtypes.OperatingSystemSLES:
-		return "/dev/xvda", nil
+		return rootDevicePathCoreOSSLES, nil
 	case providerconfigtypes.OperatingSystemRHEL:
-		return "/dev/sda1", nil
+		return rootDevicePathUbuntuCentOSRHEL, nil
 	}
 
 	return "", fmt.Errorf("no default root path found for %s operating system", os)

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -38,6 +38,7 @@ import (
 	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
 	awstypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws/types"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/rhsm"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -112,6 +113,12 @@ var (
 			// The AWS marketplace ID from Canonical
 			owner: "013907871322",
 		},
+		providerconfigtypes.OperatingSystemRHEL: {
+			// Be as precise as possible - otherwise we might get a nightly dev build
+			description: "Provided by Red Hat, Inc.",
+			// The AWS marketplace ID from Canonical
+			owner: "309956199498",
+		},
 	}
 
 	// cacheLock protects concurrent cache misses against a single key. This usually happens when multiple machines get created simultaneously
@@ -139,6 +146,7 @@ type Config struct {
 	EBSVolumeEncrypted bool
 	Tags               map[string]string
 	AssignPublicIP     *bool
+	manager            rhsm.RedHatSubscriptionManager
 }
 
 type amiFilter struct {
@@ -224,6 +232,8 @@ func getDefaultRootDevicePath(os providerconfigtypes.OperatingSystem) (string, e
 		return "/dev/xvda", nil
 	case providerconfigtypes.OperatingSystemSLES:
 		return "/dev/xvda", nil
+	case providerconfigtypes.OperatingSystemRHEL:
+		return "/dev/sda1", nil
 	}
 
 	return "", fmt.Errorf("no default root path found for %s operating system", os)
@@ -310,7 +320,13 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	c.Tags = rawConfig.Tags
 	c.IsSpotInstance = rawConfig.IsSpotInstance
 	c.AssignPublicIP = rawConfig.AssignPublicIP
-
+	offlineToken, _ := p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.RHSMOfflineToken, "REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
+	if offlineToken != "" {
+		c.manager, err = rhsm.NewRedHatSubscriptionManager(offlineToken)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to create redhat subscription manager: %v", err)
+		}
+	}
 	return &c, &pconfig, &rawConfig, err
 }
 
@@ -585,7 +601,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.Prov
 		return false, err
 	}
 
-	config, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	config, pc, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return false, cloudprovidererrors.TerminalError{
 			Reason:  common.InvalidConfigurationMachineError,
@@ -607,6 +623,12 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.Prov
 
 	if *tOut.TerminatingInstances[0].PreviousState.Name != *tOut.TerminatingInstances[0].CurrentState.Name {
 		klog.V(3).Infof("successfully triggered termination of instance %s at aws", instance.ID())
+	}
+
+	if pc.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && config.manager != nil {
+		if err := config.manager.UnregisterInstance(machine.Name); err != nil {
+			return false, fmt.Errorf("failed delete machine %s subscription: %v", machine.Name, err)
+		}
 	}
 
 	return false, nil

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -110,13 +110,13 @@ var (
 		providerconfigtypes.OperatingSystemSLES: {
 			// Be as precise as possible - otherwise we might get a nightly dev build
 			description: "SUSE Linux Enterprise Server 15 SP1 (HVM, 64-bit, SSD-Backed)",
-			// The AWS marketplace ID from Canonical
+			// The AWS marketplace ID from SLES
 			owner: "013907871322",
 		},
 		providerconfigtypes.OperatingSystemRHEL: {
 			// Be as precise as possible - otherwise we might get a nightly dev build
 			description: "Provided by Red Hat, Inc.",
-			// The AWS marketplace ID from Canonical
+			// The AWS marketplace ID from RedHat
 			owner: "309956199498",
 		},
 	}

--- a/pkg/cloudprovider/provider/aws/types/types.go
+++ b/pkg/cloudprovider/provider/aws/types/types.go
@@ -39,4 +39,5 @@ type RawConfig struct {
 	EBSVolumeEncrypted providerconfigtypes.ConfigVarBool     `json:"ebsVolumeEncrypted"`
 	Tags               map[string]string                     `json:"tags,omitempty"`
 	AssignPublicIP     *bool                                 `json:"assignPublicIP,omitempty"`
+	RHSMOfflineToken   providerconfigtypes.ConfigVarString   `json:"rhsmOfflineToken,omitempty"`
 }

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -182,9 +182,11 @@ write_files:
 {{- /*  The normal way of setting it via cloud-init is broken, see */}}
 {{- /*  https://bugs.launchpad.net/cloud-init/+bug/1662542 */}}
     hostnamectl set-hostname {{ .MachineSpec.Name }}
+{{- /*  We should create a subscription for all instances in all cloud providers, however for aws this must be done by using the gold images */}}
+{{- /*  https://github.com/kubermatic/kubermatic/issues/5099 */}}
+    subscription-manager register --username='{{.OSConfig.RHELSubscriptionManagerUser}}' --password='{{.OSConfig.RHELSubscriptionManagerPassword}}' --auto-attach --force
     {{ end }}
     
-    subscription-manager register --username='{{.OSConfig.RHELSubscriptionManagerUser}}' --password='{{.OSConfig.RHELSubscriptionManagerPassword}}' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir /etc/docker

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -69,7 +69,6 @@ write_files:
     swapoff -a
 
 
-    subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir /etc/docker

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -69,7 +69,6 @@ write_files:
     swapoff -a
 
 
-    subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir /etc/docker

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -69,7 +69,6 @@ write_files:
     swapoff -a
 
 
-    subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir /etc/docker

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -69,7 +69,6 @@ write_files:
     swapoff -a
 
 
-    subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir /etc/docker

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -79,9 +79,9 @@ write_files:
     swapoff -a
 
     hostnamectl set-hostname node1
-
-
     subscription-manager register --username='' --password='' --auto-attach --force
+
+
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir /etc/docker

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -79,9 +79,9 @@ write_files:
     swapoff -a
 
     hostnamectl set-hostname node1
-
-
     subscription-manager register --username='' --password='' --auto-attach --force
+
+
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir /etc/docker

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -71,9 +71,9 @@ write_files:
     swapoff -a
 
     hostnamectl set-hostname node1
-
-
     subscription-manager register --username='' --password='' --auto-attach --force
+
+
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir /etc/docker

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -69,7 +69,6 @@ write_files:
     swapoff -a
 
 
-    subscription-manager register --username='' --password='' --auto-attach --force
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir /etc/docker

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -151,7 +151,7 @@ func TestAWSProvisioningE2E(t *testing.T) {
 	if len(awsKeyID) == 0 || len(awsSecret) == 0 {
 		t.Fatal("unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
 	}
-	excludeSelector := &scenarioSelector{osName: []string{"sles", "rhel"}}
+	excludeSelector := &scenarioSelector{osName: []string{"sles"}}
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
 		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -138,6 +138,7 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>=%s", rhelSubscriptionManagerPassword))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", rhsmOfflineToken))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 50))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", "ami-dafdcfc7"))
 	} else {
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 25))
 	}

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -138,8 +138,9 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>=%s", rhelSubscriptionManagerPassword))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", rhsmOfflineToken))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 50))
-		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", "ami-dafdcfc7"))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", "ami-0badcc5b522737046"))
 	} else {
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 25))
 	}
 

--- a/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
@@ -34,6 +34,7 @@ spec:
             diskSize: 50
             diskType: "gp2"
             ebsVolumeEncrypted: false
+            ami: "<< AMI >>"
             securityGroupIDs:
             - "sg-a2c195ca"
             tags:
@@ -42,10 +43,15 @@ spec:
               "KubernetesCluster": "randomString"
             # Disabling the public IP assignment requires a private subnet with internet access.
             assignPublicIP: true
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           # Can be 'ubuntu', 'coreos' , 'centos' or 'sles'
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false
             disableAutoUpdate: true
+            # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
+            # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding rhel as an OS option for AWS cloud provider. 

**Which issue(s) this PR fixes** 

Fixes #5005

```release-note
None
```
