### PR TITLE
adjust the source url for the registry server

### DIFF
--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt-dns-config.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt-dns-config.yaml
@@ -28,7 +28,7 @@ spec:
           cloudProviderSpec:
             storageClassName: kubermatic-fast
             pvcSize: "10Gi"
-            sourceURL: http://10.108.49.221/<< OS_NAME >>.img
+            sourceURL: http://10.102.236.197/<< OS_NAME >>.img
             cpus: "1"
             memory: "4096M"
             dnsPolicy: "None"

--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
@@ -28,7 +28,7 @@ spec:
           cloudProviderSpec:
             storageClassName: kubermatic-fast
             pvcSize: "10Gi"
-            sourceURL: http://10.108.49.221/<< OS_NAME >>.img
+            sourceURL: http://10.102.236.197/<< OS_NAME >>.img
             cpus: "1"
             memory: "4096M"
             kubeconfig:


### PR DESCRIPTION
**What this PR does / why we need it**:
After the creation of the new Kubevirt cluster, the images registry address has been changed. This PR adds the new images server address to the tests templates for Kubevirt cloud provider. 

**Optional Release Note**:
```release-note
None
```
