### PR TITLE
Unify the way kubelet works on Flatcar/CoreOS with other OS

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -163,10 +163,15 @@ func main() {
 	flag.StringVar(&nodeInsecureRegistries, "node-insecure-registries", "", "Comma separated list of registries which should be configured as insecure on the container runtime")
 	flag.StringVar(&nodeRegistryMirrors, "node-registry-mirrors", "", "Comma separated list of Docker image mirrors")
 	flag.StringVar(&nodePauseImage, "node-pause-image", "", "Image for the pause container including tag. If not set, the kubelet default will be used: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/")
-	flag.String("node-hyperkube-image", "k8s.gcr.io/hyperkube-amd64", "Image for the hyperkube container excluding tag. (DEPRECATED, NOOP)")
+	flag.String("node-hyperkube-image", "", "Image for the hyperkube container excluding tag. (DEPRECATED, NOOP)")
 	flag.BoolVar(&nodeCSRApprover, "node-csr-approver", false, "Enable NodeCSRApprover controller to automatically approve node serving certificate requests.")
 
 	flag.Parse()
+
+	if fv := flag.Lookup("node-hyperkube-image"); fv.DefValue != fv.Value.String() {
+		klog.Warning("-node-hyperkube-image flag IS DEPRECATED and has no EFFECT ANYMORE")
+	}
+
 	kubeconfig = flag.Lookup("kubeconfig").Value.(flag.Getter).Get().(string)
 	masterURL = flag.Lookup("master").Value.(flag.Getter).Get().(string)
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/digitalocean/godo v1.1.3
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
-	github.com/docker/distribution v2.7.1+incompatible
 	github.com/emicklei/go-restful v2.11.2+incompatible // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
@@ -44,7 +43,6 @@ require (
 	github.com/mailru/easyjson v0.7.1 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a
 	github.com/oklog/run v1.0.0
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/packethost/packngo v0.1.1-0.20190410075950-a02c426e4888
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pborman/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,6 @@ github.com/dimchansky/utfbom v1.1.0 h1:FcM3g+nofKgUteL8dm/UpdRXNC9KmADgTpLKsu0TR
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
-github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
-github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
@@ -368,8 +366,6 @@ github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
-github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/openshift/api v0.0.0-20191219222812-2987a591a72c/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/custom-resource-status v0.0.0-20190822192428-e62f2f3b79f3 h1:XuAys09+XqT5/FjdR23G/UtbBLII89dFe9XIi73EKIQ=

--- a/pkg/apis/plugin/plugin.go
+++ b/pkg/apis/plugin/plugin.go
@@ -51,7 +51,6 @@ type UserDataRequest struct {
 	InsecureRegistries    []string
 	RegistryMirrors       []string
 	PauseImage            string
-	HyperkubeImage        string
 }
 
 // UserDataResponse contains the responded user data.

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -123,8 +123,6 @@ type NodeSettings struct {
 	RegistryMirrors []string
 	// Translates to --pod-infra-container-image on the kubelet. If not set, the kubelet will default it.
 	PauseImage string
-	// The hyperkube image to use. Currently only Container Linux uses it.
-	HyperkubeImage string
 }
 
 type KubeconfigProvider interface {
@@ -656,7 +654,6 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 				InsecureRegistries:    r.nodeSettings.InsecureRegistries,
 				RegistryMirrors:       r.nodeSettings.RegistryMirrors,
 				PauseImage:            r.nodeSettings.PauseImage,
-				HyperkubeImage:        r.nodeSettings.HyperkubeImage,
 				NoProxy:               r.nodeSettings.NoProxy,
 				HTTPProxy:             r.nodeSettings.HTTPProxy,
 			}

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -23,7 +23,6 @@ package coreos
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"text/template"
 
 	"github.com/Masterminds/semver"
@@ -38,7 +37,6 @@ type Provider struct{}
 
 // UserData renders user-data template to string.
 func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
-
 	tmpl, err := template.New("user-data").Funcs(userdatahelper.TxtFuncMap()).Parse(userDataTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse user-data template: %v", err)
@@ -73,14 +71,6 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
-	// We need to reconfigure rkt to allow insecure registries in case the hyperkube image comes from an insecure registry
-	var insecureHyperkubeImage bool
-	for _, registry := range req.InsecureRegistries {
-		if strings.Contains(req.HyperkubeImage, registry) {
-			insecureHyperkubeImage = true
-		}
-	}
-
 	if coreosConfig.DisableAutoUpdate {
 		coreosConfig.DisableLocksmithD = true
 		coreosConfig.DisableUpdateEngine = true
@@ -88,20 +78,18 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec           *providerconfigtypes.Config
-		CoreOSConfig           *Config
-		Kubeconfig             string
-		KubernetesCACert       string
-		KubeletVersion         string
-		InsecureHyperkubeImage bool
+		ProviderSpec     *providerconfigtypes.Config
+		CoreOSConfig     *Config
+		Kubeconfig       string
+		KubernetesCACert string
+		KubeletVersion   string
 	}{
-		UserDataRequest:        req,
-		ProviderSpec:           pconfig,
-		CoreOSConfig:           coreosConfig,
-		Kubeconfig:             kubeconfigString,
-		KubernetesCACert:       kubernetesCACert,
-		KubeletVersion:         kubeletVersion.String(),
-		InsecureHyperkubeImage: insecureHyperkubeImage,
+		UserDataRequest:  req,
+		ProviderSpec:     pconfig,
+		CoreOSConfig:     coreosConfig,
+		Kubeconfig:       kubeconfigString,
+		KubernetesCACert: kubernetesCACert,
+		KubeletVersion:   kubeletVersion.String(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -162,7 +162,7 @@ systemd:
             Environment=ALL_PROXY={{ .HTTPProxy }}
 {{- end }}
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -181,8 +181,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
 {{ containerRuntimeHealthCheckSystemdUnit | indent 10 }}
 
@@ -192,58 +192,15 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
 {{ kubeletHealthCheckSystemdUnit | indent 10 }}
 
     - name: kubelet.service
       enabled: true
       contents: |
-        [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
-        After=docker.service
-        [Service]
-        TimeoutStartSec=5min
-        CPUAccounting=true
-        MemoryAccounting=true
-        EnvironmentFile=-/etc/environment
-{{- if .HTTPProxy }}
-        Environment=KUBELET_IMAGE=docker://{{ .HyperkubeImage }}:v{{ .KubeletVersion }}
-{{- else }}
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v{{ .KubeletVersion }}
-{{- end }}
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image{{if .InsecureHyperkubeImage }},http{{ end }} \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
-        ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
-{{ if semverCompare ">=1.17.0" .KubeletVersion }}{{ print "          kubelet \\\n" }}{{ end -}}
-{{ kubeletFlags .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints | indent 10 }}
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
-        [Install]
-        WantedBy=multi-user.target
+{{ kubeletSystemdUnit .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints | indent 8 }}
 
     - name: docker.service
       enabled: true

--- a/pkg/userdata/coreos/provider_test.go
+++ b/pkg/userdata/coreos/provider_test.go
@@ -476,7 +476,6 @@ func TestUserDataGeneration(t *testing.T) {
 				InsecureRegistries:    test.insecureRegistries,
 				RegistryMirrors:       test.registryMirrors,
 				PauseImage:            test.pauseImage,
-				HyperkubeImage:        test.hyperkubeImage,
 			}
 
 			s, err := provider.UserData(req)

--- a/pkg/userdata/coreos/provider_test.go
+++ b/pkg/userdata/coreos/provider_test.go
@@ -108,7 +108,6 @@ type userDataTestCase struct {
 	insecureRegistries    []string
 	registryMirrors       []string
 	pauseImage            string
-	hyperkubeImage        string
 }
 
 // TestUserDataGeneration runs the data generation for different
@@ -370,7 +369,6 @@ func TestUserDataGeneration(t *testing.T) {
 			noProxy:            "192.168.1.0",
 			insecureRegistries: []string{"192.168.100.100:5000", "10.0.0.1:5000"},
 			pauseImage:         "192.168.100.100:5000/kubernetes/pause:v3.1",
-			hyperkubeImage:     "192.168.100.100:5000/kubernetes/hyperkube",
 		},
 		{
 			name: "v1.12.0-vsphere-mirrors",
@@ -404,7 +402,6 @@ func TestUserDataGeneration(t *testing.T) {
 			noProxy:         "192.168.1.0",
 			registryMirrors: []string{"https://registry.docker-cn.com"},
 			pauseImage:      "192.168.100.100:5000/kubernetes/pause:v3.1",
-			hyperkubeImage:  "192.168.100.100:5000/kubernetes/hyperkube",
 		},
 		{
 			name: "v1.17.0",

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -11,7 +11,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -30,8 +30,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -49,8 +49,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -67,38 +67,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -115,9 +101,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -11,7 +11,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -30,8 +30,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -49,8 +49,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -67,38 +67,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.10.3
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -115,9 +101,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -31,7 +31,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -50,8 +50,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -69,8 +69,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -87,38 +87,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.11.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -135,9 +121,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -37,7 +37,7 @@ systemd:
             [Service]
             Environment=ALL_PROXY=http://192.168.100.100:3128
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -56,8 +56,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -75,8 +75,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -93,38 +93,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://192.168.100.100:5000/kubernetes/hyperkube:v1.12.0
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -141,9 +127,7 @@ systemd:
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -31,7 +31,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -50,8 +50,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -69,8 +69,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -87,38 +87,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.12.0
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -134,9 +120,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -37,7 +37,7 @@ systemd:
             [Service]
             Environment=ALL_PROXY=http://192.168.100.100:3128
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -56,8 +56,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -75,8 +75,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -93,38 +93,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://192.168.100.100:5000/kubernetes/hyperkube:v1.12.0
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image,http \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -141,9 +127,7 @@ systemd:
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -9,7 +9,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -28,8 +28,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -47,8 +47,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -65,38 +65,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.15.0-beta.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -111,9 +97,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.17.0.yaml
+++ b/pkg/userdata/coreos/testdata/v1.17.0.yaml
@@ -31,7 +31,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -50,8 +50,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -69,8 +69,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -87,39 +87,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.17.0
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
-          kubelet \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -134,9 +119,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -15,7 +15,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -34,8 +34,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -53,8 +53,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -71,38 +71,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -117,9 +103,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -15,7 +15,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -34,8 +34,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -53,8 +53,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -71,38 +71,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -118,9 +104,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -13,7 +13,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -32,8 +32,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -51,8 +51,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -69,38 +69,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -116,9 +102,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -13,7 +13,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -32,8 +32,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -51,8 +51,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -69,38 +69,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/coreos/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -116,9 +102,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -23,7 +23,6 @@ package flatcar
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"text/template"
 
 	"github.com/Masterminds/semver"
@@ -38,7 +37,6 @@ type Provider struct{}
 
 // UserData renders user-data template to string.
 func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
-
 	tmpl, err := template.New("user-data").Funcs(userdatahelper.TxtFuncMap()).Parse(userDataTemplate)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse user-data template: %v", err)
@@ -73,14 +71,6 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
-	// We need to reconfigure rkt to allow insecure registries in case the hyperkube image comes from an insecure registry
-	var insecureHyperkubeImage bool
-	for _, registry := range req.InsecureRegistries {
-		if strings.Contains(req.HyperkubeImage, registry) {
-			insecureHyperkubeImage = true
-		}
-	}
-
 	if flatcarConfig.DisableAutoUpdate {
 		flatcarConfig.DisableLocksmithD = true
 		flatcarConfig.DisableUpdateEngine = true
@@ -88,20 +78,18 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec           *providerconfigtypes.Config
-		FlatcarConfig          *Config
-		Kubeconfig             string
-		KubernetesCACert       string
-		KubeletVersion         string
-		InsecureHyperkubeImage bool
+		ProviderSpec     *providerconfigtypes.Config
+		FlatcarConfig    *Config
+		Kubeconfig       string
+		KubernetesCACert string
+		KubeletVersion   string
 	}{
-		UserDataRequest:        req,
-		ProviderSpec:           pconfig,
-		FlatcarConfig:          flatcarConfig,
-		Kubeconfig:             kubeconfigString,
-		KubernetesCACert:       kubernetesCACert,
-		KubeletVersion:         kubeletVersion.String(),
-		InsecureHyperkubeImage: insecureHyperkubeImage,
+		UserDataRequest:  req,
+		ProviderSpec:     pconfig,
+		FlatcarConfig:    flatcarConfig,
+		Kubeconfig:       kubeconfigString,
+		KubernetesCACert: kubernetesCACert,
+		KubeletVersion:   kubeletVersion.String(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/pkg/userdata/flatcar/provider_test.go
+++ b/pkg/userdata/flatcar/provider_test.go
@@ -476,7 +476,6 @@ func TestUserDataGeneration(t *testing.T) {
 				InsecureRegistries:    test.insecureRegistries,
 				RegistryMirrors:       test.registryMirrors,
 				PauseImage:            test.pauseImage,
-				HyperkubeImage:        test.hyperkubeImage,
 			}
 
 			s, err := provider.UserData(req)

--- a/pkg/userdata/flatcar/provider_test.go
+++ b/pkg/userdata/flatcar/provider_test.go
@@ -108,7 +108,6 @@ type userDataTestCase struct {
 	insecureRegistries    []string
 	registryMirrors       []string
 	pauseImage            string
-	hyperkubeImage        string
 }
 
 // TestUserDataGeneration runs the data generation for different
@@ -370,7 +369,6 @@ func TestUserDataGeneration(t *testing.T) {
 			noProxy:            "192.168.1.0",
 			insecureRegistries: []string{"192.168.100.100:5000", "10.0.0.1:5000"},
 			pauseImage:         "192.168.100.100:5000/kubernetes/pause:v3.1",
-			hyperkubeImage:     "192.168.100.100:5000/kubernetes/hyperkube",
 		},
 		{
 			name: "v1.12.0-vsphere-mirrors",
@@ -404,7 +402,6 @@ func TestUserDataGeneration(t *testing.T) {
 			noProxy:         "192.168.1.0",
 			registryMirrors: []string{"https://registry.docker-cn.com"},
 			pauseImage:      "192.168.100.100:5000/kubernetes/pause:v3.1",
-			hyperkubeImage:  "192.168.100.100:5000/kubernetes/hyperkube",
 		},
 		{
 			name: "v1.17.0",

--- a/pkg/userdata/flatcar/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/flatcar/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -11,7 +11,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -30,8 +30,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -49,8 +49,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -67,38 +67,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -115,9 +101,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -11,7 +11,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -30,8 +30,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -49,8 +49,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -67,38 +67,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.10.3
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -115,9 +101,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -31,7 +31,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -50,8 +50,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -69,8 +69,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -87,38 +87,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.11.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -135,9 +121,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -37,7 +37,7 @@ systemd:
             [Service]
             Environment=ALL_PROXY=http://192.168.100.100:3128
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -56,8 +56,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -75,8 +75,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -93,38 +93,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://192.168.100.100:5000/kubernetes/hyperkube:v1.12.0
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -141,9 +127,7 @@ systemd:
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -31,7 +31,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -50,8 +50,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -69,8 +69,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -87,38 +87,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.12.0
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -134,9 +120,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.12.0-vsphere-proxy.yaml
@@ -37,7 +37,7 @@ systemd:
             [Service]
             Environment=ALL_PROXY=http://192.168.100.100:3128
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -56,8 +56,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -75,8 +75,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -93,38 +93,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://192.168.100.100:5000/kubernetes/hyperkube:v1.12.0
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image,http \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -141,9 +127,7 @@ systemd:
           --lock-file=/tmp/kubelet.lock \
           --pod-infra-container-image=192.168.100.100:5000/kubernetes/pause:v3.1 \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.15.0-vsphere.yaml
@@ -9,7 +9,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -28,8 +28,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -47,8 +47,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -65,38 +65,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.15.0-beta.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -111,9 +97,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.17.0.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.17.0.yaml
@@ -31,7 +31,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -50,8 +50,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -69,8 +69,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -87,39 +87,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.17.0
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
-          kubelet \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -134,9 +119,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -15,7 +15,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -34,8 +34,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -53,8 +53,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -71,38 +71,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -117,9 +103,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -15,7 +15,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -34,8 +34,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -53,8 +53,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -71,38 +71,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -118,9 +104,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -13,7 +13,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -32,8 +32,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -51,8 +51,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -69,38 +69,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -116,9 +102,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/flatcar/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -13,7 +13,7 @@ systemd:
     - name: docker.service
       enabled: true
 
-    - name: download-healthcheck-script.service
+    - name: download-binaries-script.service
       enabled: true
       contents: |
         [Unit]
@@ -32,8 +32,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=docker.service
@@ -51,8 +51,8 @@ systemd:
       - name: 40-docker.conf
         contents: |
           [Unit]
-          Requires=download-healthcheck-script.service
-          After=download-healthcheck-script.service
+          Requires=download-binaries-script.service
+          After=download-binaries-script.service
       contents: |
           [Unit]
           Requires=kubelet.service
@@ -69,38 +69,24 @@ systemd:
       enabled: true
       contents: |
         [Unit]
-        Description=Kubernetes Kubelet
-        Requires=docker.service
         After=docker.service
+        Requires=docker.service
+
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io/docs/home/
+
         [Service]
-        TimeoutStartSec=5min
+        Restart=always
+        StartLimitInterval=0
+        RestartSec=10
         CPUAccounting=true
         MemoryAccounting=true
+
+        Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
         EnvironmentFile=-/etc/environment
-        Environment=KUBELET_IMAGE=docker://k8s.gcr.io/hyperkube-amd64:v1.9.2
-        Environment="RKT_RUN_ARGS=--uuid-file-save=/var/cache/kubelet-pod.uuid \
-          --inherit-env \
-          --insecure-options=image \
-          --volume=resolv,kind=host,source=/etc/resolv.conf \
-          --mount volume=resolv,target=/etc/resolv.conf \
-          --volume cni-bin,kind=host,source=/opt/cni/bin \
-          --mount volume=cni-bin,target=/opt/cni/bin \
-          --volume cni-conf,kind=host,source=/etc/cni/net.d \
-          --mount volume=cni-conf,target=/etc/cni/net.d \
-          --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
-          --mount volume=etc-kubernetes,target=/etc/kubernetes \
-          --volume var-log,kind=host,source=/var/log \
-          --mount volume=var-log,target=/var/log \
-          --volume var-lib-calico,kind=host,source=/var/lib/calico \
-          --mount volume=var-lib-calico,target=/var/lib/calico"
-        ExecStartPre=/bin/mkdir -p /var/lib/calico
-        ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
-        ExecStartPre=/bin/mkdir -p /etc/cni/net.d
-        ExecStartPre=/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/cache/kubelet-pod.uuid
-        ExecStartPre=-/bin/rm -rf /var/lib/rkt/cas/tmp/
+
         ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-        ExecStart=/usr/lib/flatcar/kubelet-wrapper \
+        ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -116,9 +102,7 @@ systemd:
           --exit-on-lock-contention \
           --lock-file=/tmp/kubelet.lock \
           --volume-plugin-dir=/var/lib/kubelet/volumeplugins
-        ExecStop=-/usr/bin/rkt stop --uuid-file=/var/cache/kubelet-pod.uuid
-        Restart=always
-        RestartSec=10
+
         [Install]
         WantedBy=multi-user.target
 

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -135,7 +135,7 @@ func KubeletSystemdUnit(kubeletVersion, cloudProvider, hostname string, dnsIPs [
 }
 
 // kubeletConfiguration returns marshaled kubelet.config.k8s.io/v1beta1 KubeletConfiguration
-func kubeletConfiguration(clusterDomain string, clusterDNS []net.IP) (string, error) {
+func KubeletConfiguration(clusterDomain string, clusterDNS []net.IP) (string, error) {
 	clusterDNSstr := make([]string, 0, len(clusterDNS))
 	for _, ip := range clusterDNS {
 		clusterDNSstr = append(clusterDNSstr, ip.String())

--- a/pkg/userdata/helper/template_functions.go
+++ b/pkg/userdata/helper/template_functions.go
@@ -30,7 +30,7 @@ func TxtFuncMap() template.FuncMap {
 	funcMap["downloadBinariesScript"] = DownloadBinariesScript
 	funcMap["safeDownloadBinariesScript"] = SafeDownloadBinariesScript
 	funcMap["kubeletSystemdUnit"] = KubeletSystemdUnit
-	funcMap["kubeletConfiguration"] = kubeletConfiguration
+	funcMap["kubeletConfiguration"] = KubeletConfiguration
 	funcMap["kubeletFlags"] = KubeletFlags
 	funcMap["cloudProviderFlags"] = CloudProviderFlags
 	funcMap["kernelModulesScript"] = LoadKernelModulesScript


### PR DESCRIPTION
**What this PR does / why we need it**:
Unify the way kubelet works on Flatcar/CoreOS with other OS, now it uses exactly the same kubelet flags and binary download procedures.

Because of the above, hyperkube image is no longer needed so its handling is removed and CLI flag is DEPRECATED and NOOP.

Part of the https://github.com/kubermatic/kubeone/issues/125

**Optional Release Note**:
```release-note
* `-node-hyperkube-image` flag is deprecated and has no effect
* Flatcar/CoreOS will use "normal" kubelet like all other OS
```
