### PR TITLE
Restructure redhat subscription manager

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -216,6 +216,7 @@ presubmits:
               cpu: 500m
 
   - name: pull-machine-controller-e2e-azure
+    always_run: true
     decorate: true
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"

--- a/examples/aws-machinedeployment.yaml
+++ b/examples/aws-machinedeployment.yaml
@@ -69,5 +69,12 @@ spec:
           operatingSystem: "coreos"
           operatingSystemSpec:
             disableAutoUpdate: true
+            # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
+            # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            # 'rhsmOfflineToken' if it was provided red hat systems subscriptions will be removed upon machines deletions, and if wasn't
+            # provided the rhsm will be disabled and any created subscription won't be removed automatically
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: 1.9.6

--- a/examples/azure-machinedeployment.yaml
+++ b/examples/azure-machinedeployment.yaml
@@ -76,5 +76,12 @@ spec:
           operatingSystem: "coreos"
           operatingSystemSpec:
             distUpgradeOnBoot: false
+            # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
+            # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            # 'rhsmOfflineToken' if it was provided red hat systems subscriptions will be removed upon machines deletions, and if wasn't
+            # provided the rhsm will be disabled and any created subscription won't be removed automatically
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: 1.9.6

--- a/examples/gce-machinedeployment.yaml
+++ b/examples/gce-machinedeployment.yaml
@@ -66,5 +66,12 @@ spec:
           operatingSystem: "coreos"
           operatingSystemSpec:
             disableAutoUpdate: true
+            # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
+            # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            # 'rhsmOfflineToken' if it was provided red hat systems subscriptions will be removed upon machines deletions, and if wasn't
+            # provided the rhsm will be disabled and any created subscription won't be removed automatically
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: 1.13.5

--- a/examples/kubevirt-machinedeployment.yaml
+++ b/examples/kubevirt-machinedeployment.yaml
@@ -40,8 +40,11 @@ spec:
             distUpgradeOnBoot: false
             disableAutoUpdate: true
             # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
-            rhelSubscriptionManagerUser:
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
-            rhelSubscriptionManagerPassword:
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            # 'rhsmOfflineToken' if it was provided red hat systems subscriptions will be removed upon machines deletions, and if wasn't
+            # provided the rhsm will be disabled and any created subscription won't be removed automatically
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: "1.12.2"

--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -116,5 +116,8 @@ spec:
             rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
             rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            # 'rhsmOfflineToken' if it was provided red hat systems subscriptions will be removed upon machines deletions, and if wasn't
+            # provided the rhsm will be disabled and any created subscription won't be removed automatically
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: 1.9.6

--- a/examples/vsphere-datastore-cluster-machinedeployment.yaml
+++ b/examples/vsphere-datastore-cluster-machinedeployment.yaml
@@ -67,8 +67,11 @@ spec:
           operatingSystemSpec:
             distUpgradeOnBoot: false
             # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
-            rhelSubscriptionManagerUser:
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
-            rhelSubscriptionManagerPassword:
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            # 'rhsmOfflineToken' if it was provided red hat systems subscriptions will be removed upon machines deletions, and if wasn't
+            # provided the rhsm will be disabled and any created subscription won't be removed automatically
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: 1.9.6

--- a/examples/vsphere-machinedeployment.yaml
+++ b/examples/vsphere-machinedeployment.yaml
@@ -67,8 +67,11 @@ spec:
           operatingSystemSpec:
             distUpgradeOnBoot: false
             # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
-            rhelSubscriptionManagerUser:
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
-            rhelSubscriptionManagerPassword:
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            # 'rhsmOfflineToken' if it was provided red hat systems subscriptions will be removed upon machines deletions, and if wasn't
+            # provided the rhsm will be disabled and any created subscription won't be removed automatically
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: 1.9.6

--- a/pkg/cloudprovider/provider/aws/types/types.go
+++ b/pkg/cloudprovider/provider/aws/types/types.go
@@ -39,5 +39,4 @@ type RawConfig struct {
 	EBSVolumeEncrypted providerconfigtypes.ConfigVarBool     `json:"ebsVolumeEncrypted"`
 	Tags               map[string]string                     `json:"tags,omitempty"`
 	AssignPublicIP     *bool                                 `json:"assignPublicIP,omitempty"`
-	RHSMOfflineToken   providerconfigtypes.ConfigVarString   `json:"rhsmOfflineToken,omitempty"`
 }

