### PR TITLE
Revert "Drop some optional packages from installing (#751)"

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -195,6 +195,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.15-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.15-aws.yaml
@@ -77,6 +77,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.16-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.16-aws.yaml
@@ -77,6 +77,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-aws-external.yaml
@@ -77,6 +77,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-aws.yaml
@@ -77,6 +77,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-mirrors.yaml
@@ -89,6 +89,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-proxy.yaml
@@ -89,6 +89,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere.yaml
@@ -81,6 +81,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -195,6 +195,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.15-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.15-aws.yaml
@@ -80,6 +80,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.16-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.16-aws.yaml
@@ -80,6 +80,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
@@ -80,6 +80,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
@@ -80,6 +80,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
@@ -92,6 +92,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
@@ -92,6 +92,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
@@ -84,6 +84,7 @@ write_files:
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
+      nfs-utils \
       bash-completion \
       sudo \
       socat \

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -164,8 +164,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -58,8 +58,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -58,8 +58,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/version-1.15.10.yaml
+++ b/pkg/userdata/sles/testdata/version-1.15.10.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/version-1.16.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.16.3.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/version-1.17.1.yaml
+++ b/pkg/userdata/sles/testdata/version-1.17.1.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -65,8 +65,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -65,8 +65,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -56,8 +56,8 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    zypper --non-interactive --quiet --color install \
-      ebtables \
+    zypper --non-interactive --quiet --color install ebtables \
+      ceph-common \
       e2fsprogs \
       jq \
       socat \

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -253,14 +253,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -143,14 +143,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -141,14 +141,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -141,14 +141,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -143,14 +143,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -141,14 +141,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -141,14 +141,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/version-1.15.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.15.10.yaml
@@ -141,14 +141,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/version-1.16.6.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.16.6.yaml
@@ -141,14 +141,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/version-1.17.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.17.3.yaml
@@ -141,14 +141,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -150,14 +150,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -150,14 +150,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -141,14 +141,18 @@ write_files:
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \
+      ceph-common \
+      cifs-utils \
       conntrack \
       e2fsprogs \
       ebtables \
       ethtool \
+      glusterfs-client \
       iptables \
       jq \
       kmod \
       openssh-client \
+      nfs-common \
       socat \
       util-linux \
       docker-ce="${DOCKER_VERSION}" \


### PR DESCRIPTION
**What this PR does / why we need it**:
After internal discussion we estimated that to avoid risk of regressions it is better to revert the changes introduced by https://github.com/kubermatic/machine-controller/pull/751.

This reverts commit fd630e89c39dcaa990c37fa79f99a1b53b78e9b0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
```release-note
Re-introduce kubelet dependencies previously considered as optional (i.e. ceph-common, cifs-utils, glusterfs-client, nfs-common/nfs-utils) to avoid the risk of regressions.
```
