### PR TITLE
Fix Github PR template formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,16 @@
 **What this PR does / why we need it**:
 
-**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
+**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
 Fixes #
 
 **Special notes for your reviewer**:
 
+**Optional Release Note**:
+<!--
+Write your release note:
+1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
+2. If no release note is required, just write "NONE".
+-->
 ```release-note
+
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
The old template made the release-note block look like the review notes.

```release-note
NONE
```