### PR TITLE
Assign external IP and DNS name for GCP machines

### DIFF
--- a/pkg/cloudprovider/provider/gce/instance.go
+++ b/pkg/cloudprovider/provider/gce/instance.go
@@ -62,7 +62,11 @@ func (gi *googleInstance) Addresses() map[string]v1.NodeAddressType {
 	addrs := map[string]v1.NodeAddressType{}
 	for _, ifc := range gi.ci.NetworkInterfaces {
 		addrs[ifc.NetworkIP] = v1.NodeInternalIP
+		for _, ac := range ifc.AccessConfigs {
+			addrs[ac.NatIP] = v1.NodeExternalIP
+		}
 	}
+	addrs[gi.ci.Hostname] = v1.NodeInternalDNS
 	return addrs
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Assign external IP and DNS name for GCP machines.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #781

**Optional Release Note**:
```release-note
Add external IPs and DNS name to .status.Addresses for the GCP machines. This fixes the issue with NodeCSRApprover controller refusing to approve CSRs for GCP worker nodes.
```
