### PR TITLE
Adding kubevirt dnsconfig

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -127,6 +127,29 @@ presubmits:
               memory: 1Gi
               cpu: 500m
 
+  - name: pull-machine-controller-e2e-kubevirt-dns-config
+    always_run: true
+    decorate: true
+    error_on_eviction: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    max_concurrency: 1
+    labels:
+      preset-kubevirt: "true"
+      preset-hetzner: "true"
+      preset-e2e-ssh: "true"
+      preset-rhel: "true"
+    spec:
+      containers:
+        - image: golang:1.13.8
+          command:
+            - "./hack/ci-e2e-test.sh"
+          args:
+            - "TestKubevirtDNSConfigProvisioningE2E"
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 500m
+
   - name: pull-machine-controller-e2e-alibaba
     optional: true
     always_run: false

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	gopkg.in/ini.v1 v1.46.0 // indirect
 	gopkg.in/resty.v1 v1.12.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.2.8
 	k8s.io/api v0.16.4
 	k8s.io/apiextensions-apiserver v0.16.4
 	k8s.io/apimachinery v0.16.4

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -73,7 +73,7 @@ func New(configVarResolver *providerconfig.ConfigVarResolver) cloudprovidertypes
 
 type Config struct {
 	Kubeconfig       rest.Config
-	DNSConfig        corev1.PodDNSConfig
+	DNSConfig        *corev1.PodDNSConfig
 	DNSPolicy        corev1.DNSPolicy
 	CPUs             string
 	Memory           string
@@ -170,19 +170,23 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	if err != nil {
 		return nil, nil, fmt.Errorf(`failed to parse "dnsPolicy" field: %v`, err)
 	}
-	config.DNSPolicy, err = dnsPolicy(dnsPolicyString)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get dns policy: %v", err)
+	if dnsPolicyString != "" {
+		config.DNSPolicy, err = dnsPolicy(dnsPolicyString)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get dns policy: %v", err)
+		}
 	}
 	dnsConfigString, err := p.configVarResolver.GetConfigVarStringValue(rawConfig.DNSConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf(`failed to get value of "dnsConfig" field: %v`, err)
 	}
-	dnsConfig := corev1.PodDNSConfig{}
-	if err := yaml.Unmarshal([]byte(dnsConfigString), &dnsConfig); err != nil {
-		return nil, nil, fmt.Errorf(`failed to unmarshal "dnsConfig" field: %v`, err)
+	if dnsConfigString != "" {
+		dnsConfig := &corev1.PodDNSConfig{}
+		if err := yaml.Unmarshal([]byte(dnsConfigString), &dnsConfig); err != nil {
+			return nil, nil, fmt.Errorf(`failed to unmarshal "dnsConfig" field: %v`, err)
+		}
+		config.DNSConfig = dnsConfig
 	}
-	config.DNSConfig = dnsConfig
 
 	return &config, &pconfig, nil
 }
@@ -263,8 +267,10 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	if _, ok := supportedOS[pc.OperatingSystem]; !ok {
 		return fmt.Errorf("invalid/not supported operating system specified %q: %v", pc.OperatingSystem, providerconfigtypes.ErrOSNotSupported)
 	}
-	if c.DNSPolicy == corev1.DNSNone && len(c.DNSConfig.Nameservers) == 0 {
-		return fmt.Errorf("dns config must be specified when dns policy is None")
+	if c.DNSPolicy == corev1.DNSNone {
+		if c.DNSConfig == nil || len(c.DNSConfig.Nameservers) == 0 {
+			return fmt.Errorf("dns config must be specified when dns policy is None")
+		}
 	}
 	// Check if we can reach the API of the target cluster
 	vmi := &kubevirtv1.VirtualMachineInstance{}
@@ -395,7 +401,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Provi
 						},
 					},
 					DNSPolicy: c.DNSPolicy,
