### PR TITLE
Improve openstack default subnet selection

### DIFF
--- a/pkg/cloudprovider/provider/openstack/helper.go
+++ b/pkg/cloudprovider/provider/openstack/helper.go
@@ -414,18 +414,15 @@ NetworkLoop:
 }
 
 func getDefaultSubnet(client *gophercloud.ProviderClient, network *osnetworks.Network, region string) (*string, error) {
-	if len(network.Subnets) == 0 {
-		return nil, nil
-	} else if len(network.Subnets) == 1 {
+	if len(network.Subnets) == 1 {
 		return &network.Subnets[0], nil
-	} else {
-		subnets, err := getSubnets(client, region, network.ID)
-		if err != nil {
-			return nil, err
-		}
-		if len(subnets) == 1 {
-			return &subnets[0].ID, nil
-		}
 	}
-	return nil, nil
+	subnets, err := getSubnets(client, region, network.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(subnets) == 0 {
+		return nil, errors.New("no subnets available")
+	}
+	return &subnets[0].ID, nil
 }


### PR DESCRIPTION
Previously no openstack subnet would be defaulted when more than one is available.

Details of this change on openstack default subnet selection:
* pick the first subnet if more than one is available (instead of returning nil)
* error out when no subnet is available (after subnet api request)
* continue to skip subnet api request when network has exactly one subnet already

```release-note
NONE
```
