### PR TITLE
Drop coreos from e2e testing as it had EOL

### DIFF
--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -40,7 +40,6 @@ var (
 
 	operatingSystems = []providerconfigtypes.OperatingSystem{
 		providerconfigtypes.OperatingSystemUbuntu,
-		providerconfigtypes.OperatingSystemCoreos,
 		providerconfigtypes.OperatingSystemCentOS,
 		providerconfigtypes.OperatingSystemSLES,
 		providerconfigtypes.OperatingSystemRHEL,
@@ -49,7 +48,6 @@ var (
 
 	openStackImages = map[string]string{
 		string(providerconfigtypes.OperatingSystemUbuntu):  "machine-controller-e2e-ubuntu",
-		string(providerconfigtypes.OperatingSystemCoreos):  "machine-controller-e2e-coreos",
 		string(providerconfigtypes.OperatingSystemCentOS):  "machine-controller-e2e-centos",
 		string(providerconfigtypes.OperatingSystemRHEL):    "machine-controller-e2e-rhel",
 		string(providerconfigtypes.OperatingSystemFlatcar): "machine-controller-e2e-flatcar",


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable coreos e2e testing entirely as it had EOL yesterday and providers already thinking about remove the images.

```release-note
NONE
```
