### PR TITLE
Add --volume-plugin-dir kubelet flag

### DIFF
--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -149,6 +149,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -149,6 +149,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -147,6 +147,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -148,6 +148,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -165,6 +165,7 @@ write_files:
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -165,6 +165,7 @@ write_files:
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -156,6 +156,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -149,6 +149,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -114,6 +114,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -114,6 +114,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -134,6 +134,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -140,6 +140,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -133,6 +133,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -140,6 +140,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -110,6 +110,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.17.0.yaml
+++ b/pkg/userdata/coreos/testdata/v1.17.0.yaml
@@ -133,6 +133,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -116,6 +116,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -117,6 +117,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -115,6 +115,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -115,6 +115,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/flatcar/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -114,6 +114,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -114,6 +114,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -134,6 +134,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -140,6 +140,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -133,6 +133,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-proxy.yaml
@@ -140,6 +140,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.15.0-vsphere.yaml
@@ -110,6 +110,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.17.0.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.17.0.yaml
@@ -133,6 +133,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -116,6 +116,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -117,6 +117,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -115,6 +115,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -115,6 +115,7 @@ systemd:
           --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
           --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
           --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -59,6 +59,7 @@ const (
 {{- if .InitialTaints }}
 --register-with-taints={{- .InitialTaints }} \
 {{- end }}
+--volume-plugin-dir=/var/lib/kubelet/volumeplugins \
 --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
 --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi`
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -31,6 +31,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
@@ -30,6 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
@@ -31,6 +31,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
@@ -31,6 +31,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --register-with-taints=key1=value1:NoSchedule,key2=value2:NoExecute \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
@@ -31,6 +31,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
@@ -30,6 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
@@ -31,6 +31,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
@@ -31,6 +31,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
@@ -30,6 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
@@ -30,6 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
@@ -31,6 +31,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
@@ -30,6 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
@@ -30,6 +30,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
@@ -29,6 +29,7 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
   --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
   --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -154,6 +154,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -154,6 +154,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -152,6 +152,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -153,6 +153,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -170,6 +170,7 @@ write_files:
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -170,6 +170,7 @@ write_files:
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -161,6 +161,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -154,6 +154,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -134,6 +134,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -133,6 +133,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -133,6 +133,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -135,6 +135,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -135,6 +135,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -135,6 +135,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.10.10.yaml
@@ -133,6 +133,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.11.3.yaml
@@ -133,6 +133,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.12.1.yaml
@@ -132,6 +132,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.9.10.yaml
@@ -133,6 +133,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -146,6 +146,7 @@ write_files:
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -146,6 +146,7 @@ write_files:
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -136,6 +136,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -236,6 +236,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -235,6 +235,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -235,6 +235,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -237,6 +237,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -237,6 +237,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -237,6 +237,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -235,6 +235,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -235,6 +235,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -234,6 +234,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -235,6 +235,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -248,6 +248,7 @@ write_files:
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -248,6 +248,7 @@ write_files:
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -238,6 +238,7 @@ write_files:
       --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
       --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
       --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
 


### PR DESCRIPTION
Default plugin dir "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
is not writable on coreos/flatcat. So we use other well known location
`/var/lib/kubelet/volumeplugins`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
always set --volume-plugin-dir=/var/lib/kubelet/volumeplugins
```
