### PR TITLE
Remove duplicated GOFLAGS from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,6 @@ GO_VERSION = 1.13.8
 
 export CGO_ENABLED := 0
 
-export GOFLAGS ?= -mod=readonly
-
 export E2E_SSH_PUBKEY ?= $(shell test -f ~/.ssh/id_rsa.pub && cat ~/.ssh/id_rsa.pub)
 
 export DOCKER_TAG ?= $(shell git tag --points-at HEAD)


### PR DESCRIPTION
**What this PR does / why we need it**:
Concurrent PRs having almost the same GOFLAG settings caused duplication

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