--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -36,10 +36,9 @@ type RawConfig struct {
 	AvailabilitySet   providerconfigtypes.ConfigVarString `json:"availabilitySet"`
 	SecurityGroupName providerconfigtypes.ConfigVarString `json:"securityGroupName"`
 
-	ImageID          providerconfigtypes.ConfigVarString `json:"imageID"`
-	RHSMOfflineToken providerconfigtypes.ConfigVarString `json:"rhsmOfflineToken,omitempty"`
-	OSDiskSize       int32                               `json:"osDiskSize"`
-	DataDiskSize     int32                               `json:"dataDiskSize"`
-	AssignPublicIP   providerconfigtypes.ConfigVarBool   `json:"assignPublicIP"`
-	Tags             map[string]string                   `json:"tags,omitempty"`
+	ImageID        providerconfigtypes.ConfigVarString `json:"imageID"`
+	OSDiskSize     int32                               `json:"osDiskSize"`
+	DataDiskSize   int32                               `json:"dataDiskSize"`
+	AssignPublicIP providerconfigtypes.ConfigVarBool   `json:"assignPublicIP"`
+	Tags           map[string]string                   `json:"tags,omitempty"`
 }

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	gcetypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/gce/types"
-	"github.com/kubermatic/machine-controller/pkg/cloudprovider/rhsm"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 )
@@ -106,7 +105,6 @@ type config struct {
 	multizone             bool
 	regional              bool
 	customImage           string
-	manager               rhsm.RedHatSubscriptionManager
 }
 
 // newConfig creates a Provider configuration out of the passed resolver and spec.
@@ -190,13 +188,6 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 		return nil, fmt.Errorf("failed to retrieve gce custom image: %v", err)
 	}
 
-	offlineToken, _ := resolver.GetConfigVarStringValue(cpSpec.RHSMOfflineToken)
-	if offlineToken != "" {
-		cfg.manager, err = rhsm.NewRedHatSubscriptionManager(offlineToken)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create redhat subscription manager: %v", err)
-		}
-	}
 	return cfg, nil
 }
 

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -38,7 +38,6 @@ import (
 	gcetypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/gce/types"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
-	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 )
 
 // Terminal error messages.
@@ -292,11 +291,6 @@ func (p *Provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 		return false, newError(common.InvalidConfigurationMachineError, errDeleteInstance, err)
 	}
 
-	if cfg.providerConfig.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && cfg.manager != nil {
-		if err := cfg.manager.UnregisterInstance(machine.Name); err != nil {
-			return false, fmt.Errorf("failed delete machine %s subscription: %v", machine.Name, err)
-		}
-	}
 	return false, nil
 }
 

--- a/pkg/cloudprovider/provider/gce/types/types.go
+++ b/pkg/cloudprovider/provider/gce/types/types.go
@@ -42,7 +42,6 @@ type CloudProviderSpec struct {
 	AssignPublicIPAddress *providerconfigtypes.ConfigVarBool  `json:"assignPublicIPAddress,omitempty"`
 	MultiZone             providerconfigtypes.ConfigVarBool   `json:"multizone"`
 	Regional              providerconfigtypes.ConfigVarBool   `json:"regional"`
-	RHSMOfflineToken      providerconfigtypes.ConfigVarString `json:"rhsmOfflineToken,omitempty"`
 	CustomImage           providerconfigtypes.ConfigVarString `json:"customImage,omitempty"`
 }
 

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -32,7 +32,6 @@ import (
 	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
 	kubevirttypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/kubevirt/types"
-	"github.com/kubermatic/machine-controller/pkg/cloudprovider/rhsm"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -77,7 +76,6 @@ type Config struct {
 	Namespace        string
 	SourceURL        string
 	StorageClassName string
-	manager          rhsm.RedHatSubscriptionManager
 	PVCSize          resource.Quantity
 }
 
@@ -163,13 +161,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		return nil, nil, fmt.Errorf("failed to decode kubeconfig: %v", err)
 	}
 	config.Kubeconfig = *restConfig
-	offlineToken, _ := p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.RHSMOfflineToken, "REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
-	if offlineToken != "" {
-		config.manager, err = rhsm.NewRedHatSubscriptionManager(offlineToken)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create redhat subscription manager: %v", err)
-		}
-	}
+
 	return &config, &pconfig, nil
 }
 
@@ -431,7 +423,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Provi
 }
 
 func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
-	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
+	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return false, cloudprovidererrors.TerminalError{
 			Reason:  common.InvalidConfigurationMachineError,
@@ -451,12 +443,6 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.Prov
 		}
 		// VMI is gone
 		return true, nil
-	}
-
-	if pc.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && c.manager != nil {
-		if err := c.manager.UnregisterInstance(machine.Name); err != nil {
-			return false, fmt.Errorf("failed to delete machine %s subscription: %v", machine.Name, err)
-		}
 	}
 
 	return false, sigClient.Delete(ctx, vm)

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -28,5 +28,4 @@ type RawConfig struct {
 	SourceURL        providerconfigtypes.ConfigVarString `json:"sourceURL,omitempty"`
 	PVCSize          providerconfigtypes.ConfigVarString `json:"pvcSize,omitempty"`
 	StorageClassName providerconfigtypes.ConfigVarString `json:"storageClassName,omitempty"`
-	RHSMOfflineToken providerconfigtypes.ConfigVarString `json:"rhsmOfflineToken,omitempty"`
 }

