### PR TITLE
Fix the ip address updating in the cluster status

### DIFF
--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -167,7 +167,7 @@ spec:
             # Machines that fail to join the cluster within this timeout and
             # are owned by a MachineSet will get deleted so the MachineSet
             # controller re-creates them
-            - -join-cluster-timeout=15m
+            - -join-cluster-timeout=25m
           ports:
           - containerPort: 8085
           livenessProbe:

--- a/hack/ci-e2e-test.sh
+++ b/hack/ci-e2e-test.sh
@@ -99,4 +99,4 @@ EXTRA_ARGS=""
 if [[ $# -gt 0 ]]; then
   EXTRA_ARGS="-run $1"
 fi
-go test -race -tags=e2e -parallel 240 -v -timeout 50m  ./test/e2e/... -identifier=$BUILD_ID $EXTRA_ARGS
+go test -race -tags=e2e -parallel 240 -v -timeout 70m  ./test/e2e/... -identifier=$BUILD_ID $EXTRA_ARGS

--- a/pkg/cloudprovider/provider/azure/get_client.go
+++ b/pkg/cloudprovider/provider/azure/get_client.go
@@ -35,6 +35,17 @@ func getIPClient(c *config) (*network.PublicIPAddressesClient, error) {
 	return &ipClient, nil
 }
 
+func getIPConfigClient(c *config) (*network.InterfaceIPConfigurationsClient, error) {
+	var err error
+	ipConfigClient := network.NewInterfaceIPConfigurationsClient(c.SubscriptionID)
+	ipConfigClient.Authorizer, err = auth.NewClientCredentialsConfig(c.ClientID, c.ClientSecret, c.TenantID).Authorizer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authorizer: %s", err.Error())
+	}
+
+	return &ipConfigClient, nil
+}
+
 func getSubnetsClient(c *config) (*network.SubnetsClient, error) {
 	var err error
 	subnetClient := network.NewSubnetsClient(c.SubscriptionID)

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -179,7 +179,7 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 	// we decided to keep this time lower that the global timeout to prevent the following:
 	// the global timeout is set to 20 minutes and the verify tool waits up to 60 hours for a machine to show up.
 	// thus one faulty scenario prevents from showing the results for the whole group, which is confusing because it looks like all tests are broken.
-	if err := testCase.executor(kubeConfig, manifestPath, scenarioParams, 25*time.Minute); err != nil {
+	if err := testCase.executor(kubeConfig, manifestPath, scenarioParams, 35*time.Minute); err != nil {
 		t.Errorf("verify failed due to error=%v", err)
 	}
 }

--- a/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
@@ -30,7 +30,7 @@ spec:
             subscriptionID: "<< AZURE_SUBSCRIPTION_ID >>"
             location: "westeurope"
             resourceGroup: "machine-controller-e2e"
-            vmSize: "Standard_F1"
+            vmSize: "Standard_F2"
             # optional disk size values in GB. If not set, the defaults for the vmSize will be used.
             osDiskSize: 30
             dataDiskSize: 30


### PR DESCRIPTION
**What this PR does / why we need it**:
The `status.addresses` in the machine object was lacking the list of the ip addresses for the instances that are created in Azure cloud provider. The reason for that was sending wrong parameters to the azure api.
**Which issue(s) this PR fixes**
Fixes kubermatic/kubermatic#5137

**Special notes for your reviewer**:
Make sure that the `pull-machine-controller-e2e-azure` job is green :) 
```release-note
None
```
