### PR TITLE
add datastore-cluster to GlobalOpts

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -77,6 +77,7 @@ type GlobalOpts struct {
 	WorkingDir       string `gcfg:"working-dir"`
 	Datacenter       string `gcfg:"datacenter"`
 	DefaultDatastore string `gcfg:"datastore"`
+	DatastoreCluster string `gcfg:"datastore-cluster"`
 	VCenterIP        string `gcfg:"server"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce the datastore cluster to the global opts  

```release-note
None
```
