### PR TITLE
Use cloud-init rh_subscription module to register and auto-attach subscriptions

### DIFF
--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -186,10 +186,6 @@ write_files:
     hostnamectl set-hostname {{ .MachineSpec.Name }}
     {{ end }}
 
-    subscription-manager clean
-    subscription-manager register --username='{{.OSConfig.RHELSubscriptionManagerUser}}' --password='{{.OSConfig.RHELSubscriptionManagerPassword}}'
-    subscription-manager attach --auto
-
     dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     DOCKER_VERSION='18.09.1-3.el7'
@@ -314,6 +310,11 @@ write_files:
   content: |
     [Service]
     EnvironmentFile=-/etc/environment
+
+rh_subscription:
+  username: "{{.OSConfig.RHELSubscriptionManagerUser}}"
+  password: "{{.OSConfig.RHELSubscriptionManagerPassword}}"
+  auto-attach: true
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -312,9 +312,9 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 rh_subscription:
-  username: "{{.OSConfig.RHELSubscriptionManagerUser}}"
-  password: "{{.OSConfig.RHELSubscriptionManagerPassword}}"
-  auto-attach: true
+    username: "{{.OSConfig.RHELSubscriptionManagerUser}}"
+    password: "{{.OSConfig.RHELSubscriptionManagerPassword}}"
+    auto-attach: true
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.15-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.15-aws.yaml
@@ -69,10 +69,6 @@ write_files:
     swapoff -a
 
 
-    subscription-manager clean
-    subscription-manager register --username='' --password=''
-    subscription-manager attach --auto
-
     dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     DOCKER_VERSION='18.09.1-3.el7'
@@ -374,6 +370,11 @@ write_files:
   content: |
     [Service]
     EnvironmentFile=-/etc/environment
+
+rh_subscription:
+    username: ""
+    password: ""
+    auto-attach: true
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.16-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.16-aws.yaml
@@ -69,10 +69,6 @@ write_files:
     swapoff -a
 
 
-    subscription-manager clean
-    subscription-manager register --username='' --password=''
-    subscription-manager attach --auto
-
     dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     DOCKER_VERSION='18.09.1-3.el7'
@@ -374,6 +370,11 @@ write_files:
   content: |
     [Service]
     EnvironmentFile=-/etc/environment
+
+rh_subscription:
+    username: ""
+    password: ""
+    auto-attach: true
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
@@ -69,10 +69,6 @@ write_files:
     swapoff -a
 
 
-    subscription-manager clean
-    subscription-manager register --username='' --password=''
-    subscription-manager attach --auto
-
     dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     DOCKER_VERSION='18.09.1-3.el7'
@@ -373,6 +369,11 @@ write_files:
   content: |
     [Service]
     EnvironmentFile=-/etc/environment
+
+rh_subscription:
+    username: ""
+    password: ""
+    auto-attach: true
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
@@ -69,10 +69,6 @@ write_files:
     swapoff -a
 
 
-    subscription-manager clean
-    subscription-manager register --username='' --password=''
-    subscription-manager attach --auto
-
     dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     DOCKER_VERSION='18.09.1-3.el7'
@@ -374,6 +370,11 @@ write_files:
   content: |
     [Service]
     EnvironmentFile=-/etc/environment
+
+rh_subscription:
+    username: ""
+    password: ""
+    auto-attach: true
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
@@ -81,10 +81,6 @@ write_files:
     hostnamectl set-hostname node1
 
 
-    subscription-manager clean
-    subscription-manager register --username='' --password=''
-    subscription-manager attach --auto
-
     dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     DOCKER_VERSION='18.09.1-3.el7'
@@ -395,6 +391,11 @@ write_files:
   content: |
     [Service]
     EnvironmentFile=-/etc/environment
+
+rh_subscription:
+    username: ""
+    password: ""
+    auto-attach: true
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
@@ -81,10 +81,6 @@ write_files:
     hostnamectl set-hostname node1
 
 
-    subscription-manager clean
-    subscription-manager register --username='' --password=''
-    subscription-manager attach --auto
-
     dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     DOCKER_VERSION='18.09.1-3.el7'
@@ -395,6 +391,11 @@ write_files:
   content: |
     [Service]
     EnvironmentFile=-/etc/environment
+
+rh_subscription:
+    username: ""
+    password: ""
+    auto-attach: true
 
 runcmd:
 - systemctl enable --now setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
@@ -73,10 +73,6 @@ write_files:
     hostnamectl set-hostname node1
 
 
-    subscription-manager clean
-    subscription-manager register --username='' --password=''
-    subscription-manager attach --auto
-
     dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 
     DOCKER_VERSION='18.09.1-3.el7'
@@ -382,6 +378,11 @@ write_files:
   content: |
     [Service]
     EnvironmentFile=-/etc/environment
+
+rh_subscription:
+    username: ""
+    password: ""
+    auto-attach: true
 
 runcmd:
 - systemctl enable --now setup.service

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -142,7 +142,7 @@ func TestOpenstackProvisioningE2E(t *testing.T) {
 		fmt.Sprintf("<< NETWORK_NAME >>=%s", osNetwork),
 	}
 
-	selector := Not(OsSelector("sles", "rhel"))
+	selector := Not(OsSelector("sles"))
 	runScenarios(t, selector, params, OSManifest, fmt.Sprintf("os-%s", *testRunIdentifier))
 }
 
@@ -176,7 +176,7 @@ func TestAWSProvisioningE2E(t *testing.T) {
 	if len(awsKeyID) == 0 || len(awsSecret) == 0 {
 		t.Fatal("unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
 	}
-	selector := Not(OsSelector("sles", "rhel"))
+	selector := Not(OsSelector("sles"))
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
 		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),
@@ -247,7 +247,7 @@ func TestAzureProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET environment variables cannot be empty")
 	}
 
-	selector := Not(OsSelector("sles", "rhel"))
+	selector := Not(OsSelector("sles"))
 	// act
 	params := []string{
 		fmt.Sprintf("<< AZURE_TENANT_ID >>=%s", azureTenantID),
@@ -271,7 +271,7 @@ func TestGCEProvisioningE2E(t *testing.T) {
 	}
 
 	// Act. GCE does not support CentOS.
-	selector := OsSelector("ubuntu", "coreos")
+	selector := OsSelector("ubuntu", "coreos", "rhel")
 	params := []string{
 		fmt.Sprintf("<< GOOGLE_SERVICE_ACCOUNT >>=%s", googleServiceAccount),
 	}
@@ -395,7 +395,7 @@ func getVSphereTestParams(t *testing.T) []string {
 func TestVsphereProvisioningE2E(t *testing.T) {
 	t.Parallel()
 
-	selector := Not(OsSelector("sles", "rhel"))
+	selector := Not(OsSelector("sles"))
 
 	params := getVSphereTestParams(t)
 	runScenarios(t, selector, params, VSPhereManifest, fmt.Sprintf("vs-%s", *testRunIdentifier))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the registration of the machine from the setup script (run by a systemd unit) and attempts to use `rh_subscription` cloud-init module as a replacement.

The advantage of doing this is that the module attempts the registration only if the system is not already registered.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #777

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
