### PR TITLE
adding azure az support

### DIFF
--- a/examples/azure-machinedeployment.yaml
+++ b/examples/azure-machinedeployment.yaml
@@ -74,6 +74,10 @@ spec:
             imageID: "myImageID"
             assignPublicIP: false
             securityGroupName: my-security-group
+            # zones is an optional field and it represents Availability Zones is a high-availability offering
+            # that protects your applications and data from datacenter failures.
+            zones:
+              - "1"
           # Can be 'ubuntu', 'coreos' ,'centos' or 'rhel'
           operatingSystem: "coreos"
           operatingSystemSpec:

--- a/pkg/cloudprovider/provider/azure/create_delete_resources.go
+++ b/pkg/cloudprovider/provider/azure/create_delete_resources.go
@@ -206,7 +206,8 @@ func createOrUpdatePublicIPAddress(ctx context.Context, ipName string, machineUI
 			PublicIPAddressVersion:   network.IPv4,
 			PublicIPAllocationMethod: network.Static,
 		},
-		Tags: map[string]*string{machineUIDTag: to.StringPtr(string(machineUID))},
+		Tags:  map[string]*string{machineUIDTag: to.StringPtr(string(machineUID))},
+		Zones: &c.Zones,
 	}
 	future, err := ipClient.CreateOrUpdate(ctx, c.ResourceGroup, ipName, ipParams)
 	if err != nil {

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -80,6 +80,7 @@ type config struct {
 	AvailabilitySet   string
 	SecurityGroupName string
 	ImageID           string
+	Zones             []string
 
 	OSDiskSize   int32
 	DataDiskSize int32
@@ -241,6 +242,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*config, *providerconfigt
 		return nil, nil, fmt.Errorf("failed to get the value of \"securityGroupName\" field, error = %v", err)
 	}
 
+	c.Zones = rawCfg.Zones
 	c.Tags = rawCfg.Tags
 	c.OSDiskSize = rawCfg.OSDiskSize
 	c.DataDiskSize = rawCfg.DataDiskSize
@@ -506,7 +508,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 			},
 			StorageProfile: storageProfile,
 		},
-		Tags: tags,
+		Tags:  tags,
+		Zones: &config.Zones,
 	}
 
 	if config.AvailabilitySet != "" {

--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -35,6 +35,7 @@ type RawConfig struct {
 	RouteTableName    providerconfigtypes.ConfigVarString `json:"routeTableName"`
 	AvailabilitySet   providerconfigtypes.ConfigVarString `json:"availabilitySet"`
 	SecurityGroupName providerconfigtypes.ConfigVarString `json:"securityGroupName"`
+	Zones             []string                            `json:"zones"`
 
 	ImageID        providerconfigtypes.ConfigVarString `json:"imageID"`
 	OSDiskSize     int32                               `json:"osDiskSize"`

--- a/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
@@ -39,6 +39,8 @@ spec:
             routeTableName: "machine-controller-e2e"
             imageID: "<< IMAGE_ID >>"
             assignPublicIP: false
+            zones:
+              - "1"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding multiple availability zones support in the machine controller for azure cloud provider.

**Which issue(s) this PR fixes** 
Fixes #

**Optional Release Note**:
```release-note
None
```
