### PR TITLE
Use smaller VM flavor in e2e tests to avoid hitting CPU quota

### DIFF
--- a/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
@@ -29,7 +29,7 @@ spec:
             password: "<< PASSWORD >>"
             tenantName: "<< TENANT_NAME >>"
             image: "<< OS_IMAGE >>"
-            flavor: "m1.small"
+            flavor: "m1.tiny"
             floatingIpPool: ""
             domainName: "<< DOMAIN_NAME >>"
             region: "<< REGION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
We have often openstack e2e test failures due to quota issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
NONE
```
