### PR TITLE
AWS: improve AMI-ID error message

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -491,7 +491,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 		if amiID, err = getDefaultAMIID(ec2Client, pc.OperatingSystem, config.Region); err != nil {
 			return nil, cloudprovidererrors.TerminalError{
 				Reason:  common.InvalidConfigurationMachineError,
-				Message: fmt.Sprintf("Invalid Region and Operating System configuration: %v", err),
+				Message: fmt.Sprintf("Failed to get AMI-ID for operating system %s in region %s: %v", pc.OperatingSystem, config.Region, err),
 			}
 		}
 	}


### PR DESCRIPTION
The error message when searching for the AMI-ID fails did not indicate this problem.

```release-note
NONE
```
