### PR TITLE
Add rhel support in azure cloud provider

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -230,6 +230,7 @@ presubmits:
       preset-azure: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-rhel: "true"
     spec:
       containers:
         # Uses go1.11.1

--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -36,6 +36,8 @@ type RawConfig struct {
 	AvailabilitySet   providerconfigtypes.ConfigVarString `json:"availabilitySet"`
 	SecurityGroupName providerconfigtypes.ConfigVarString `json:"securityGroupName"`
 
-	AssignPublicIP providerconfigtypes.ConfigVarBool `json:"assignPublicIP"`
-	Tags           map[string]string                 `json:"tags,omitempty"`
+	AssignPublicIP   providerconfigtypes.ConfigVarBool   `json:"assignPublicIP"`
+	Tags             map[string]string                   `json:"tags,omitempty"`
+	ImageID          providerconfigtypes.ConfigVarString `json:"imageID"`
+	RHSMOfflineToken providerconfigtypes.ConfigVarString `json:"rhsmOfflineToken,omitempty"`
 }

--- a/pkg/cloudprovider/rhsm/subscription_manager.go
+++ b/pkg/cloudprovider/rhsm/subscription_manager.go
@@ -81,9 +81,9 @@ func NewRedHatSubscriptionManager(offlineToken string) (RedHatSubscriptionManage
 
 func (d *defaultRedHatSubscriptionManager) UnregisterInstance(machineName string) error {
 	if d.credentials == nil {
-		klog.Info("access token has been expired, refreshing token")
+		klog.Info("access token has been expired or not initialized, refreshing token")
 		if err := d.refreshToken(); err != nil {
-			return fmt.Errorf("failed to refresh offline token")
+			return fmt.Errorf("failed to refresh offline token: %v", err)
 		}
 	}
 

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -184,12 +184,16 @@ write_files:
     hostnamectl set-hostname {{ .MachineSpec.Name }}
 {{- /*  We should create a subscription for all instances in all cloud providers, however for aws this must be done by using the gold images */}}
 {{- /*  https://github.com/kubermatic/kubermatic/issues/5099 */}}
-    subscription-manager register --username='{{.OSConfig.RHELSubscriptionManagerUser}}' --password='{{.OSConfig.RHELSubscriptionManagerPassword}}' --auto-attach --force
+    subscription-manager clean
+    subscription-manager register --username='{{.OSConfig.RHELSubscriptionManagerUser}}' --password='{{.OSConfig.RHELSubscriptionManagerPassword}}'
+    subscription-manager attach --auto
+    yum clean all
+    yum repolist
     {{ end }}
-    
+
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    mkdir /etc/docker
+    [ ! -d "/etc/docker" ] && mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \
@@ -216,7 +220,7 @@ write_files:
       ]
     }
     EOF
-      
+
 {{ downloadBinariesScript .KubeletVersion true | indent 4 }}
 
     {{- if eq .CloudProviderName "vsphere" }}

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -193,7 +193,7 @@ write_files:
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    [ ! -d "/etc/docker" ] && mkdir -p "/etc/docker"
+    mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -71,7 +71,7 @@ write_files:
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    mkdir /etc/docker
+    mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -71,7 +71,7 @@ write_files:
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    mkdir /etc/docker
+    mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -71,7 +71,7 @@ write_files:
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    mkdir /etc/docker
+    mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -71,7 +71,7 @@ write_files:
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    mkdir /etc/docker
+    mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -79,12 +79,16 @@ write_files:
     swapoff -a
 
     hostnamectl set-hostname node1
-    subscription-manager register --username='' --password='' --auto-attach --force
+    subscription-manager clean
+    subscription-manager register --username='' --password=''
+    subscription-manager attach --auto
+    yum clean all
+    yum repolist
 
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    mkdir /etc/docker
+    mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -79,12 +79,16 @@ write_files:
     swapoff -a
 
     hostnamectl set-hostname node1
-    subscription-manager register --username='' --password='' --auto-attach --force
+    subscription-manager clean
+    subscription-manager register --username='' --password=''
+    subscription-manager attach --auto
+    yum clean all
+    yum repolist
 
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    mkdir /etc/docker
+    mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -71,12 +71,16 @@ write_files:
     swapoff -a
 
     hostnamectl set-hostname node1
-    subscription-manager register --username='' --password='' --auto-attach --force
+    subscription-manager clean
+    subscription-manager register --username='' --password=''
+    subscription-manager attach --auto
+    yum clean all
+    yum repolist
 
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    mkdir /etc/docker
+    mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -71,7 +71,7 @@ write_files:
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
-    mkdir /etc/docker
+    mkdir -p "/etc/docker"
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
       ebtables \

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -222,7 +222,7 @@ func TestAzureProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET environment variables cannot be empty")
 	}
 
-	excludeSelector := &scenarioSelector{osName: []string{"sles", "rhel"}}
+	excludeSelector := &scenarioSelector{osName: []string{"sles"}}
 	// act
 	params := []string{
 		fmt.Sprintf("<< AZURE_TENANT_ID >>=%s", azureTenantID),

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -130,10 +130,19 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		rhelSubscriptionManagerUser := os.Getenv("RHEL_SUBSCRIPTION_MANAGER_USER")
 		rhelSubscriptionManagerPassword := os.Getenv("RHEL_SUBSCRIPTION_MANAGER_PASSWORD")
 		rhsmOfflineToken := os.Getenv("REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
+		if strings.Contains(cloudProvider, string(providerconfigtypes.CloudProviderAzure)) {
+			rhelImageID := os.Getenv("AZURE_RHEL_IMAGE_ID")
+			if rhelImageID == "" {
+				t.Fatalf("Unable to run e2e tests, AZURE_RHEL_IMAGE_ID must be set when rhel is used as an os in Azure")
+			}
+			scenarioParams = append(scenarioParams, fmt.Sprintf("<< IMAGE_ID >>=%s", rhelImageID))
+		}
+
 		if rhelSubscriptionManagerUser == "" || rhelSubscriptionManagerPassword == "" || rhsmOfflineToken == "" {
-			t.Errorf("Unable to run e2e tests, RHEL_SUBSCRIPTION_MANAGER_USER, RHEL_SUBSCRIPTION_MANAGER_PASSWORD, and " +
+			t.Fatalf("Unable to run e2e tests, RHEL_SUBSCRIPTION_MANAGER_USER, RHEL_SUBSCRIPTION_MANAGER_PASSWORD, and " +
 				"REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN must be set when rhel is used as an os")
 		}
+
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_USER >>=%s", rhelSubscriptionManagerUser))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>=%s", rhelSubscriptionManagerPassword))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", rhsmOfflineToken))
@@ -141,6 +150,7 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", "ami-0badcc5b522737046"))
 	} else {
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", ""))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< IMAGE_ID >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 25))
 	}
 

--- a/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
@@ -34,10 +34,16 @@ spec:
             vnetName: "machine-controller-e2e"
             subnetName: "machine-controller-e2e"
             routeTableName: "machine-controller-e2e"
+            imageID: "<< IMAGE_ID >>"
             assignPublicIP: false
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false
             disableAutoUpdate: true
+            # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
+            # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding support for Red Hat Enterprise Linux in Azure cloud provider.

**Which issue(s) this PR fixes**
Fixes kubermatic/kubermatic#5004

**Special notes for your reviewer**:
`pull-machine-controller-e2e-azure` should pass. 
```release-note
None
```