--- a/pkg/cloudprovider/provider/openstack/types/types.go
+++ b/pkg/cloudprovider/provider/openstack/types/types.go
@@ -42,7 +42,6 @@ type RawConfig struct {
 	TrustDevicePath       providerconfigtypes.ConfigVarBool     `json:"trustDevicePath"`
 	RootDiskSizeGB        *int                                  `json:"rootDiskSizeGB"`
 	NodeVolumeAttachLimit *uint                                 `json:"nodeVolumeAttachLimit"`
-	RHSMOfflineToken      providerconfigtypes.ConfigVarString   `json:"rhsmOfflineToken"`
 	// This tag is related to server metadata, not compute server's tag
 	Tags map[string]string `json:"tags,omitempty"`
 }

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -35,7 +35,6 @@ import (
 	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
 	vspheretypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/types"
-	"github.com/kubermatic/machine-controller/pkg/cloudprovider/rhsm"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -72,7 +71,6 @@ type Config struct {
 	CPUs             int32
 	MemoryMB         int64
 	DiskSizeGB       *int64
-	Manager          rhsm.RedHatSubscriptionManager
 }
 
 // Ensures that Server implements Instance interface.
@@ -184,13 +182,6 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	c.CPUs = rawConfig.CPUs
 	c.MemoryMB = rawConfig.MemoryMB
 	c.DiskSizeGB = rawConfig.DiskSizeGB
-	offlineToken, _ := p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.RHSMOfflineToken, "REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
-	if offlineToken != "" {
-		c.Manager, err = rhsm.NewRedHatSubscriptionManager(offlineToken)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to create redhat subscription manager: %v", err)
-		}
-	}
 
 	return &c, &pconfig, &rawConfig, nil
 }
@@ -408,12 +399,6 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 					}
 				}
 			}
-		}
-	}
-
-	if pc.OperatingSystem == providerconfigtypes.OperatingSystemRHEL && config.Manager != nil {
-		if err := config.Manager.UnregisterInstance(machine.Name); err != nil {
-			return false, fmt.Errorf("failed to delete machine %s subscription: %v", machine.Name, err)
 		}
 	}
 

--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -35,9 +35,8 @@ type RawConfig struct {
 	DatastoreCluster providerconfigtypes.ConfigVarString `json:"datastoreCluster"`
 	Datastore        providerconfigtypes.ConfigVarString `json:"datastore"`
 
-	CPUs             int32                               `json:"cpus"`
-	MemoryMB         int64                               `json:"memoryMB"`
-	DiskSizeGB       *int64                              `json:"diskSizeGB,omitempty"`
-	AllowInsecure    providerconfigtypes.ConfigVarBool   `json:"allowInsecure"`
-	RHSMOfflineToken providerconfigtypes.ConfigVarString `json:"rhsmOfflineToken"`
+	CPUs          int32                             `json:"cpus"`
+	MemoryMB      int64                             `json:"memoryMB"`
+	DiskSizeGB    *int64                            `json:"diskSizeGB,omitempty"`
+	AllowInsecure providerconfigtypes.ConfigVarBool `json:"allowInsecure"`
 }

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -570,7 +570,12 @@ func (r *Reconciler) deleteCloudProviderInstance(prov cloudprovidertypes.Provide
 		}
 
 		if rhelConfig.RedHatSubscriptionOfflineToken != "" {
-			if err := r.redhatSubscriptionManager.UnregisterInstance(rhelConfig.RedHatSubscriptionOfflineToken, machine.Name); err != nil {
+			machineName := machine.Name
+			if machineConfig.CloudProvider == providerconfigtypes.CloudProviderAWS {
+				machineName = machine.Status.NodeRef.Name
+			}
+
+			if err := r.redhatSubscriptionManager.UnregisterInstance(rhelConfig.RedHatSubscriptionOfflineToken, machineName); err != nil {
 				return nil, fmt.Errorf("failed to delete subscribtion for machine name %s: %v", machine.Name, err)
 			}
 		}

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -576,7 +576,7 @@ func (r *Reconciler) deleteCloudProviderInstance(prov cloudprovidertypes.Provide
 			}
 
 			if err := r.redhatSubscriptionManager.UnregisterInstance(rhelConfig.RedHatSubscriptionOfflineToken, machineName); err != nil {
-				return nil, fmt.Errorf("failed to delete subscribtion for machine name %s: %v", machine.Name, err)
+				return nil, fmt.Errorf("failed to delete subscription for machine name %s: %v", machine.Name, err)
 			}
 		}
 

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -37,8 +37,10 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/node/eviction"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"github.com/kubermatic/machine-controller/pkg/rhsm"
 	userdatamanager "github.com/kubermatic/machine-controller/pkg/userdata/manager"
 	userdataplugin "github.com/kubermatic/machine-controller/pkg/userdata/plugin"
