### PR TITLE
Use addresses instead of node ref for rhel aws instances

### DIFF
--- a/pkg/cloudprovider/instance/instance.go
+++ b/pkg/cloudprovider/instance/instance.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package instance
 
+import v1 "k8s.io/api/core/v1"
+
 // Instance represents a instance on the cloud provider
 type Instance interface {
 	// Name returns the instance name.
@@ -23,7 +25,7 @@ type Instance interface {
 	// ID returns the instance identifier.
 	ID() string
 	// Addresses returns a list of addresses associated with the instance.
-	Addresses() []string
+	Addresses() map[string]v1.NodeAddressType
 	// Status returns the instance status.
 	Status() Status
 }

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -85,10 +86,10 @@ func (a *alibabaInstance) ID() string {
 	return a.instance.InstanceId
 }
 
-func (a *alibabaInstance) Addresses() []string {
-	var primaryIPAddresses []string
+func (a *alibabaInstance) Addresses() map[string]v1.NodeAddressType {
+	primaryIPAddresses := map[string]v1.NodeAddressType{}
 	for _, networkInterface := range a.instance.NetworkInterfaces.NetworkInterface {
-		primaryIPAddresses = append(primaryIPAddresses, networkInterface.PrimaryIpAddress)
+		primaryIPAddresses[networkInterface.PrimaryIpAddress] = v1.NodeInternalIP
 	}
 
 	return primaryIPAddresses

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -43,6 +43,7 @@ import (
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"github.com/kubermatic/machine-controller/pkg/userdata/convert"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -741,13 +742,17 @@ func (d *awsInstance) ID() string {
 	return aws.StringValue(d.instance.InstanceId)
 }
 
-func (d *awsInstance) Addresses() []string {
-	return []string{
-		aws.StringValue(d.instance.PublicIpAddress),
-		aws.StringValue(d.instance.PublicDnsName),
-		aws.StringValue(d.instance.PrivateIpAddress),
-		aws.StringValue(d.instance.PrivateDnsName),
+func (d *awsInstance) Addresses() map[string]v1.NodeAddressType {
+	addresses := map[string]v1.NodeAddressType{
+		aws.StringValue(d.instance.PublicIpAddress):  v1.NodeExternalIP,
+		aws.StringValue(d.instance.PublicDnsName):    v1.NodeExternalDNS,
+		aws.StringValue(d.instance.PrivateIpAddress): v1.NodeInternalIP,
+		aws.StringValue(d.instance.PrivateDnsName):   v1.NodeInternalDNS,
 	}
+
+	delete(addresses, "")
+
+	return addresses
 }
 
 func (d *awsInstance) Status() instance.Status {

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -333,7 +333,7 @@ func getNICIPAddresses(ctx context.Context, c *config, ifaceName string) (map[st
 				return nil, fmt.Errorf("failed to retrieve internal IP string for IP %q: %v", name, err)
 			}
 			for _, ip := range internalIPs {
-				ipAddresses[ip] = v1.NodeExternalIP
+				ipAddresses[ip] = v1.NodeInternalIP
 			}
 
 		}

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -38,6 +38,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -494,13 +495,21 @@ func (d *doInstance) ID() string {
 	return strconv.Itoa(d.droplet.ID)
 }
 
-func (d *doInstance) Addresses() []string {
-	var addresses []string
+func (d *doInstance) Addresses() map[string]v1.NodeAddressType {
+	addresses := map[string]v1.NodeAddressType{}
 	for _, n := range d.droplet.Networks.V4 {
-		addresses = append(addresses, n.IPAddress)
+		if n.Type == "public" {
+			addresses[n.IPAddress] = v1.NodeExternalIP
+		} else {
+			addresses[n.IPAddress] = v1.NodeInternalIP
+		}
 	}
 	for _, n := range d.droplet.Networks.V6 {
-		addresses = append(addresses, n.IPAddress)
+		if n.Type == "public" {
+			addresses[n.IPAddress] = v1.NodeExternalIP
+		} else {
+			addresses[n.IPAddress] = v1.NodeInternalIP
+		}
 	}
 	return addresses
 }

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -19,6 +19,7 @@ package fake
 import (
 	"encoding/json"
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
@@ -44,7 +45,7 @@ func (f CloudProviderInstance) Name() string {
 func (f CloudProviderInstance) ID() string {
 	return ""
 }
-func (f CloudProviderInstance) Addresses() []string {
+func (f CloudProviderInstance) Addresses() map[string]v1.NodeAddressType {
 	return nil
 }
 func (f CloudProviderInstance) Status() instance.Status {

--- a/pkg/cloudprovider/provider/gce/instance.go
+++ b/pkg/cloudprovider/provider/gce/instance.go
@@ -26,6 +26,8 @@ import (
 	"google.golang.org/api/compute/v1"
 
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
+
+	v1 "k8s.io/api/core/v1"
 )
 
 // Possible instance statuses.
@@ -56,10 +58,10 @@ func (gi *googleInstance) ID() string {
 }
 
 // Addresses implements instance.Instance.
-func (gi *googleInstance) Addresses() []string {
-	var addrs []string
+func (gi *googleInstance) Addresses() map[string]v1.NodeAddressType {
+	addrs := map[string]v1.NodeAddressType{}
 	for _, ifc := range gi.ci.NetworkInterfaces {
-		addrs = append(addrs, ifc.NetworkIP)
+		addrs[ifc.NetworkIP] = v1.NodeInternalIP
 	}
 	return addrs
 }

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 )
@@ -401,16 +402,17 @@ func (s *hetznerServer) ID() string {
 	return strconv.Itoa(s.server.ID)
 }
 
-func (s *hetznerServer) Addresses() []string {
-	var addresses []string
+func (s *hetznerServer) Addresses() map[string]v1.NodeAddressType {
+	addresses := map[string]v1.NodeAddressType{}
 	for _, fips := range s.server.PublicNet.FloatingIPs {
-		addresses = append(addresses, fips.IP.String())
+		addresses[fips.IP.String()] = v1.NodeExternalIP
 	}
 	for _, privateNetwork := range s.server.PrivateNet {
-		addresses = append(addresses, privateNetwork.IP.String())
+		addresses[privateNetwork.IP.String()] = v1.NodeInternalIP
 	}
-
-	return append(addresses, s.server.PublicNet.IPv4.IP.String(), s.server.PublicNet.IPv6.IP.String())
+	addresses[s.server.PublicNet.IPv4.IP.String()] = v1.NodeExternalIP
+	addresses[s.server.PublicNet.IPv6.IP.String()] = v1.NodeExternalIP
+	return addresses
 }
 
 func (s *hetznerServer) Status() instance.Status {

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -91,11 +91,11 @@ func (k *kubeVirtServer) ID() string {
 	return string(k.vmi.UID)
 }
 
-func (k *kubeVirtServer) Addresses() []string {
-	var addresses []string
+func (k *kubeVirtServer) Addresses() map[string]corev1.NodeAddressType {
+	addresses := map[string]corev1.NodeAddressType{}
 	for _, kvInterface := range k.vmi.Status.Interfaces {
 		if address := strings.Split(kvInterface.IP, "/")[0]; address != "" {
-			addresses = append(addresses, address)
+			addresses[address] = corev1.NodeInternalIP
 		}
 	}
 	return addresses

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -41,6 +41,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -413,12 +414,12 @@ func (d *linodeInstance) ID() string {
 	return strconv.Itoa(d.linode.ID)
 }
 
-func (d *linodeInstance) Addresses() []string {
-	var addresses []string
+func (d *linodeInstance) Addresses() map[string]v1.NodeAddressType {
+	addresses := map[string]v1.NodeAddressType{}
 	for _, n := range d.linode.IPv4 {
-		addresses = append(addresses, n.String())
+		addresses[n.String()] = v1.NodeInternalIP
 	}
-	addresses = append(addresses, d.linode.IPv6)
+	addresses[d.linode.IPv6] = v1.NodeInternalIP
 	return addresses
 }
 

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -42,6 +42,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -748,12 +749,12 @@ func (d *osInstance) ID() string {
 	return d.server.ID
 }
 
-func (d *osInstance) Addresses() []string {
-	var addresses []string
+func (d *osInstance) Addresses() map[string]v1.NodeAddressType {
+	addresses := map[string]v1.NodeAddressType{}
 	for _, networkAddresses := range d.server.Addresses {
 		for _, element := range networkAddresses.([]interface{}) {
 			address := element.(map[string]interface{})
-			addresses = append(addresses, address["addr"].(string))
+			addresses[address["addr"].(string)] = ""
 		}
 	}
 

--- a/pkg/cloudprovider/provider/packet/provider.go
+++ b/pkg/cloudprovider/provider/packet/provider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
@@ -356,11 +357,15 @@ func (s *packetDevice) ID() string {
 	return s.device.ID
 }
 
-func (s *packetDevice) Addresses() []string {
+func (s *packetDevice) Addresses() map[string]v1.NodeAddressType {
 	// returns addresses in CIDR format
-	var addresses []string
+	addresses := map[string]v1.NodeAddressType{}
 	for _, ip := range s.device.Network {
-		addresses = append(addresses, ip.Address)
+		if ip.Public {
+			addresses[ip.Address] = v1.NodeExternalIP
+			continue
+		}
+		addresses[ip.Address] = v1.NodeInternalIP
 	}
 
 	return addresses

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -82,7 +82,7 @@ type Server struct {
 	name      string
 	id        string
 	status    instance.Status
-	addresses []string
+	addresses map[string]corev1.NodeAddressType
 }
 
 func (vsphereServer Server) Name() string {
@@ -93,7 +93,7 @@ func (vsphereServer Server) ID() string {
 	return vsphereServer.id
 }
 
-func (vsphereServer Server) Addresses() []string {
+func (vsphereServer Server) Addresses() map[string]corev1.NodeAddressType {
 	return vsphereServer.addresses
 }
 
@@ -480,7 +480,7 @@ func (p *provider) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.Provi
 	}
 
 	// virtualMachine.IsToolsRunning panics when executed on a VM that is not powered on
-	addresses := []string{}
+	addresses := map[string]corev1.NodeAddressType{}
 	isGuestToolsRunning, err := virtualMachine.IsToolsRunning(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if guest utils are running: %v", err)
@@ -496,7 +496,7 @@ func (p *provider) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.Provi
 			for _, address := range nic.IpAddress {
 				// Exclude ipv6 link-local addresses and default Docker bridge
 				if !strings.HasPrefix(address, "fe80:") && !strings.HasPrefix(address, "172.17.") {
-					addresses = append(addresses, address)
+					addresses[address] = ""
 				}
 			}
 		}

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -877,7 +877,7 @@ func (r *Reconciler) getNode(instance instance.Instance, provider providerconfig
 			}
 		}
 		for _, nodeAddress := range node.Status.Addresses {
-			for instanceAddress, _ := range instance.Addresses() {
+			for instanceAddress := range instance.Addresses() {
 				if nodeAddress.Address == instanceAddress {
 					return node.DeepCopy(), true, nil
 				}

--- a/pkg/controller/machine/machine_test.go
+++ b/pkg/controller/machine/machine_test.go
@@ -48,7 +48,7 @@ func init() {
 type fakeInstance struct {
 	name      string
 	id        string
-	addresses []string
+	addresses map[string]corev1.NodeAddressType
 	status    instance.Status
 }
 
@@ -64,7 +64,7 @@ func (i *fakeInstance) Status() instance.Status {
 	return i.status
 }
 
-func (i *fakeInstance) Addresses() []string {
+func (i *fakeInstance) Addresses() map[string]corev1.NodeAddressType {
 	return i.addresses
 }
 
@@ -115,7 +115,7 @@ func TestController_GetNode(t *testing.T) {
 			resNode:  nil,
 			exists:   false,
 			err:      nil,
-			instance: &fakeInstance{id: "99", addresses: []string{"192.168.1.99"}},
+			instance: &fakeInstance{id: "99", addresses: map[string]corev1.NodeAddressType{"192.168.1.99": corev1.NodeInternalIP}},
 		},
 		{
 			name:     "node not found - no suitable node",
@@ -123,7 +123,7 @@ func TestController_GetNode(t *testing.T) {
 			resNode:  nil,
 			exists:   false,
 			err:      nil,
-			instance: &fakeInstance{id: "99", addresses: []string{"192.168.1.99"}},
+			instance: &fakeInstance{id: "99", addresses: map[string]corev1.NodeAddressType{"192.168.1.99": corev1.NodeInternalIP}},
 		},
 		{
 			name:     "node found by provider id",
@@ -131,7 +131,7 @@ func TestController_GetNode(t *testing.T) {
 			resNode:  &node1,
 			exists:   true,
 			err:      nil,
-			instance: &fakeInstance{id: "1", addresses: []string{""}},
+			instance: &fakeInstance{id: "1", addresses: map[string]corev1.NodeAddressType{"": ""}},
 		},
 		{
 			name:     "node found by internal ip",
@@ -139,7 +139,7 @@ func TestController_GetNode(t *testing.T) {
 			resNode:  &node3,
 			exists:   true,
 			err:      nil,
-			instance: &fakeInstance{id: "3", addresses: []string{"192.168.1.3"}},
+			instance: &fakeInstance{id: "3", addresses: map[string]corev1.NodeAddressType{"192.168.1.3": corev1.NodeInternalIP}},
 		},
 		{
 			name:     "node found by external ip",
@@ -147,7 +147,7 @@ func TestController_GetNode(t *testing.T) {
 			resNode:  &node3,
 			exists:   true,
 			err:      nil,
-			instance: &fakeInstance{id: "3", addresses: []string{"172.16.1.3"}},
+			instance: &fakeInstance{id: "3", addresses: map[string]corev1.NodeAddressType{"172.16.1.3": corev1.NodeInternalIP}},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Attaching the Node Address Type to the created machines, and cleanup rhel subscription based on the private dns for aws cloud provider. 

**Which issue(s) this PR fixes**
Fixes kubermatic/kubermatic#5307

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
