### PR TITLE
Reduce disk storage consumption in Openstack e2e tests

### DIFF
--- a/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
@@ -34,6 +34,7 @@ spec:
             domainName: "<< DOMAIN_NAME >>"
             region: "<< REGION >>"
             network: "<< NETWORK_NAME >>"
+            rootDiskSizeGB: 10
             rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
@@ -34,7 +34,6 @@ spec:
             domainName: "<< DOMAIN_NAME >>"
             region: "<< REGION >>"
             network: "<< NETWORK_NAME >>"
-            rootDiskSizeGB: 20
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Lastly we hit some quota issues in the openstack tenant we use for our e2e tests. In order to reduce disk consumption this PR is:
* Moving the `rootDiskSizeGB` to the openstack upgrade test that is run with ubuntu OS only
* Reducing `rootDIskSizeGB` to 10G that should be enough

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
