### PR TITLE
Make it work for CentOS7/CentOS8/RHEL7/RHEL8

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -508,6 +508,27 @@ presubmits:
               memory: 1Gi
               cpu: 500m
 
+  - name: pull-machine-controller-e2e-aws-centos8
+    always_run: false
+    decorate: true
+    error_on_eviction: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    labels:
+      preset-aws: "true"
+      preset-hetzner: "true"
+      preset-e2e-ssh: "true"
+    spec:
+      containers:
+        - image: golang:1.13.8
+          command:
+            - "./hack/ci-e2e-test.sh"
+          args:
+            - "TestAWSCentOS8ProvisioningE2E"
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 500m
+
   - name: pull-machine-controller-e2e-vsphere-datastore-cluster
     always_run: false
     decorate: true

--- a/pkg/userdata/centos/testdata/kubelet-v1.15-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.15-aws.yaml
@@ -40,7 +40,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -63,14 +63,13 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
@@ -85,7 +84,7 @@ write_files:
       curl \
       yum-plugin-versionlock \
       ipvsadm
-    yum versionlock docker-ce-*
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/centos/testdata/kubelet-v1.16-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.16-aws.yaml
@@ -40,7 +40,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -63,14 +63,13 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
@@ -85,7 +84,7 @@ write_files:
       curl \
       yum-plugin-versionlock \
       ipvsadm
-    yum versionlock docker-ce-*
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-aws-external.yaml
@@ -40,7 +40,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -63,14 +63,13 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
@@ -85,7 +84,7 @@ write_files:
       curl \
       yum-plugin-versionlock \
       ipvsadm
-    yum versionlock docker-ce-*
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-aws.yaml
@@ -40,7 +40,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -63,14 +63,13 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
@@ -85,7 +84,7 @@ write_files:
       curl \
       yum-plugin-versionlock \
       ipvsadm
-    yum versionlock docker-ce-*
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-mirrors.yaml
@@ -50,7 +50,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -73,9 +73,7 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
     hostnamectl set-hostname node1
@@ -83,6 +81,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
@@ -98,7 +97,7 @@ write_files:
       yum-plugin-versionlock \
       open-vm-tools \
       ipvsadm
-    yum versionlock docker-ce-*
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-proxy.yaml
@@ -50,7 +50,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -73,9 +73,7 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
     hostnamectl set-hostname node1
@@ -83,6 +81,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
@@ -98,7 +97,7 @@ write_files:
       yum-plugin-versionlock \
       open-vm-tools \
       ipvsadm
-    yum versionlock docker-ce-*
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere.yaml
@@ -42,7 +42,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -65,9 +65,7 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
     hostnamectl set-hostname node1
@@ -75,6 +73,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
@@ -90,7 +89,7 @@ write_files:
       yum-plugin-versionlock \
       open-vm-tools \
       ipvsadm
-    yum versionlock docker-ce-*
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -149,7 +149,7 @@ write_files:
   content: |
 {{ kernelSettings | indent 4 }}
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -176,9 +176,7 @@ write_files:
     sysctl --system
 
 {{- /* Make sure we always disable swap - Otherwise the kubelet won't start */}}
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
     {{ if ne .CloudProviderName "aws" }}
 {{- /*  The normal way of setting it via cloud-init is broken, see */}}
@@ -186,10 +184,14 @@ write_files:
     hostnamectl set-hostname {{ .MachineSpec.Name }}
     {{ end }}
 
-    dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y yum-utils
+    yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+{{- /*	Due to DNF modules we have to do this on docker-ce repo
+		More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473 */}}
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.1-3.el7'
-    dnf install -y docker-ce-${DOCKER_VERSION} \
+    DOCKER_VERSION='18.09.9-3.el7'
+    yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
@@ -199,13 +201,12 @@ write_files:
       socat \
       wget \
       curl \
-      python3-dnf-plugin-versionlock \
+      yum-plugin-versionlock \
       {{- if eq .CloudProviderName "vsphere" }}
       open-vm-tools \
       {{- end }}
       ipvsadm
-    dnf versionlock add docker-ce docker-ce-cli
-    dnf clean all
+    yum versionlock add docker-ce-*
 
 {{ safeDownloadBinariesScript .KubeletVersion | indent 4 }}
     # set kubelet nodeip environment variable

--- a/pkg/userdata/rhel/testdata/kubelet-v1.15-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.15-aws.yaml
@@ -40,7 +40,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -63,16 +63,16 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
 
-    dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y yum-utils
+    yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.1-3.el7'
-    dnf install -y docker-ce-${DOCKER_VERSION} \
+    DOCKER_VERSION='18.09.9-3.el7'
+    yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
@@ -82,10 +82,9 @@ write_files:
       socat \
       wget \
       curl \
-      python3-dnf-plugin-versionlock \
+      yum-plugin-versionlock \
       ipvsadm
-    dnf versionlock add docker-ce docker-ce-cli
-    dnf clean all
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/rhel/testdata/kubelet-v1.16-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.16-aws.yaml
@@ -40,7 +40,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -63,16 +63,16 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
 
-    dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y yum-utils
+    yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.1-3.el7'
-    dnf install -y docker-ce-${DOCKER_VERSION} \
+    DOCKER_VERSION='18.09.9-3.el7'
+    yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
@@ -82,10 +82,9 @@ write_files:
       socat \
       wget \
       curl \
-      python3-dnf-plugin-versionlock \
+      yum-plugin-versionlock \
       ipvsadm
-    dnf versionlock add docker-ce docker-ce-cli
-    dnf clean all
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
@@ -40,7 +40,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -63,16 +63,16 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
 
