### PR TITLE
Deprecated kubelet flags

### DIFF
--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -145,12 +145,10 @@ write_files:
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -205,6 +203,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -214,6 +216,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -145,12 +145,10 @@ write_files:
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -205,6 +203,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -214,6 +216,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -143,12 +143,10 @@ write_files:
       --cni-bin-dir=/opt/cni/bin \
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=external \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -203,6 +201,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -212,6 +214,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -144,12 +144,10 @@ write_files:
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -204,6 +202,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -213,6 +215,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -160,13 +160,11 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -221,6 +219,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -230,6 +232,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -160,13 +160,11 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -221,6 +219,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -230,6 +232,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -152,12 +152,10 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -212,6 +210,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -221,6 +223,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -145,12 +145,10 @@ write_files:
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -205,6 +203,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -214,6 +216,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -111,12 +111,10 @@ systemd:
           --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -174,6 +172,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -183,6 +185,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -111,12 +111,10 @@ systemd:
           --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -176,6 +174,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -185,6 +187,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -131,12 +131,10 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -194,6 +192,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -203,6 +205,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -136,13 +136,11 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -211,6 +209,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -220,6 +222,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -130,12 +130,10 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -193,6 +191,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -202,6 +204,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -136,13 +136,11 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -211,6 +209,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -220,6 +222,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -107,12 +107,10 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -170,6 +168,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -179,6 +181,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.17.0.yaml
+++ b/pkg/userdata/coreos/testdata/v1.17.0.yaml
@@ -130,12 +130,10 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -193,6 +191,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -202,6 +204,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -113,12 +113,10 @@ systemd:
           --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
           --cloud-provider=external \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -176,6 +174,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -185,6 +187,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -114,12 +114,10 @@ systemd:
           --cert-dir=/etc/kubernetes/pki \
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -177,6 +175,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -186,6 +188,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -112,12 +112,10 @@ systemd:
           --cert-dir=/etc/kubernetes/pki \
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -175,6 +173,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -184,6 +186,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -112,12 +112,10 @@ systemd:
           --cert-dir=/etc/kubernetes/pki \
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -175,6 +173,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -184,6 +186,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/flatcar/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -111,12 +111,10 @@ systemd:
           --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -174,6 +172,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -183,6 +185,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -111,12 +111,10 @@ systemd:
           --cloud-provider=openstack \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -176,6 +174,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -185,6 +187,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -131,12 +131,10 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -194,6 +192,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -203,6 +205,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -136,13 +136,11 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -211,6 +209,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -220,6 +222,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -130,12 +130,10 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -193,6 +191,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -202,6 +204,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-proxy.yaml
@@ -136,13 +136,11 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -211,6 +209,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -220,6 +222,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.15.0-vsphere.yaml
@@ -107,12 +107,10 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -170,6 +168,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -179,6 +181,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.17.0.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.17.0.yaml
@@ -130,12 +130,10 @@ systemd:
           --cloud-provider=vsphere \
           --cloud-config=/etc/kubernetes/cloud-config \
           --hostname-override=node1 \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -193,6 +191,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -202,6 +204,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -113,12 +113,10 @@ systemd:
           --cadvisor-port=0 \
           --cert-dir=/etc/kubernetes/pki \
           --cloud-provider=external \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -176,6 +174,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -185,6 +187,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -114,12 +114,10 @@ systemd:
           --cert-dir=/etc/kubernetes/pki \
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -177,6 +175,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -186,6 +188,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -112,12 +112,10 @@ systemd:
           --cert-dir=/etc/kubernetes/pki \
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -175,6 +173,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -184,6 +186,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -112,12 +112,10 @@ systemd:
           --cert-dir=/etc/kubernetes/pki \
           --cloud-provider=aws \
           --cloud-config=/etc/kubernetes/cloud-config \
-          --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+          --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
-          --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-          --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-          --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+          --volume-plugin-dir=/var/lib/kubelet/volumeplugins
         ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
         Restart=always
         RestartSec=10
@@ -175,6 +173,10 @@ storage:
           httpCheckFrequency: 0s
           imageMinimumGCAge: 0s
           kind: KubeletConfiguration
+          kubeReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           nodeStatusReportFrequency: 0s
           nodeStatusUpdateFrequency: 0s
           protectKernelDefaults: true