-					DNSConfig: &c.DNSConfig,
+					DNSConfig: c.DNSConfig,
 				},
 			},
 			DataVolumeTemplates: []cdi.DataVolume{

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -506,5 +506,5 @@ func dnsPolicy(policy string) (corev1.DNSPolicy, error) {
 		return corev1.DNSNone, nil
 	}
 
-	return "", fmt.Errorf("unkown dns policy: %s", policy)
+	return "", fmt.Errorf("unknown dns policy: %s", policy)
 }

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"gopkg.in/yaml.v2"
+
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	cdi "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 
@@ -71,6 +73,8 @@ func New(configVarResolver *providerconfig.ConfigVarResolver) cloudprovidertypes
 
 type Config struct {
 	Kubeconfig       rest.Config
+	DNSConfig        corev1.PodDNSConfig
+	DNSPolicy        corev1.DNSPolicy
 	CPUs             string
 	Memory           string
 	Namespace        string
@@ -162,6 +166,24 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	}
 	config.Kubeconfig = *restConfig
 
+	dnsPolicyString, err := p.configVarResolver.GetConfigVarStringValue(rawConfig.DNSPolicy)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`failed to parse "dnsPolicy" field: %v`, err)
+	}
+	config.DNSPolicy, err = dnsPolicy(dnsPolicyString)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get dns policy: %v", err)
+	}
+	dnsConfigString, err := p.configVarResolver.GetConfigVarStringValue(rawConfig.DNSConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`failed to get value of "dnsConfig" field: %v`, err)
+	}
+	dnsConfig := corev1.PodDNSConfig{}
+	if err := yaml.Unmarshal([]byte(dnsConfigString), &dnsConfig); err != nil {
+		return nil, nil, fmt.Errorf(`failed to unmarshal "dnsConfig" field: %v`, err)
+	}
+	config.DNSConfig = dnsConfig
+
 	return &config, &pconfig, nil
 }
 
@@ -240,6 +262,9 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	}
 	if _, ok := supportedOS[pc.OperatingSystem]; !ok {
 		return fmt.Errorf("invalid/not supported operating system specified %q: %v", pc.OperatingSystem, providerconfigtypes.ErrOSNotSupported)
+	}
+	if c.DNSPolicy == corev1.DNSNone && len(c.DNSConfig.Nameservers) == 0 {
+		return fmt.Errorf("dns config must be specified when dns policy is None")
 	}
 	// Check if we can reach the API of the target cluster
 	vmi := &kubevirtv1.VirtualMachineInstance{}
@@ -369,6 +394,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Provi
 							},
 						},
 					},
