### PR TITLE
Drop some optional packages from installing

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -190,7 +190,6 @@ write_files:
     yum install -y docker-ce-18.09.9-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -75,7 +75,6 @@ write_files:
     yum install -y docker-ce-18.09.9-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -75,7 +75,6 @@ write_files:
     yum install -y docker-ce-18.09.9-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -75,7 +75,6 @@ write_files:
     yum install -y docker-ce-18.09.9-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -75,7 +75,6 @@ write_files:
     yum install -y docker-ce-18.09.9-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -87,7 +87,6 @@ write_files:
     yum install -y docker-ce-18.09.9-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -87,7 +87,6 @@ write_files:
     yum install -y docker-ce-18.09.9-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -79,7 +79,6 @@ write_files:
     yum install -y docker-ce-18.09.9-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -75,7 +75,6 @@ write_files:
     yum install -y docker-ce-18.09.9-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -195,7 +195,6 @@ write_files:
     yum install -y docker-ce-18.09.1-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -80,7 +80,6 @@ write_files:
     yum install -y docker-ce-18.09.1-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -80,7 +80,6 @@ write_files:
     yum install -y docker-ce-18.09.1-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -80,7 +80,6 @@ write_files:
     yum install -y docker-ce-18.09.1-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -80,7 +80,6 @@ write_files:
     yum install -y docker-ce-18.09.1-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -92,7 +92,6 @@ write_files:
     yum install -y docker-ce-18.09.1-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -92,7 +92,6 @@ write_files:
     yum install -y docker-ce-18.09.1-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -84,7 +84,6 @@ write_files:
     yum install -y docker-ce-18.09.1-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -80,7 +80,6 @@ write_files:
     yum install -y docker-ce-18.09.1-3.el7 \
       ebtables \
       ethtool \
-      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -159,8 +159,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -58,8 +58,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.10.10.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.11.3.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.12.1.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.9.10.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -65,8 +65,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -65,8 +65,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install ebtables \
-      ceph-common \
+    zypper --non-interactive --quiet --color install \
+      ebtables \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -246,18 +246,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -144,18 +144,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -151,18 +151,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -151,18 +151,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -142,18 +142,14 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
-      ceph-common \
-      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
-      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
-      nfs-common \
       socat \
       util-linux \
       ${CR_PKG} \


### PR DESCRIPTION
**What this PR does / why we need it**:
Some packages seems very redundant, others are even dangerous (nfs for example).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Don't install ceph-common cifs-utils glusterfs-client nfs-common/nfs-utils packages
```