@@ -184,6 +186,10 @@ storage:
           staticPodPath: /etc/kubernetes/manifests
           streamingConnectionIdleTimeout: 0s
           syncFrequency: 0s
+          systemReserved:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 100Mi
           volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -50,7 +50,7 @@ const (
 {{- if and (.Hostname) (ne .CloudProvider "aws") }}
 --hostname-override={{ .Hostname }} \
 {{- end }}
---dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+--dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
 --exit-on-lock-contention \
 --lock-file=/tmp/kubelet.lock \
 {{- if .PauseImage }}
@@ -59,9 +59,7 @@ const (
 {{- if .InitialTaints }}
 --register-with-taints={{- .InitialTaints }} \
 {{- end }}
---volume-plugin-dir=/var/lib/kubelet/volumeplugins \
---kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
---system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi`
+--volume-plugin-dir=/var/lib/kubelet/volumeplugins`
 
 	kubeletSystemdUnitTpl = `[Unit]
 After=docker.service
@@ -146,7 +144,7 @@ func kubeletConfiguration(clusterDomain string, clusterDNS []net.IP) (string, er
 	cfg := kubeletv1b1.KubeletConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KubeletConfiguration",
-			APIVersion: "kubelet.config.k8s.io/v1beta1",
+			APIVersion: kubeletv1b1.SchemeGroupVersion.String(),
 		},
 		Authentication: kubeletv1b1.KubeletAuthentication{
 			X509: kubeletv1b1.KubeletX509Authentication{
@@ -171,6 +169,8 @@ func kubeletConfiguration(clusterDomain string, clusterDNS []net.IP) (string, er
 		RotateCertificates:    true,
 		ServerTLSBootstrap:    true,
 		StaticPodPath:         "/etc/kubernetes/manifests",
+		KubeReserved:          map[string]string{"cpu": "100m", "memory": "100Mi", "ephemeral-storage": "1Gi"},
+		SystemReserved:        map[string]string{"cpu": "100m", "memory": "100Mi", "ephemeral-storage": "1Gi"},
 	}
 
 	buf, err := kyaml.Marshal(cfg)

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_cloud-provider-set.golden
@@ -28,12 +28,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cert-dir=/etc/kubernetes/pki \
   --cloud-provider=aws \
   --cloud-config=/etc/kubernetes/cloud-config \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_multiple-dns-servers.golden
@@ -27,12 +27,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cadvisor-port=0 \
   --cert-dir=/etc/kubernetes/pki \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_pause-image-set.golden
@@ -27,13 +27,11 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cert-dir=/etc/kubernetes/pki \
   --cloud-provider=aws \
   --cloud-config=/etc/kubernetes/cloud-config \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_taints-set.golden
@@ -27,13 +27,11 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cert-dir=/etc/kubernetes/pki \
   --cloud-provider=aws \
   --cloud-config=/etc/kubernetes/cloud-config \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
   --register-with-taints=key1=value1:NoSchedule,key2=value2:NoExecute \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0-external.golden
@@ -28,12 +28,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cert-dir=/etc/kubernetes/pki \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.10.0.golden
@@ -27,12 +27,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cadvisor-port=0 \
   --cert-dir=/etc/kubernetes/pki \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-external.golden
@@ -28,12 +28,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cert-dir=/etc/kubernetes/pki \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2-external.golden
@@ -28,12 +28,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cert-dir=/etc/kubernetes/pki \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0-rc.2.golden
@@ -27,12 +27,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cadvisor-port=0 \
   --cert-dir=/etc/kubernetes/pki \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.0.golden
@@ -27,12 +27,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cadvisor-port=0 \
   --cert-dir=/etc/kubernetes/pki \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3-external.golden
@@ -28,12 +28,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cert-dir=/etc/kubernetes/pki \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.11.3.golden
@@ -27,12 +27,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cadvisor-port=0 \
   --cert-dir=/etc/kubernetes/pki \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0-external.golden
@@ -27,12 +27,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cert-dir=/etc/kubernetes/pki \
   --cloud-provider=external \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/kublet_systemd_unit_version-v1.12.0.golden
@@ -26,12 +26,10 @@ ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
   --cni-bin-dir=/opt/cni/bin \
   --cert-dir=/etc/kubernetes/pki \
   --hostname-override=some-test-node \
-  --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+  --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
   --exit-on-lock-contention \
   --lock-file=/tmp/kubelet.lock \
-  --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-  --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-  --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+  --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -150,12 +150,10 @@ write_files:
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -210,6 +208,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -219,6 +221,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -150,12 +150,10 @@ write_files:
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -210,6 +208,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -219,6 +221,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -148,12 +148,10 @@ write_files:
       --cni-bin-dir=/opt/cni/bin \
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=external \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -208,6 +206,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -217,6 +219,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -149,12 +149,10 @@ write_files:
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -209,6 +207,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -218,6 +220,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -165,13 +165,11 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -226,6 +224,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -235,6 +237,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -165,13 +165,11 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -226,6 +224,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -235,6 +237,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -157,12 +157,10 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -217,6 +215,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -226,6 +228,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -150,12 +150,10 @@ write_files:
       --cert-dir=/etc/kubernetes/pki \
       --cloud-provider=aws \
       --cloud-config=/etc/kubernetes/cloud-config \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -210,6 +208,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -219,6 +221,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -131,12 +131,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -243,6 +241,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -252,6 +254,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -130,12 +130,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -242,6 +240,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -251,6 +253,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -130,12 +130,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -244,6 +242,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -253,6 +255,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -132,12 +132,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -244,6 +242,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -253,6 +255,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -132,12 +132,10 @@ write_files:
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -246,6 +244,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -255,6 +257,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -132,12 +132,10 @@ write_files:
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -246,6 +244,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -255,6 +257,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.10.10.yaml
@@ -130,12 +130,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -242,6 +240,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -251,6 +253,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.11.3.yaml
@@ -130,12 +130,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -242,6 +240,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -251,6 +253,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.12.1.yaml
@@ -129,12 +129,10 @@ write_files:
       --cni-bin-dir=/opt/cni/bin \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -241,6 +239,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -250,6 +252,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.9.10.yaml
@@ -130,12 +130,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -242,6 +240,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -251,6 +253,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -142,13 +142,11 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -257,6 +255,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -266,6 +268,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -142,13 +142,11 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -257,6 +255,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -266,6 +268,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -133,12 +133,10 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -247,6 +245,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -256,6 +258,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -229,12 +229,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -346,6 +344,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -355,6 +357,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -228,12 +228,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -345,6 +343,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -354,6 +356,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -228,12 +228,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -347,6 +345,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -356,6 +358,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -230,12 +230,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -347,6 +345,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -356,6 +358,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -230,12 +230,10 @@ write_files:
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -349,6 +347,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -358,6 +360,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -230,12 +230,10 @@ write_files:
       --cloud-provider=openstack \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -349,6 +347,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -358,6 +360,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -228,12 +228,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -345,6 +343,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -354,6 +356,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -228,12 +228,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -345,6 +343,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -354,6 +356,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -227,12 +227,10 @@ write_files:
       --cni-bin-dir=/opt/cni/bin \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -344,6 +342,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -353,6 +355,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -228,12 +228,10 @@ write_files:
       --cadvisor-port=0 \
       --cert-dir=/etc/kubernetes/pki \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -345,6 +343,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -354,6 +356,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -240,13 +240,11 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -360,6 +358,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -369,6 +371,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -240,13 +240,11 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -360,6 +358,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -369,6 +371,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -231,12 +231,10 @@ write_files:
       --cloud-provider=vsphere \
       --cloud-config=/etc/kubernetes/cloud-config \
       --hostname-override=node1 \
-      --dynamic-config-dir /etc/kubernetes/dynamic-config-dir \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
-      --volume-plugin-dir=/var/lib/kubelet/volumeplugins \
-      --kube-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi \
-      --system-reserved=cpu=100m,memory=100Mi,ephemeral-storage=1Gi
+      --volume-plugin-dir=/var/lib/kubelet/volumeplugins
 
     [Install]
     WantedBy=multi-user.target
@@ -350,6 +348,10 @@ write_files:
     httpCheckFrequency: 0s
     imageMinimumGCAge: 0s
     kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
     protectKernelDefaults: true
@@ -359,6 +361,10 @@ write_files:
     staticPodPath: /etc/kubernetes/manifests
     streamingConnectionIdleTimeout: 0s
     syncFrequency: 0s
+    systemReserved:
+      cpu: 100m
+      ephemeral-storage: 1Gi
+      memory: 100Mi
     volumeStatsAggPeriod: 0s
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Deprecated kubelet flags moved to kubeconfig

```release-note
NONE
```