+					DNSPolicy: c.DNSPolicy,
+					DNSConfig: &c.DNSConfig,
 				},
 			},
 			DataVolumeTemplates: []cdi.DataVolume{
@@ -465,4 +492,19 @@ func parseResources(cpus, memory string) (*corev1.ResourceList, error) {
 
 func (p *provider) SetMetricsForMachines(machines v1alpha1.MachineList) error {
 	return nil
+}
+
+func dnsPolicy(policy string) (corev1.DNSPolicy, error) {
+	switch policy {
+	case string(corev1.DNSClusterFirstWithHostNet):
+		return corev1.DNSClusterFirstWithHostNet, nil
+	case string(corev1.DNSClusterFirst):
+		return corev1.DNSClusterFirst, nil
+	case string(corev1.DNSDefault):
+		return corev1.DNSDefault, nil
+	case string(corev1.DNSNone):
+		return corev1.DNSNone, nil
+	}
+
+	return "", fmt.Errorf("unkown dns policy: %s", policy)
 }

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -28,4 +28,6 @@ type RawConfig struct {
 	SourceURL        providerconfigtypes.ConfigVarString `json:"sourceURL,omitempty"`
 	PVCSize          providerconfigtypes.ConfigVarString `json:"pvcSize,omitempty"`
 	StorageClassName providerconfigtypes.ConfigVarString `json:"storageClassName,omitempty"`
+	DNSPolicy        providerconfigtypes.ConfigVarString `json:"dnsPolicy,omitempty"`
+	DNSConfig        providerconfigtypes.ConfigVarString `json:"dnsConfig,omitempty"`
 }

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -95,10 +95,9 @@ type DNSConfig struct {
 
 // NetworkConfig contains a machine's static network configuration
 type NetworkConfig struct {
-	CIDR      string    `json:"cidr"`
-	Gateway   string    `json:"gateway"`
-	DNS       DNSConfig `json:"dns"`
-	DNSPolicy string    `json:"dnsPolicy"`
+	CIDR    string    `json:"cidr"`
+	Gateway string    `json:"gateway"`
+	DNS     DNSConfig `json:"dns"`
 }
 
 type Config struct {

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -95,9 +95,10 @@ type DNSConfig struct {
 
 // NetworkConfig contains a machine's static network configuration
 type NetworkConfig struct {
-	CIDR    string    `json:"cidr"`
-	Gateway string    `json:"gateway"`
-	DNS     DNSConfig `json:"dns"`
+	CIDR      string    `json:"cidr"`
+	Gateway   string    `json:"gateway"`
+	DNS       DNSConfig `json:"dns"`
+	DNSPolicy string    `json:"dnsPolicy"`
 }
 
 type Config struct {

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -52,6 +52,7 @@ const (
 	OSUpgradeManifest           = "./testdata/machinedeployment-openstack-upgrade.yml"
 	invalidMachineManifest      = "./testdata/machine-invalid.yaml"
 	kubevirtManifest            = "./testdata/machinedeployment-kubevirt.yaml"
+	kubevirtManifestDNSConfig   = "./testdata/machinedeployment-kubevirt-dns-config.yaml"
 	alibabaManifest             = "./testdata/machinedeployment-alibaba.yaml"
 )
 
@@ -90,6 +91,30 @@ func TestKubevirtProvisioningE2E(t *testing.T) {
 	}
 
 	runScenarios(t, selector, params, kubevirtManifest, fmt.Sprintf("kubevirt-%s", *testRunIdentifier))
+}
+
+func TestKubevirtDNSConfigProvisioningE2E(t *testing.T) {
+	t.Parallel()
+
+	kubevirtKubeconfig := os.Getenv("KUBEVIRT_E2E_TESTS_KUBECONFIG")
+
+	if kubevirtKubeconfig == "" {
+		t.Fatalf("Unable to run kubevirt tests, KUBEVIRT_E2E_TESTS_KUBECONFIG must be set")
+	}
+
+	params := []string{
+		fmt.Sprintf("<< KUBECONFIG >>=%s", kubevirtKubeconfig),
+	}
+
+	scenario := scenario{
+		name:              "Kubevirt with dns config",
+		osName:            "ubuntu",
+		containerRuntime:  "docker",
+		kubernetesVersion: "v1.17.0",
+		executor:          verifyCreateAndDelete,
+	}
+
+	testScenario(t, scenario, *testRunIdentifier, params, kubevirtManifestDNSConfig, false)
 }
 
 func TestOpenstackProvisioningE2E(t *testing.T) {
@@ -199,7 +224,7 @@ func TestAWSProvisioningE2EWithEbsEncryptionEnabled(t *testing.T) {
 	}
 
 	scenario := scenario{
-		name:              "Ubuntu",
+		name:              "AWS with ebs encryption enabled",
 		osName:            "ubuntu",
 		containerRuntime:  "docker",
 		kubernetesVersion: "v1.15.6",

--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt-dns-config.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt-dns-config.yaml
@@ -1,0 +1,52 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: << MACHINE_NAME >>
+  namespace: kube-system
+spec:
+  paused: false
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  minReadySeconds: 0
+  selector:
+    matchLabels:
+      name: << MACHINE_NAME >>
+  template:
+    metadata:
+      labels:
+        name: << MACHINE_NAME >>
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProvider: "kubevirt"
+          cloudProviderSpec:
+            storageClassName: kubermatic-fast
+            pvcSize: "10Gi"
+            sourceURL: http://10.109.79.210/<< OS_NAME >>.img
+            cpus: "1"
+            memory: "4096M"
+            dnsPolicy: "None"
+            dnsConfig:
+              value: |
+                nameservers:
+                - 8.8.8.8
+            kubeconfig:
+              value: '<< KUBECONFIG >>'
+            namespace: kube-system
+          operatingSystem: "<< OS_NAME >>"
+          operatingSystemSpec:
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+            # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
+            # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
+      versions:
+        kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Support `DNSConfig` propagation from the `MachineDeployment` to the Kubevirt `VM`.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
None
```
