### PR TITLE
[release/v1.10] bump CNI Plugins to v0.8.6

### DIFF
--- a/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.10-aws.yaml
@@ -86,7 +86,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.10.2/bin/linux/amd64/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.11-aws.yaml
@@ -86,7 +86,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws-external.yaml
@@ -86,7 +86,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-aws.yaml
@@ -86,7 +86,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -99,7 +99,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -99,7 +99,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.12-vsphere.yaml
@@ -91,7 +91,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.9-aws.yaml
@@ -86,7 +86,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.9.2/bin/linux/amd64/kubelet

--- a/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
+++ b/pkg/userdata/coreos/testdata/auto-update-openstack-kubelet-v-version-prefix.yaml
@@ -331,7 +331,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
+++ b/pkg/userdata/coreos/testdata/v1.10.3-auto-update-openstack-multiple-dns.yaml
@@ -333,7 +333,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.11.2-vsphere-static-ipconfig.yaml
@@ -351,7 +351,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-mirrors.yaml
@@ -368,7 +368,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-overwrite-cloudconfig.yaml
@@ -352,7 +352,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
+++ b/pkg/userdata/coreos/testdata/v1.12.0-vsphere-proxy.yaml
@@ -368,7 +368,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
+++ b/pkg/userdata/coreos/testdata/v1.15.0-vsphere.yaml
@@ -327,7 +327,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.17.0.yaml
+++ b/pkg/userdata/coreos/testdata/v1.17.0.yaml
@@ -350,7 +350,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws-external.yaml
@@ -328,7 +328,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-auto-update-aws.yaml
@@ -329,7 +329,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-locksmith-aws.yaml
@@ -327,7 +327,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
+++ b/pkg/userdata/coreos/testdata/v1.9.2-disable-update-engine-aws.yaml
@@ -327,7 +327,7 @@ storage:
           mkdir -p /etc/cni/net.d
           mkdir -p /opt/cni/bin
           if [ ! -f /opt/cni/bin/loopback ]; then
-              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+              curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
           fi
 
           if [[ ! -x /opt/bin/health-monitor.sh ]]; then

--- a/pkg/userdata/helper/download_binaries_script.go
+++ b/pkg/userdata/helper/download_binaries_script.go
@@ -32,7 +32,7 @@ mkdir -p /opt/cni/bin
 
 {{- /* # cni */}}
 if [ ! -f /opt/cni/bin/loopback ]; then
-    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
 fi
 
 {{- if .DownloadKubelet }}

--- a/pkg/userdata/helper/testdata/download_binaries_v1.10.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.10.0.golden
@@ -4,7 +4,7 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 if [ ! -f /opt/cni/bin/loopback ]; then
-    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
 fi
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/helper/testdata/download_binaries_v1.11.0-rc.2.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.11.0-rc.2.golden
@@ -4,7 +4,7 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 if [ ! -f /opt/cni/bin/loopback ]; then
-    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
 fi
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.0-rc.2/bin/linux/amd64/kubelet

--- a/pkg/userdata/helper/testdata/download_binaries_v1.11.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.11.0.golden
@@ -4,7 +4,7 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 if [ ! -f /opt/cni/bin/loopback ]; then
-    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
 fi
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/helper/testdata/download_binaries_v1.11.3.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.11.3.golden
@@ -4,7 +4,7 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 if [ ! -f /opt/cni/bin/loopback ]; then
-    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
 fi
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/helper/testdata/download_binaries_v1.12.0.golden
+++ b/pkg/userdata/helper/testdata/download_binaries_v1.12.0.golden
@@ -4,7 +4,7 @@ mkdir -p /etc/kubernetes/manifests
 mkdir -p /etc/cni/net.d
 mkdir -p /opt/cni/bin
 if [ ! -f /opt/cni/bin/loopback ]; then
-    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+    curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
 fi
 if [ ! -f /opt/bin/kubelet ]; then
     curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.10-aws.yaml
@@ -105,7 +105,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.10.2/bin/linux/amd64/kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.11-aws.yaml
@@ -105,7 +105,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws-external.yaml
@@ -105,7 +105,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-aws.yaml
@@ -105,7 +105,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-mirrors.yaml
@@ -119,7 +119,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere-proxy.yaml
@@ -119,7 +119,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.12-vsphere.yaml
@@ -111,7 +111,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.9-aws.yaml
@@ -105,7 +105,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.9.2/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -73,7 +73,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -72,7 +72,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -72,7 +72,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -74,7 +74,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -72,7 +72,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -72,7 +72,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.10.10.yaml
@@ -72,7 +72,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.10.10/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.11.3.yaml
@@ -72,7 +72,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.12.1.yaml
@@ -72,7 +72,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.1/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.9.10.yaml
@@ -72,7 +72,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.9.10/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -82,7 +82,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -82,7 +82,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -73,7 +73,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -178,7 +178,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -177,7 +177,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -177,7 +177,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -179,7 +179,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -177,7 +177,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -177,7 +177,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.10.10.yaml
@@ -177,7 +177,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.10.10/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.11.3.yaml
@@ -177,7 +177,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.12.1.yaml
@@ -177,7 +177,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.12.1/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.9.10.yaml
@@ -177,7 +177,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.9.10/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -187,7 +187,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -187,7 +187,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -178,7 +178,7 @@ write_files:
     mkdir -p /etc/cni/net.d
     mkdir -p /opt/cni/bin
     if [ ! -f /opt/cni/bin/loopback ]; then
-        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.2/cni-plugins-linux-amd64-v0.8.2.tgz | tar -xvzC /opt/cni/bin -f -
+        curl -L https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar -xvzC /opt/cni/bin -f -
     fi
     if [ ! -f /opt/bin/kubelet ]; then
         curl -Lfo /opt/bin/kubelet https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubelet


### PR DESCRIPTION

```release-note
CNI plugins have been upgraded to `v0.8.6`
```