+	"github.com/kubermatic/machine-controller/pkg/userdata/rhel"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -105,6 +107,7 @@ type Reconciler struct {
 	bootstrapTokenServiceAccountName *types.NamespacedName
 	skipEvictionAfter                time.Duration
 	nodeSettings                     NodeSettings
+	redhatSubscriptionManager        rhsm.RedHatSubscriptionManager
 }
 
 type NodeSettings struct {
@@ -167,6 +170,7 @@ func Add(
 		bootstrapTokenServiceAccountName: bootstrapTokenServiceAccountName,
 		skipEvictionAfter:                skipEvictionAfter,
 		nodeSettings:                     nodeSettings,
+		redhatSubscriptionManager:        rhsm.NewRedHatSubscriptionManager(),
 	}
 	m, err := userdatamanager.New()
 	if err != nil {
@@ -554,6 +558,28 @@ func (r *Reconciler) deleteCloudProviderInstance(prov cloudprovidertypes.Provide
 		return &reconcile.Result{RequeueAfter: deletionRetryWaitPeriod}, nil
 	}
 
+	machineConfig, err := providerconfigtypes.GetConfig(machine.Spec.ProviderSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get provider config: %v", err)
+	}
+
+	if machineConfig.OperatingSystem == providerconfigtypes.OperatingSystemRHEL {
+		rhelConfig, err := rhel.LoadConfig(machineConfig.OperatingSystemSpec)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get rhel os specs: %v", err)
+		}
+
+		if rhelConfig.RedHatSubscriptionOfflineToken != "" {
+			if err := r.redhatSubscriptionManager.UnregisterInstance(rhelConfig.RedHatSubscriptionOfflineToken, machine.Name); err != nil {
+				return nil, fmt.Errorf("failed to delete subscribtion for machine name %s: %v", machine.Name, err)
+			}
+		}
+
+		if err := rhsm.RemoveRHELSubscriptionFinalizer(machine, r.updateMachine); err != nil {
+			return nil, fmt.Errorf("failed to remove redhat subscription finalizer: %v", err)
+		}
+	}
+
 	return nil, r.updateMachine(machine, func(m *clusterv1alpha1.Machine) {
 		finalizers := sets.NewString(m.Finalizers...)
 		finalizers.Delete(FinalizerDeleteInstance)
@@ -634,6 +660,11 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 			if _, err = r.createProviderInstance(prov, machine, userdata); err != nil {
 				message := fmt.Sprintf("%v. Unable to create a machine.", err)
 				return nil, r.updateMachineErrorIfTerminalError(machine, common.CreateMachineError, message, err, "failed to create machine at cloudprovider")
+			}
+			if providerConfig.OperatingSystem == providerconfigtypes.OperatingSystemRHEL {
+				if err := rhsm.AddRHELSubscriptionFinalizer(machine, r.updateMachine); err != nil {
+					return nil, fmt.Errorf("failed to add redhat subscription finalizer: %v", err)
+				}
 			}
 			r.recorder.Event(machine, corev1.EventTypeNormal, "Created", "Successfully created instance")
 			klog.V(3).Infof("Created machine %s at cloud provider", machine.Name)

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -569,13 +569,13 @@ func (r *Reconciler) deleteCloudProviderInstance(prov cloudprovidertypes.Provide
 			return nil, fmt.Errorf("failed to get rhel os specs: %v", err)
 		}
 
-		if rhelConfig.RedHatSubscriptionOfflineToken != "" {
+		if rhelConfig.RHSMOfflineToken != "" {
 			machineName := machine.Name
 			if machineConfig.CloudProvider == providerconfigtypes.CloudProviderAWS {
 				machineName = machine.Status.NodeRef.Name
 			}
 
-			if err := r.redhatSubscriptionManager.UnregisterInstance(rhelConfig.RedHatSubscriptionOfflineToken, machineName); err != nil {
+			if err := r.redhatSubscriptionManager.UnregisterInstance(rhelConfig.RHSMOfflineToken, machineName); err != nil {
 				return nil, fmt.Errorf("failed to delete subscription for machine name %s: %v", machine.Name, err)
 			}
 		}

--- a/pkg/rhsm/subscription_manager.go
+++ b/pkg/rhsm/subscription_manager.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/klog"
 )
 
-const defaultTimeout = 50 * time.Second
+const defaultTimeout = 10 * time.Second
 
 // RedHatSubscriptionManager is responsible for removing redhat subscriptions.
 type RedHatSubscriptionManager interface {
@@ -109,7 +109,7 @@ func (d *defaultRedHatSubscriptionManager) UnregisterInstance(offlineToken, mach
 			return nil
 		}
 
-		err = d.deleteSubscription(ctx, offlineToken, machineUUID)
+		err = d.deleteSubscription(ctx, machineUUID, offlineToken)
 		if err == nil {
 			klog.Infof("subscription for vm %v has been deleted successfully", machineUUID)
 			return nil

--- a/pkg/rhsm/subscription_manager.go
+++ b/pkg/rhsm/subscription_manager.go
@@ -30,12 +30,12 @@ import (
 	"k8s.io/klog"
 )
 
-const defaultTimeout = 10 * time.Second
+const defaultTimeout = 50 * time.Second
 
 // RedHatSubscriptionManager is responsible for removing redhat subscriptions.
 type RedHatSubscriptionManager interface {
 	//TODO(irozzo) add context in input to give more control to the caller
-	UnregisterInstance(machineName string) error
+	UnregisterInstance(offlineToken, machineName string) error
 }
 
 type pagination struct {
@@ -56,21 +56,16 @@ type systemsResponse struct {
 
 type defaultRedHatSubscriptionManager struct {
 	apiURL          string
-	client          *http.Client
 	requestsLimiter int
 }
 
 var errUnauthenticatedRequest = errors.New("unauthenticated")
 
-func NewRedHatSubscriptionManager(offlineToken string) (RedHatSubscriptionManager, error) {
-	if offlineToken == "" {
-		return nil, errors.New("RedHatSubscriptionManager offline token cannot be empty")
-	}
+func NewRedHatSubscriptionManager() RedHatSubscriptionManager {
 	return &defaultRedHatSubscriptionManager{
 		apiURL:          "https://api.access.redhat.com/management/v1/systems",
-		client:          newOAuthClientWithRefreshToken(offlineToken, "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"),
 		requestsLimiter: 100,
-	}, nil
+	}
 }
 
 func newOAuthClientWithRefreshToken(refreshToken string, tokenURL string) *http.Client {
@@ -95,7 +90,7 @@ func newOAuthClientWithRefreshToken(refreshToken string, tokenURL string) *http.
 	return c
 }
 
-func (d *defaultRedHatSubscriptionManager) UnregisterInstance(machineName string) error {
+func (d *defaultRedHatSubscriptionManager) UnregisterInstance(offlineToken, machineName string) error {
 	ctx := context.Background()
 
 	var (
@@ -104,7 +99,7 @@ func (d *defaultRedHatSubscriptionManager) UnregisterInstance(machineName string
 	)
 
 	for retries < maxRetries {
-		machineUUID, err := d.findSystemsProfile(ctx, machineName)
+		machineUUID, err := d.findSystemsProfile(ctx, offlineToken, machineName)
 		if err != nil {
 			return fmt.Errorf("failed to find system profile: %v", err)
 		}
@@ -114,7 +109,7 @@ func (d *defaultRedHatSubscriptionManager) UnregisterInstance(machineName string
 			return nil
 		}
 
-		err = d.deleteSubscription(ctx, machineUUID)
+		err = d.deleteSubscription(ctx, offlineToken, machineUUID)
 		if err == nil {
 			klog.Infof("subscription for vm %v has been deleted successfully", machineUUID)
 			return nil
@@ -128,10 +123,10 @@ func (d *defaultRedHatSubscriptionManager) UnregisterInstance(machineName string
 	return errors.New("failed to delete system profile after max retires number has been reached")
 }
 
-func (d *defaultRedHatSubscriptionManager) findSystemsProfile(ctx context.Context, name string) (string, error) {
+func (d *defaultRedHatSubscriptionManager) findSystemsProfile(ctx context.Context, offlineToken, name string) (string, error) {
 	var offset int
 	for {
-		systemsInfo, err := d.executeFindSystemsRequest(ctx, offset)
+		systemsInfo, err := d.executeFindSystemsRequest(ctx, offlineToken, offset)
 		if err != nil {
 			return "", fmt.Errorf("failed to retrieve systems: %v", err)
 		}
@@ -153,14 +148,15 @@ func (d *defaultRedHatSubscriptionManager) findSystemsProfile(ctx context.Contex
 	return "", nil
 }
 
-func (d *defaultRedHatSubscriptionManager) deleteSubscription(ctx context.Context, uuid string) error {
+func (d *defaultRedHatSubscriptionManager) deleteSubscription(ctx context.Context, uuid, offlineToken string) error {
+	client := newOAuthClientWithRefreshToken(offlineToken, "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token")
 	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/%s", d.apiURL, uuid), nil)
 	if err != nil {
 		return fmt.Errorf("failed to create delete system request: %v", err)
 	}
 	req.WithContext(ctx)
 
-	res, err := d.client.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("faild to delete systsem profile: %v", err)
 	}
@@ -182,14 +178,15 @@ func (d *defaultRedHatSubscriptionManager) deleteSubscription(ctx context.Contex
 	return nil
 }
 
-func (d *defaultRedHatSubscriptionManager) executeFindSystemsRequest(ctx context.Context, offset int) (*systemsResponse, error) {
+func (d *defaultRedHatSubscriptionManager) executeFindSystemsRequest(ctx context.Context, offlineToken string, offset int) (*systemsResponse, error) {
+	client := newOAuthClientWithRefreshToken(offlineToken, "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token")
 	req, err := http.NewRequest("GET", fmt.Sprintf(d.apiURL+"?limit=%v&offset=%v", d.requestsLimiter, offset), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create fetch systems request: %v", err)
 	}
 	req.WithContext(ctx)
 
-	res, err := d.client.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed executing fetch systems request: %v", err)
 	}

--- a/pkg/rhsm/subscription_manager_test.go
+++ b/pkg/rhsm/subscription_manager_test.go
@@ -40,14 +40,14 @@ func TestDefaultRedHatSubscriptionManager_UnregisterInstance(t *testing.T) {
 			name:           "execute redhat system unregister instance",
 			requestLimiter: 2,
 			offlineToken:   "test_token",
-			testingServer:  createTestingServer(false, false),
+			testingServer:  createTestingServer(false),
 			machineName:    "test-machine",
 		},
 		{
 			name:           "execute redhat system unregister instance for 5 systems",
 			requestLimiter: 2,
 			offlineToken:   "test_token",
-			testingServer:  createTestingServer(true, true),
+			testingServer:  createTestingServer(true),
 			machineName:    "test-machine-5",
 		},
 	}
@@ -57,22 +57,18 @@ func TestDefaultRedHatSubscriptionManager_UnregisterInstance(t *testing.T) {
 			defer func() {
 				tt.testingServer.Close()
 			}()
-			manager, err := NewRedHatSubscriptionManager(tt.offlineToken)
-			if err != nil {
-				t.Fatalf("failed executing test: %v", err)
-			}
+			manager := NewRedHatSubscriptionManager()
 			manager.(*defaultRedHatSubscriptionManager).apiURL = tt.testingServer.URL + apiPath
-			manager.(*defaultRedHatSubscriptionManager).client = newOAuthClientWithRefreshToken(tt.offlineToken, tt.testingServer.URL+authPath)
 			manager.(*defaultRedHatSubscriptionManager).requestsLimiter = tt.requestLimiter
 
-			if err := manager.UnregisterInstance(tt.machineName); err != nil {
+			if err := manager.UnregisterInstance(tt.offlineToken, tt.machineName); err != nil {
 				t.Fatalf("failed executing test: %v", err)
 			}
 		})
 	}
 }
 
-func createTestingServer(pagination, rounded bool) *httptest.Server {
+func createTestingServer(pagination bool) *httptest.Server {
 	var (
 		processedRequest = 1
 		result           string

--- a/pkg/rhsm/subscription_manager_test.go
+++ b/pkg/rhsm/subscription_manager_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	authPath = "/auth/"
+	authPath = "/"
 	apiPath  = "/systems"
 )
 
@@ -59,6 +59,7 @@ func TestDefaultRedHatSubscriptionManager_UnregisterInstance(t *testing.T) {
 			}()
 			manager := NewRedHatSubscriptionManager()
 			manager.(*defaultRedHatSubscriptionManager).apiURL = tt.testingServer.URL + apiPath
+			manager.(*defaultRedHatSubscriptionManager).authURL = tt.testingServer.URL
 			manager.(*defaultRedHatSubscriptionManager).requestsLimiter = tt.requestLimiter
 
 			if err := manager.UnregisterInstance(tt.offlineToken, tt.machineName); err != nil {

--- a/pkg/rhsm/util.go
+++ b/pkg/rhsm/util.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rhsm
+
+import (
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+	kuberneteshelper "github.com/kubermatic/machine-controller/pkg/kubernetes"
+)
+
+const (
+	redhatSubscriptionFinalizer = "kubermatic.io/red-hat-subscription"
+)
+
+// AddRHELSubscriptionFinalizer adds finalizer redhatSubscriptionFinalizer to the machine object on rhel machine creation.
+func AddRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.MachineUpdater) error {
+	if !kuberneteshelper.HasFinalizer(machine, redhatSubscriptionFinalizer) {
+		if err := update(machine, func(m *v1alpha1.Machine) {
+			machine.Finalizers = append(m.Finalizers, redhatSubscriptionFinalizer)
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// RemoveRHELSubscriptionFinalizer removes finalizer redhatSubscriptionFinalizer to the machine object on rhel machine deletion.
+func RemoveRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.MachineUpdater) error {
+	if kuberneteshelper.HasFinalizer(machine, redhatSubscriptionFinalizer) {
+		if err := update(machine, func(m *v1alpha1.Machine) {
+			machine.Finalizers = kuberneteshelper.RemoveFinalizer(machine.Finalizers, redhatSubscriptionFinalizer)
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/rhsm/util.go
+++ b/pkg/rhsm/util.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2019 The Machine Controller Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/userdata/rhel/rhel.go
+++ b/pkg/userdata/rhel/rhel.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog"
 )
 
 // Config contains specific configuration for RHEL.
@@ -60,11 +59,7 @@ func LoadConfig(r runtime.RawExtension) (*Config, error) {
 	}
 
 	if cfg.RedHatSubscriptionOfflineToken == "" {
-		subOfflineToken, ok := os.LookupEnv("REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
-		if !ok {
-			klog.Warning("redhat offline token is not found, rhel subscriptions won't be handled by the machine-controller")
-		}
-		cfg.RedHatSubscriptionOfflineToken = subOfflineToken
+		cfg.RedHatSubscriptionOfflineToken, _ = os.LookupEnv("REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
 	}
 
 	return cfg, nil

--- a/pkg/userdata/rhel/rhel.go
+++ b/pkg/userdata/rhel/rhel.go
@@ -18,8 +18,6 @@ package rhel
 
 import (
 	"encoding/json"
-	"fmt"
-	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -29,7 +27,7 @@ type Config struct {
 	DistUpgradeOnBoot               bool   `json:"distUpgradeOnBoot"`
 	RHELSubscriptionManagerUser     string `json:"rhelSubscriptionManagerUser,omitempty"`
 	RHELSubscriptionManagerPassword string `json:"rhelSubscriptionManagerPassword,omitempty"`
-	RedHatSubscriptionOfflineToken  string `json:"redhatSubscriptionOfflineToken,omitempty"`
+	RHSMOfflineToken                string `json:"rhsmOfflineToken,omitempty"`
 }
 
 // LoadConfig retrieves the RHEL configuration from raw data.
@@ -41,27 +39,6 @@ func LoadConfig(r runtime.RawExtension) (*Config, error) {
 	if err := json.Unmarshal(r.Raw, cfg); err != nil {
 		return nil, err
 	}
-
-	if cfg.RHELSubscriptionManagerUser == "" {
-		subUser, ok := os.LookupEnv("RHEL_SUBSCRIPTION_MANAGER_USER")
-		if !ok {
-			return nil, fmt.Errorf("RHEL_SUBSCRIPTION_MANAGER_USER env variable is not found")
-		}
-		cfg.RHELSubscriptionManagerUser = subUser
-	}
-
-	if cfg.RHELSubscriptionManagerPassword == "" {
-		subPassword, ok := os.LookupEnv("RHEL_SUBSCRIPTION_MANAGER_PASSWORD")
-		if !ok {
-			return nil, fmt.Errorf("RHEL_SUBSCRIPTION_MANAGER_PASSWORD env variable is not found")
-		}
-		cfg.RHELSubscriptionManagerPassword = subPassword
-	}
-
-	if cfg.RedHatSubscriptionOfflineToken == "" {
-		cfg.RedHatSubscriptionOfflineToken, _ = os.LookupEnv("REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
-	}
-
 	return cfg, nil
 }
 

--- a/pkg/userdata/rhel/rhel.go
+++ b/pkg/userdata/rhel/rhel.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog"
 )
 
 // Config contains specific configuration for RHEL.
@@ -29,6 +30,7 @@ type Config struct {
 	DistUpgradeOnBoot               bool   `json:"distUpgradeOnBoot"`
 	RHELSubscriptionManagerUser     string `json:"rhelSubscriptionManagerUser,omitempty"`
 	RHELSubscriptionManagerPassword string `json:"rhelSubscriptionManagerPassword,omitempty"`
+	RedHatSubscriptionOfflineToken  string `json:"redhatSubscriptionOfflineToken,omitempty"`
 }
 
 // LoadConfig retrieves the RHEL configuration from raw data.
@@ -55,6 +57,14 @@ func LoadConfig(r runtime.RawExtension) (*Config, error) {
 			return nil, fmt.Errorf("RHEL_SUBSCRIPTION_MANAGER_PASSWORD env variable is not found")
 		}
 		cfg.RHELSubscriptionManagerPassword = subPassword
+	}
+
+	if cfg.RedHatSubscriptionOfflineToken == "" {
+		subOfflineToken, ok := os.LookupEnv("REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
+		if !ok {
+			klog.Warning("redhat offline token is not found, rhel subscriptions won't be handled by the machine-controller")
+		}
+		cfg.RedHatSubscriptionOfflineToken = subOfflineToken
 	}
 
 	return cfg, nil

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -117,7 +117,7 @@ func TestOpenstackProvisioningE2E(t *testing.T) {
 		fmt.Sprintf("<< NETWORK_NAME >>=%s", osNetwork),
 	}
 
-	excludeSelector := &scenarioSelector{osName: []string{"sles", "rhel"}}
+	excludeSelector := &scenarioSelector{osName: []string{"sles"}}
 	runScenarios(t, excludeSelector, params, OSManifest, fmt.Sprintf("os-%s", *testRunIdentifier))
 }
 
@@ -151,7 +151,7 @@ func TestAWSProvisioningE2E(t *testing.T) {
 	if len(awsKeyID) == 0 || len(awsSecret) == 0 {
 		t.Fatal("unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
 	}
-	excludeSelector := &scenarioSelector{osName: []string{"sles", "rhel"}}
+	excludeSelector := &scenarioSelector{osName: []string{"sles"}}
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
 		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),
@@ -222,7 +222,7 @@ func TestAzureProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET environment variables cannot be empty")
 	}
 
-	excludeSelector := &scenarioSelector{osName: []string{"sles", "rhel"}}
+	excludeSelector := &scenarioSelector{osName: []string{"sles"}}
 	// act
 	params := []string{
 		fmt.Sprintf("<< AZURE_TENANT_ID >>=%s", azureTenantID),
@@ -246,7 +246,7 @@ func TestGCEProvisioningE2E(t *testing.T) {
 	}
 
 	// Act. GCE does not support CentOS.
-	excludeSelector := &scenarioSelector{osName: []string{"centos", "sles", "rhel"}}
+	excludeSelector := &scenarioSelector{osName: []string{"centos", "sles"}}
 	params := []string{
 		fmt.Sprintf("<< GOOGLE_SERVICE_ACCOUNT >>=%s", googleServiceAccount),
 	}
@@ -370,7 +370,7 @@ func getVSphereTestParams(t *testing.T) []string {
 func TestVsphereProvisioningE2E(t *testing.T) {
 	t.Parallel()
 
-	excludeSelector := &scenarioSelector{osName: []string{"sles", "rhel"}}
+	excludeSelector := &scenarioSelector{osName: []string{"sles"}}
 
 	params := getVSphereTestParams(t)
 	runScenarios(t, excludeSelector, params, VSPhereManifest, fmt.Sprintf("vs-%s", *testRunIdentifier))

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -147,9 +147,13 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>=%s", rhelSubscriptionManagerPassword))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", rhsmOfflineToken))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 50))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< OS_DISK_SIZE >>=%v", 0))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DATA_DISK_SIZE >>=%v", 0))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< CUSTOM-IMAGE >>=%v", "rhel-8-1-custom"))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", "ami-08c04369895785ac4"))
 	} else {
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< OS_DISK_SIZE >>=%v", 30))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DATA_DISK_SIZE >>=%v", 30))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< IMAGE_ID >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 25))

--- a/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
@@ -43,7 +43,6 @@ spec:
               "KubernetesCluster": "randomString"
             # Disabling the public IP assignment requires a private subnet with internet access.
             assignPublicIP: true
-            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           # Can be 'ubuntu', 'coreos' , 'centos' or 'sles'
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
@@ -53,5 +52,6 @@ spec:
             rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
             rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
@@ -39,7 +39,6 @@ spec:
             routeTableName: "machine-controller-e2e"
             imageID: "<< IMAGE_ID >>"
             assignPublicIP: false
-            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false
@@ -48,5 +47,6 @@ spec:
             rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
             rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
@@ -32,8 +32,8 @@ spec:
             resourceGroup: "machine-controller-e2e"
             vmSize: "Standard_F2"
             # optional disk size values in GB. If not set, the defaults for the vmSize will be used.
-            osDiskSize: 30
-            dataDiskSize: 30
+            osDiskSize: << OS_DISK_SIZE >>
+            dataDiskSize: << DATA_DISK_SIZE >>
             vnetName: "machine-controller-e2e"
             subnetName: "machine-controller-e2e"
             routeTableName: "machine-controller-e2e"

--- a/test/e2e/provisioning/testdata/machinedeployment-gce.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-gce.yaml
@@ -37,7 +37,6 @@ spec:
             labels:
                 "kubernetes_cluster": "gce-test-cluster"
             assignPublicIPAddress: true
-            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
             customImage: "<< CUSTOM-IMAGE >>"
           # Can be 'ubuntu' or 'coreos'
           operatingSystem: "<< OS_NAME >>"
@@ -48,5 +47,6 @@ spec:
             rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
             rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
@@ -34,7 +34,6 @@ spec:
             kubeconfig:
               value: '<< KUBECONFIG >>'
             namespace: kube-system
-            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false
@@ -43,5 +42,6 @@ spec:
             rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
             rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
@@ -34,7 +34,6 @@ spec:
             domainName: "<< DOMAIN_NAME >>"
             region: "<< REGION >>"
             network: "<< NETWORK_NAME >>"
-            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false
@@ -43,5 +42,6 @@ spec:
             rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
             rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -36,7 +36,6 @@ spec:
             cpus: 2
             MemoryMB: 2048
             diskSizeGB: << DISK_SIZE >>
-            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false
@@ -45,5 +44,6 @@ spec:
             rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
             rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR focuses on using RedHat Subscription Manager in the MC controller instead of the cloud providers because:
- OS specs is not cloud provider specific
- Centralizing the functionality of rhsm

**Special notes for your reviewer:**
Please do not merge even if all tests and review have passed
```release-note
None
```
