### PR TITLE
add rhel support to the gcp cloud provider

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -253,6 +253,7 @@ presubmits:
       preset-gce: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-rhel: "true"
     spec:
       containers:
         # Uses go1.11.1

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -38,6 +38,7 @@ import (
 	gcetypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/gce/types"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 )
 
 // Terminal error messages.
@@ -289,6 +290,12 @@ func (p *Provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 	err = svc.waitZoneOperation(cfg, op.Name)
 	if err != nil {
 		return false, newError(common.InvalidConfigurationMachineError, errDeleteInstance, err)
+	}
+
+	if cfg.providerConfig.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && cfg.manager != nil {
+		if err := cfg.manager.UnregisterInstance(machine.Name); err != nil {
+			return false, fmt.Errorf("failed delete machine %s subscription: %v", machine.Name, err)
+		}
 	}
 	return false, nil
 }

--- a/pkg/cloudprovider/provider/gce/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/gce/types/cloudconfig.go
@@ -44,14 +44,15 @@ const cloudConfigTemplate = "[global]\n" +
 
 // GlobalOpts contains the values of the global section of the cloud configuration.
 type GlobalOpts struct {
-	ProjectID      string
-	LocalZone      string
-	NetworkName    string
-	SubnetworkName string
-	TokenURL       string
-	MultiZone      bool
-	Regional       bool
-	NodeTags       []string
+	ProjectID        string
+	LocalZone        string
+	NetworkName      string
+	SubnetworkName   string
+	TokenURL         string
+	MultiZone        bool
+	Regional         bool
+	NodeTags         []string
+	RHSMOfflineToken string
 }
 
 // CloudConfig contains only the section global.

--- a/pkg/cloudprovider/provider/gce/types/types.go
+++ b/pkg/cloudprovider/provider/gce/types/types.go
@@ -42,6 +42,8 @@ type CloudProviderSpec struct {
 	AssignPublicIPAddress *providerconfigtypes.ConfigVarBool  `json:"assignPublicIPAddress,omitempty"`
 	MultiZone             providerconfigtypes.ConfigVarBool   `json:"multizone"`
 	Regional              providerconfigtypes.ConfigVarBool   `json:"regional"`
+	RHSMOfflineToken      providerconfigtypes.ConfigVarString `json:"rhsmOfflineToken,omitempty"`
+	CustomImage           providerconfigtypes.ConfigVarString `json:"customImage,omitempty"`
 }
 
 // UpdateProviderSpec updates the given provider spec with changed

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -246,7 +246,7 @@ func TestGCEProvisioningE2E(t *testing.T) {
 	}
 
 	// Act. GCE does not support CentOS.
-	excludeSelector := &scenarioSelector{osName: []string{"centos", "sles", "rhel"}}
+	excludeSelector := &scenarioSelector{osName: []string{"centos", "sles"}}
 	params := []string{
 		fmt.Sprintf("<< GOOGLE_SERVICE_ACCOUNT >>=%s", googleServiceAccount),
 	}

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -147,11 +147,13 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>=%s", rhelSubscriptionManagerPassword))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", rhsmOfflineToken))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 50))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< CUSTOM-IMAGE >>=%v", "rhel-8-1-custom"))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", "ami-0badcc5b522737046"))
 	} else {
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< IMAGE_ID >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 25))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< CUSTOM-IMAGE >>=%v", ""))
 	}
 
 	// only used by OpenStack scenarios

--- a/test/e2e/provisioning/testdata/machinedeployment-gce.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-gce.yaml
@@ -37,10 +37,16 @@ spec:
             labels:
                 "kubernetes_cluster": "gce-test-cluster"
             assignPublicIPAddress: true
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
+            customImage: "<< CUSTOM-IMAGE >>"
           # Can be 'ubuntu' or 'coreos'
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false
             disableAutoUpdate: true
+            # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
+            # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding support for RHEL in gcp cloud provider.

**Which issue(s) this PR fixes** 
Fixes kubermatic/kubermatic#5007

```release-note
None
```
