### PR TITLE
Enable subscription manager for aws

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -615,7 +615,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.Prov
 	}
 
 	if pc.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && config.manager != nil {
-		if err := config.manager.UnregisterInstance(machine.Name); err != nil {
+		if err := config.manager.UnregisterInstance(*instance.instance.PrivateDnsName); err != nil {
 			return false, fmt.Errorf("failed delete machine %s subscription: %v", machine.Name, err)
 		}
 	}

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -182,14 +182,13 @@ write_files:
 {{- /*  The normal way of setting it via cloud-init is broken, see */}}
 {{- /*  https://bugs.launchpad.net/cloud-init/+bug/1662542 */}}
     hostnamectl set-hostname {{ .MachineSpec.Name }}
-{{- /*  We should create a subscription for all instances in all cloud providers, however for aws this must be done by using the gold images */}}
-{{- /*  https://github.com/kubermatic/kubermatic/issues/5099 */}}
+    {{ end }}
+
     subscription-manager clean
     subscription-manager register --username='{{.OSConfig.RHELSubscriptionManagerUser}}' --password='{{.OSConfig.RHELSubscriptionManagerPassword}}'
     subscription-manager attach --auto
     yum clean all
     yum repolist
-    {{ end }}
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -69,6 +69,12 @@ write_files:
     swapoff -a
 
 
+    subscription-manager clean
+    subscription-manager register --username='' --password=''
+    subscription-manager attach --auto
+    yum clean all
+    yum repolist
+
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir -p "/etc/docker"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -69,6 +69,12 @@ write_files:
     swapoff -a
 
 
+    subscription-manager clean
+    subscription-manager register --username='' --password=''
+    subscription-manager attach --auto
+    yum clean all
+    yum repolist
+
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir -p "/etc/docker"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -69,6 +69,12 @@ write_files:
     swapoff -a
 
 
+    subscription-manager clean
+    subscription-manager register --username='' --password=''
+    subscription-manager attach --auto
+    yum clean all
+    yum repolist
+
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir -p "/etc/docker"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -69,6 +69,12 @@ write_files:
     swapoff -a
 
 
+    subscription-manager clean
+    subscription-manager register --username='' --password=''
+    subscription-manager attach --auto
+    yum clean all
+    yum repolist
+
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir -p "/etc/docker"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -79,12 +79,13 @@ write_files:
     swapoff -a
 
     hostnamectl set-hostname node1
+
+
     subscription-manager clean
     subscription-manager register --username='' --password=''
     subscription-manager attach --auto
     yum clean all
     yum repolist
-
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -79,12 +79,13 @@ write_files:
     swapoff -a
 
     hostnamectl set-hostname node1
+
+
     subscription-manager clean
     subscription-manager register --username='' --password=''
     subscription-manager attach --auto
     yum clean all
     yum repolist
-
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -71,12 +71,13 @@ write_files:
     swapoff -a
 
     hostnamectl set-hostname node1
+
+
     subscription-manager clean
     subscription-manager register --username='' --password=''
     subscription-manager attach --auto
     yum clean all
     yum repolist
-
 
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -69,6 +69,12 @@ write_files:
     swapoff -a
 
 
+    subscription-manager clean
+    subscription-manager register --username='' --password=''
+    subscription-manager attach --auto
+    yum clean all
+    yum repolist
+
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     mkdir -p "/etc/docker"

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -148,7 +148,7 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", rhsmOfflineToken))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 50))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< CUSTOM-IMAGE >>=%v", "rhel-8-1-custom"))
-		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", "ami-0badcc5b522737046"))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", "ami-08c04369895785ac4"))
 	} else {
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< IMAGE_ID >>=%s", ""))


### PR DESCRIPTION
**What this PR does / why we need it**:
To manage red hat linux subscriptions in the customer cloud portal. This functionality was not available in aws due to the lack of support for rhel-8.x GA images. 

**Which issue(s) this PR fixes** 
Fixes kubermatic/kubermatic#5001

**Optional Release Note**:
```release-note
None
```
