### PR TITLE
Fix docker-image rule in Makefile

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -504,7 +504,7 @@ postsubmits:
               /usr/local/bin/entrypoint.sh &&
               docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD &&
               docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io &&
-              make docker-image
+              make docker-image-publish
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.9
+ARG GO_VERSION=1.13
+FROM golang:${GO_VERSION} AS builder
+WORKDIR /go/src/github.com/kubermatic/machine-controller
+COPY . .
+RUN make all
+
+FROM alpine:3.11
 
 RUN apk add --no-cache ca-certificates cdrkit
 
-COPY machine-controller machine-controller-userdata-* webhook /usr/local/bin/
-
+COPY --from=builder /go/src/github.com/kubermatic/machine-controller/machine-controller \
+    /go/src/github.com/kubermatic/machine-controller/machine-controller-userdata-* \
+    /go/src/github.com/kubermatic/machine-controller/webhook \
+    /usr/local/bin/
 USER nobody

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ GO_VERSION = 1.13.8
 
 export CGO_ENABLED := 0
 
+export GOFLAGS ?= -mod=readonly
+
 export E2E_SSH_PUBKEY ?= $(shell test -f ~/.ssh/id_rsa.pub && cat ~/.ssh/id_rsa.pub)
 
 export DOCKER_TAG ?= $(shell git tag --points-at HEAD)
@@ -86,7 +88,7 @@ test-unit-docker:
 		-e GOCACHE=/cache \
 		-w /go/src/github.com/kubermatic/machine-controller \
 		golang:$(GO_VERSION) \
-			make test-unit
+			make test-unit GOFLAGS=$(GOFLAGS)
 
 .PHONY: test-unit
 test-unit:

--- a/Makefile
+++ b/Makefile
@@ -58,23 +58,16 @@ clean:
 		webhook \
 		$(USERDATA_BIN)
 
-.PHONY: machine-controller-docker
-machine-controller-docker:
-	@docker run --rm \
-		-v $$PWD:/go/src/github.com/kubermatic/machine-controller \
-		-v $$PWD/.buildcache:/cache \
-		-e GOCACHE=/cache \
-		-w /go/src/github.com/kubermatic/machine-controller \
-		golang:$(GO_VERSION) \
-			make all CGO_ENABLED="$(CGO_ENABLED)"
-
 .PHONY: lint
 lint:
 	golangci-lint run -v
 
 .PHONY: docker-image
-docker-image: machine-controller webhook
-	docker build -t $(IMAGE_NAME) .
+docker-image:
+	docker build --build-arg GO_VERSION=$(GO_VERSION) -t $(IMAGE_NAME) .
+
+.PHONY: docker-image-publish
+docker-image-publish: docker-image
 	docker push $(IMAGE_NAME)
 	if [[ -n "$(GIT_TAG)" ]]; then \
 		$(eval IMAGE_TAG = $(GIT_TAG)) \


### PR DESCRIPTION
**What this PR does / why we need it**:
When I updated the Makefile in PR #680 I replaced `machine-controller` rule with a pattern rule that differently from the previous one just builds the `machine-controller` and not the userdata binaries, but I forgot to update the `docker-image` rule accordingly, thus the images generated when the PR was merged do not include the userdata binaries

This PR does following things:
- Fixes the issue described above.
- Split the generation and the upload of the docker image in two different rules in the Makefile `docker-image` and `docker-image-publish`
- Builds the binary included in the docker image with a multistage build
- Adds the `-mod=readonly` flag to the build to avoid modifying the committed `go.mod` and `go.sum`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

```release-note
NONE
```
