### PR TITLE
[release/v1.10] Bind docker-ce-cli to the same version as docker-ce

### DIFF
--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -191,8 +191,8 @@ write_files:
 
     mkdir /etc/docker
 
-    yum install -y docker-ce-3:18.09.1-3.el7 \
-      docker-ce-cli-3:18.09.1-3.el7 \
+    yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -192,6 +192,7 @@ write_files:
     mkdir /etc/docker
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
+      docker-ce-cli-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -74,6 +74,7 @@ write_files:
     mkdir /etc/docker
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
+      docker-ce-cli-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -73,8 +73,8 @@ write_files:
 
     mkdir /etc/docker
 
-    yum install -y docker-ce-3:18.09.1-3.el7 \
-      docker-ce-cli-3:18.09.1-3.el7 \
+    yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -74,6 +74,7 @@ write_files:
     mkdir /etc/docker
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
+      docker-ce-cli-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -73,8 +73,8 @@ write_files:
 
     mkdir /etc/docker
 
-    yum install -y docker-ce-3:18.09.1-3.el7 \
-      docker-ce-cli-3:18.09.1-3.el7 \
+    yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -74,6 +74,7 @@ write_files:
     mkdir /etc/docker
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
+      docker-ce-cli-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -73,8 +73,8 @@ write_files:
 
     mkdir /etc/docker
 
-    yum install -y docker-ce-3:18.09.1-3.el7 \
-      docker-ce-cli-3:18.09.1-3.el7 \
+    yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -74,6 +74,7 @@ write_files:
     mkdir /etc/docker
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
+      docker-ce-cli-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -73,8 +73,8 @@ write_files:
 
     mkdir /etc/docker
 
-    yum install -y docker-ce-3:18.09.1-3.el7 \
-      docker-ce-cli-3:18.09.1-3.el7 \
+    yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -87,6 +87,7 @@ write_files:
     mkdir /etc/docker
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
+      docker-ce-cli-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -86,8 +86,8 @@ write_files:
 
     mkdir /etc/docker
 
-    yum install -y docker-ce-3:18.09.1-3.el7 \
-      docker-ce-cli-3:18.09.1-3.el7 \
+    yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -87,6 +87,7 @@ write_files:
     mkdir /etc/docker
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
+      docker-ce-cli-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -86,8 +86,8 @@ write_files:
 
     mkdir /etc/docker
 
-    yum install -y docker-ce-3:18.09.1-3.el7 \
-      docker-ce-cli-3:18.09.1-3.el7 \
+    yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -78,8 +78,8 @@ write_files:
 
     mkdir /etc/docker
 
-    yum install -y docker-ce-3:18.09.1-3.el7 \
-      docker-ce-cli-3:18.09.1-3.el7 \
+    yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -79,6 +79,7 @@ write_files:
     mkdir /etc/docker
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
+      docker-ce-cli-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -74,6 +74,7 @@ write_files:
     mkdir /etc/docker
 
     yum install -y docker-ce-3:18.09.1-3.el7 \
+      docker-ce-cli-3:18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -73,8 +73,8 @@ write_files:
 
     mkdir /etc/docker
 
-    yum install -y docker-ce-3:18.09.1-3.el7 \
-      docker-ce-cli-3:18.09.1-3.el7 \
+    yum install -y docker-ce-18.09.1-3.el7 \
+      docker-ce-cli-18.09.1-3.el7 \
       ebtables \
       ethtool \
       nfs-utils \

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -242,6 +242,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -261,12 +262,14 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm{{ if eq .CloudProviderName "vsphere" }} \
       open-vm-tools{{ end }}
 
 {{- /* If something failed during package installation but docker got installed, we need to put it on hold */}}
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     {{- if .OSConfig.DistUpgradeOnBoot }}
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade -y

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,9 +158,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade -y
 
     # Update grub to include kernel command options to enable swap accounting.

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,9 +158,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,9 +158,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -140,6 +140,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -159,9 +160,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,9 +158,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,9 +158,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,9 +158,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,9 +158,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,9 +158,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,9 +158,11 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -147,6 +147,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -166,10 +167,12 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm \
       open-vm-tools
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -147,6 +147,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -166,10 +167,12 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm \
       open-vm-tools
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -138,6 +138,7 @@ write_files:
     swapoff -a
 
     export CR_PKG='docker-ce=5:18.09.2~3-0~ubuntu-bionic'
+    export CR_CLI_PKG='docker-ce-cli=5:18.09.2~3-0~ubuntu-bionic'
 
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
@@ -157,10 +158,12 @@ write_files:
       socat \
       util-linux \
       ${CR_PKG} \
+      ${CR_CLI_PKG} \
       ipvsadm \
       open-vm-tools
     apt-mark hold docker.io || true
     apt-mark hold docker-ce || true
+    apt-mark hold docker-ce-cli || true
 
     # Update grub to include kernel command options to enable swap accounting.
     # Exclude alibaba cloud until this is fixed https://github.com/kubermatic/machine-controller/issues/682


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubermatic/machine-controller/pull/759

Bind `docker-ce-cli` to the same version as `docker-ce`.

CentOS is not affected in 1.10 release because we are using the [Docker v1.13 package](https://github.com/kubermatic/machine-controller/blob/04c3f2ab0fe688858b8ac124ce17cf686cd6d9c7/pkg/userdata/centos/provider.go#L187).

**Optional Release Note**:
```release-note
release/v1.10: Bind docker-ce-cli to the same version as docker-ce
```

/assign @kron4eg 