### PR TITLE
Add finalizer for rhsm subscription

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -216,6 +216,7 @@ presubmits:
               cpu: 500m
 
   - name: pull-machine-controller-e2e-azure
+    always_run: true
     decorate: true
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -580,7 +580,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 
 	if pc.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && config.manager != nil {
 		if err := rhsm.AddRHELSubscriptionFinalizer(machine, data.Update); err != nil {
-			return nil, fmt.Errorf("failed adding finlizer: %v", err)
+			return nil, fmt.Errorf("failed adding finalizer: %v", err)
 		}
 	}
 

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -541,7 +541,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 
 	if providerCfg.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && config.manager != nil {
 		if err := rhsm.AddRHELSubscriptionFinalizer(machine, data.Update); err != nil {
-			return nil, fmt.Errorf("failed adding finlizer: %v", err)
+			return nil, fmt.Errorf("failed adding finalizer: %v", err)
 		}
 	}
 	return &azureVM{vm: &vm, ipAddresses: ipAddresses, status: status}, nil

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -265,7 +265,7 @@ func (p *Provider) Create(
 
 	if cfg.providerConfig.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && cfg.manager != nil {
 		if err := rhsm.AddRHELSubscriptionFinalizer(machine, data.Update); err != nil {
-			return nil, fmt.Errorf("failed adding finlizer: %v", err)
+			return nil, fmt.Errorf("failed adding finalizer: %v", err)
 		}
 	}
 

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -429,7 +429,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 
 	if pc.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && c.manager != nil {
 		if err := rhsm.AddRHELSubscriptionFinalizer(machine, data.Update); err != nil {
-			return nil, fmt.Errorf("failed adding finlizer: %v", err)
+			return nil, fmt.Errorf("failed adding finalizer: %v", err)
 		}
 	}
 

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -507,7 +507,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 
 	if pc.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && c.manager != nil {
 		if err := rhsm.AddRHELSubscriptionFinalizer(machine, data.Update); err != nil {
-			return nil, fmt.Errorf("failed adding finlizer: %v", err)
+			return nil, fmt.Errorf("failed adding finalizer: %v", err)
 		}
 	}
 	return &osInstance{server: &server}, nil

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -344,7 +344,7 @@ func (p *provider) create(machine *v1alpha1.Machine, updater cloudprovidertypes.
 
 	if pc.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && config.manager != nil {
 		if err := rhsm.AddRHELSubscriptionFinalizer(machine, updater); err != nil {
-			return nil, fmt.Errorf("failed adding finlizer: %v", err)
+			return nil, fmt.Errorf("failed adding finalizer: %v", err)
 		}
 	}
 

--- a/pkg/cloudprovider/rhsm/util.go
+++ b/pkg/cloudprovider/rhsm/util.go
@@ -1,0 +1,37 @@
+package rhsm
+
+import (
+	"fmt"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+	kuberneteshelper "github.com/kubermatic/machine-controller/pkg/kubernetes"
+)
+
+const (
+	redhatSubscriptionFinalizer = "kubermatic.io/red-hat-subscription"
+)
+
+func AddRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.MachineUpdater) error {
+	if !kuberneteshelper.HasFinalizer(machine, redhatSubscriptionFinalizer) {
+		if err := update(machine, func(m *v1alpha1.Machine) {
+			machine.Finalizers = append(m.Finalizers, redhatSubscriptionFinalizer)
+		}); err != nil {
+			return fmt.Errorf("failed to add redhat subscription finalizer: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func RemoveRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.MachineUpdater) error {
+	if kuberneteshelper.HasFinalizer(machine, redhatSubscriptionFinalizer) {
+		if err := update(machine, func(m *v1alpha1.Machine) {
+			machine.Finalizers = kuberneteshelper.RemoveFinalizer(machine.Finalizers, redhatSubscriptionFinalizer)
+		}); err != nil {
+			return fmt.Errorf("failed to remove redhat subscription finalizer: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cloudprovider/rhsm/util.go
+++ b/pkg/cloudprovider/rhsm/util.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package rhsm
 
 import (
@@ -12,6 +28,7 @@ const (
 	redhatSubscriptionFinalizer = "kubermatic.io/red-hat-subscription"
 )
 
+// AddRHELSubscriptionFinalizer adds finalizer redhatSubscriptionFinalizer to the machine object on rhel machine creation.
 func AddRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.MachineUpdater) error {
 	if !kuberneteshelper.HasFinalizer(machine, redhatSubscriptionFinalizer) {
 		if err := update(machine, func(m *v1alpha1.Machine) {
@@ -24,6 +41,7 @@ func AddRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.Machin
 	return nil
 }
 
+// RemoveRHELSubscriptionFinalizer removes finalizer redhatSubscriptionFinalizer to the machine object on rhel machine deletion.
 func RemoveRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.MachineUpdater) error {
 	if kuberneteshelper.HasFinalizer(machine, redhatSubscriptionFinalizer) {
 		if err := update(machine, func(m *v1alpha1.Machine) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Up until now, we never added finalizers on the machine object when RedHat Subscription Manager is enabled for machines running rhel, this PR changes that.

```release-note
None
```
