### PR TITLE
Add vSphere ResourcePool support

### DIFF
--- a/docs/vsphere.md
+++ b/docs/vsphere.md
@@ -235,6 +235,10 @@ templateVMName: ubuntu-template
 vmNetName: network1
 # Optional
 folder: folder1
+# Optional: Force VMs to be provisoned to the specified resourcePool
+# Default is to use the resourcePool of the template VM
+# example: kubeone or /DC/host/Cluster01/Resources/kubeone
+resourcePool: kubeone
 cluster: cluster1
 # either datastore or datastoreCluster have to be provided.
 datastore: datastore1
@@ -251,7 +255,7 @@ diskSizeGB: 10
 
 ### Datastore and DatastoreCluster
 
-A `Datastore` is the basic unit of storage abstraction in VSphere storage (more details [here][datastore]).
+A `Datastore` is the basic unit of storage abstraction in vSphere storage (more details [here][datastore]).
 
 A `DatastoreCluster` (sometimes referred to as StoragePod) is a logical grouping of `Datastores`, it provides some resource management capabilities (more details [here][datastore_cluster]).
 

--- a/pkg/cloudprovider/provider/vsphere/helper.go
+++ b/pkg/cloudprovider/provider/vsphere/helper.go
@@ -441,7 +441,6 @@ func resolveResourcePoolRef(ctx context.Context, config *Config, session *Sessio
 			return nil, fmt.Errorf("failed to get target resourcepool: %v", err)
 		}
 		return types.NewReference(targetResourcePool.Reference()), nil
-	} else {
-		return nil, nil
 	}
+	return nil, nil
 }

--- a/pkg/cloudprovider/provider/vsphere/helper.go
+++ b/pkg/cloudprovider/provider/vsphere/helper.go
@@ -435,28 +435,13 @@ func getDatastoreFromVM(ctx context.Context, session *Session, vmRef *object.Vir
 }
 
 func resolveResourcePoolRef(ctx context.Context, config *Config, session *Session, vm *object.VirtualMachine) (*types.ManagedObjectReference, error) {
-	var targetResourcePool *object.ResourcePool
-	var isTemplate, err = vm.IsTemplate(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get vm template property: %v", err)
-	}
 	if config.ResourcePool != "" {
-		targetResourcePool, err = session.Finder.ResourcePool(ctx, config.ResourcePool)
+		targetResourcePool, err := session.Finder.ResourcePool(ctx, config.ResourcePool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get target resourcepool: %v", err)
 		}
-	} else if isTemplate {
-		var targetCluster *object.ClusterComputeResource
-		targetCluster, err = session.Finder.ClusterComputeResource(ctx, config.Cluster)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get target cluster: %v", err)
-		}
-		targetResourcePool, err = targetCluster.ResourcePool(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get target resourcepool from cluster: %v", err)
-		}
+		return types.NewReference(targetResourcePool.Reference()), nil
 	} else {
 		return nil, nil
 	}
-	return types.NewReference(targetResourcePool.Reference()), nil
 }

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -65,6 +65,7 @@ type Config struct {
 	Datacenter       string
 	Cluster          string
 	Folder           string
+	ResourcePool     string
 	Datastore        string
 	DatastoreCluster string
 	AllowInsecure    bool
@@ -164,6 +165,11 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		return nil, nil, nil, err
 	}
 
+	c.ResourcePool, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.ResourcePool)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	c.Datastore, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Datastore)
 	if err != nil {
 		return nil, nil, nil, err
@@ -224,6 +230,12 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 
 	if _, err := p.get(ctx, config.Folder, spec, session.Finder); err == nil {
 		return fmt.Errorf("a vm %s/%s already exists", config.Folder, spec.Name)
+	}
+
+	if config.ResourcePool != "" {
+		if _, err := session.Finder.ResourcePool(ctx, config.ResourcePool); err != nil {
+			return fmt.Errorf("failed to get resourcepool %q: %v", config.ResourcePool, err)
+		}
 	}
 
 	templateVM, err := session.Finder.VirtualMachine(ctx, config.TemplateVMName)

--- a/pkg/cloudprovider/provider/vsphere/provider_test.go
+++ b/pkg/cloudprovider/provider/vsphere/provider_test.go
@@ -56,6 +56,7 @@ func (m machineSpecArgs) generateMachineSpec(user, password, url string) v1alpha
 						"datacenter": "DC0",
 						%s
 						"folder": "/",
+						"resourcePool": "/DC0/host/DC0_C0/Resources",
 						"memoryMB": 2000,
 						"password": "%s",
 						"templateVMName": "DC0_H0_VM0",

--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -30,6 +30,7 @@ type RawConfig struct {
 	Datacenter     providerconfigtypes.ConfigVarString `json:"datacenter"`
 	Cluster        providerconfigtypes.ConfigVarString `json:"cluster"`
 	Folder         providerconfigtypes.ConfigVarString `json:"folder"`
+	ResourcePool   providerconfigtypes.ConfigVarString `json:"resourcePool"`
 
 	// Either Datastore or DatastoreCluster have to be provided.
 	DatastoreCluster providerconfigtypes.ConfigVarString `json:"datastoreCluster"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for resource pools and coincidently adds [support for VM templates](#670 ) . 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #596

**Special notes for your reviewer**:
Introduces resourcePool as required field for the machinedeployments

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add vSphere ResourcePool support
```