### PR TITLE
Add CSR RBAC to the example manifest

### DIFF
--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -456,6 +456,30 @@ rules:
   - "pods/eviction"
   verbs:
   - "create"
+# The following roles are required for NodeCSRApprover controller to be able
+# to reconcile CertificateSigningRequests for kubelet serving certificates.
+- apiGroups:
+  - "certificates.k8s.io"
+  resources:
+  - "certificatesigningrequests"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+- apiGroups:
+  - "certificates.k8s.io"
+  resources:
+  - "certificatesigningrequests/approval"
+  verbs:
+  - "update"
+- apiGroups:
+  - "certificates.k8s.io"
+  resources:
+  - "signers"
+  resourceNames:
+  - "kubernetes.io/kubelet-serving"
+  verbs:
+  - "approve"
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the RBAC rules needed for the NodeCSRApprover controller to work properly.

**Optional Release Note**:
```release-note
NONE
```