-    dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y yum-utils
+    yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.1-3.el7'
-    dnf install -y docker-ce-${DOCKER_VERSION} \
+    DOCKER_VERSION='18.09.9-3.el7'
+    yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
@@ -82,10 +82,9 @@ write_files:
       socat \
       wget \
       curl \
-      python3-dnf-plugin-versionlock \
+      yum-plugin-versionlock \
       ipvsadm
-    dnf versionlock add docker-ce docker-ce-cli
-    dnf clean all
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
@@ -40,7 +40,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -63,16 +63,16 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
 
-    dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y yum-utils
+    yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.1-3.el7'
-    dnf install -y docker-ce-${DOCKER_VERSION} \
+    DOCKER_VERSION='18.09.9-3.el7'
+    yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
@@ -82,10 +82,9 @@ write_files:
       socat \
       wget \
       curl \
-      python3-dnf-plugin-versionlock \
+      yum-plugin-versionlock \
       ipvsadm
-    dnf versionlock add docker-ce docker-ce-cli
-    dnf clean all
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
@@ -50,7 +50,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -73,18 +73,18 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
     hostnamectl set-hostname node1
 
 
-    dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y yum-utils
+    yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.1-3.el7'
-    dnf install -y docker-ce-${DOCKER_VERSION} \
+    DOCKER_VERSION='18.09.9-3.el7'
+    yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
@@ -94,11 +94,10 @@ write_files:
       socat \
       wget \
       curl \
-      python3-dnf-plugin-versionlock \
+      yum-plugin-versionlock \
       open-vm-tools \
       ipvsadm
-    dnf versionlock add docker-ce docker-ce-cli
-    dnf clean all
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
@@ -50,7 +50,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -73,18 +73,18 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
     hostnamectl set-hostname node1
 
 
-    dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y yum-utils
+    yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.1-3.el7'
-    dnf install -y docker-ce-${DOCKER_VERSION} \
+    DOCKER_VERSION='18.09.9-3.el7'
+    yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
@@ -94,11 +94,10 @@ write_files:
       socat \
       wget \
       curl \
-      python3-dnf-plugin-versionlock \
+      yum-plugin-versionlock \
       open-vm-tools \
       ipvsadm
-    dnf versionlock add docker-ce docker-ce-cli
-    dnf clean all
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
@@ -42,7 +42,7 @@ write_files:
     fs.inotify.max_user_watches = 1048576
 
 
-- path: /etc/sysconfig/selinux
+- path: /etc/selinux/config
   content: |
     # This file controls the state of SELinux on the system.
     # SELINUX= can take one of these three values:
@@ -65,18 +65,18 @@ write_files:
     setenforce 0 || true
     systemctl restart systemd-modules-load.service
     sysctl --system
-    cp /etc/fstab /etc/fstab.orig
-    cat /etc/fstab.orig | awk '$3 ~ /^swap$/ && $1 !~ /^#/ {$0="# commented out by cloudinit\n#"$0} 1' > /etc/fstab.noswap
-    mv /etc/fstab.noswap /etc/fstab
+    sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
     hostnamectl set-hostname node1
 
 
-    dnf config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum install -y yum-utils
+    yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.1-3.el7'
-    dnf install -y docker-ce-${DOCKER_VERSION} \
+    DOCKER_VERSION='18.09.9-3.el7'
+    yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \
       ethtool \
@@ -86,11 +86,10 @@ write_files:
       socat \
       wget \
       curl \
-      python3-dnf-plugin-versionlock \
+      yum-plugin-versionlock \
       open-vm-tools \
       ipvsadm
-    dnf versionlock add docker-ce docker-ce-cli
-    dnf clean all
+    yum versionlock add docker-ce-*
 
     opt_bin=/opt/bin
     cni_bin_dir=/opt/cni/bin

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -207,6 +207,29 @@ func TestAWSSLESProvisioningE2E(t *testing.T) {
 	runScenarios(t, selector, params, AWSManifest, fmt.Sprintf("aws-%s", *testRunIdentifier))
 }
 
+func TestAWSCentOS8ProvisioningE2E(t *testing.T) {
+	t.Parallel()
+
+	// test data
+	awsKeyID := os.Getenv("AWS_E2E_TESTS_KEY_ID")
+	awsSecret := os.Getenv("AWS_E2E_TESTS_SECRET")
+	if len(awsKeyID) == 0 || len(awsSecret) == 0 {
+		t.Fatal("unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
+	}
+
+	amiID := "ami-032025b3afcbb6b34" // official "CentOS 8.2.2004 x86_64"
+
+	params := []string{
+		fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
+		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),
+		fmt.Sprintf("<< AMI >>=%s", amiID),
+	}
+
+	// We would like to test CentOS8 image only in this test as the other images are tested in TestAWSProvisioningE2E
+	selector := OsSelector("centos")
+	runScenarios(t, selector, params, AWSManifest, fmt.Sprintf("aws-%s", *testRunIdentifier))
+}
+
 // TestAWSProvisioningE2EWithEbsEncryptionEnabled - a test suite that exercises AWS provider with ebs encryption enabled
 // by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
 func TestAWSProvisioningE2EWithEbsEncryptionEnabled(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR unblocks the ability to user CentOS8 / RHEL7.

* now it's possible to upgrade docker version
* CentOS8 / RHEL7 can be provisioned

**Special notes for your reviewer**:
While by default without externally provided image machine-controller will search for CentOS7 images (fixing this is out of scope of this PR), it's now possible to provide CentOS8 (or RHEL7) image in MachineDeployment.

**Optional Release Note**:
```release-note
support CentOS7/CentOS8/RHEL7/RHEL8
```
