### PR TITLE
Bind docker-ce-cli to the same version as docker-ce

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -188,6 +188,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.9-3.el7 \
+      docker-ce-cli-18.09.9-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -73,6 +73,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.9-3.el7 \
+      docker-ce-cli-18.09.9-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -73,6 +73,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.9-3.el7 \
+      docker-ce-cli-18.09.9-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -73,6 +73,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.9-3.el7 \
+      docker-ce-cli-18.09.9-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -73,6 +73,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.9-3.el7 \
+      docker-ce-cli-18.09.9-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -85,6 +85,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.9-3.el7 \
+      docker-ce-cli-18.09.9-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -85,6 +85,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.9-3.el7 \
+      docker-ce-cli-18.09.9-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -77,6 +77,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.9-3.el7 \
+      docker-ce-cli-18.09.9-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -73,6 +73,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.9-3.el7 \
+      docker-ce-cli-18.09.9-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -193,6 +193,7 @@ write_files:
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -78,6 +78,7 @@ write_files:
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -78,6 +78,7 @@ write_files:
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -78,6 +78,7 @@ write_files:
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -78,6 +78,7 @@ write_files:
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -90,6 +90,7 @@ write_files:
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -90,6 +90,7 @@ write_files:
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -82,6 +82,7 @@ write_files:
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -78,6 +78,7 @@ write_files:
     yum config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       bash-completion \

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -247,6 +247,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -263,6 +264,7 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       {{- if eq .CloudProviderName "vsphere" }}
       open-vm-tools \
       {{- end }}
@@ -271,6 +273,7 @@ write_files:
 {{- /* If something failed during package installation but docker got installed, we need to put it on hold */}}
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -140,6 +140,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -156,9 +157,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -154,9 +155,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -154,9 +155,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -140,6 +140,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -156,9 +157,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -154,9 +155,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -154,9 +155,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -154,9 +155,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -154,9 +155,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -154,9 +155,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -154,9 +155,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -147,6 +147,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -163,10 +164,12 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       open-vm-tools \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -147,6 +147,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -163,10 +164,12 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       open-vm-tools \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.9~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.9~3-0~ubuntu-bionic'
     export DEBIAN_FRONTEND=noninteractive
 
     apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
@@ -154,10 +155,12 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       open-vm-tools \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR binds the `docker-ce-cli` package to the same version as the `docker-ce` package for Ubuntu, CentOS, and RHEL. As far as I know, there's nothing to do for CentOS/Flatcar and SLES. This is supposed to fix the incompatibilities between CLI and daemon.

Before this fix, the health-monitor script was logging the following error:

```
health-monitor.sh[23271]: Error response from daemon: client version 1.40 is too new. Maximum supported API version is 1.39
```

Relevant: https://github.com/kubermatic/kubeone/pull/896

**Optional Release Note**:
```release-note
Bind docker-ce-cli to the same version as docker-ce
```

/assign @kron4eg 