### PR TITLE
Add proper hostnames to the GCP Machine objects

### DIFF
--- a/pkg/cloudprovider/provider/gce/instance.go
+++ b/pkg/cloudprovider/provider/gce/instance.go
@@ -21,6 +21,7 @@ limitations under the License.
 package gce
 
 import (
+	"fmt"
 	"strconv"
 
 	"google.golang.org/api/compute/v1"
@@ -44,7 +45,9 @@ const (
 
 // googleInstance implements instance.Instance for the Google compute instance.
 type googleInstance struct {
-	ci *compute.Instance
+	ci        *compute.Instance
+	projectID string
+	zone      string
 }
 
 // Name implements instance.Instance.
@@ -66,7 +69,25 @@ func (gi *googleInstance) Addresses() map[string]v1.NodeAddressType {
 			addrs[ac.NatIP] = v1.NodeExternalIP
 		}
 	}
-	addrs[gi.ci.Hostname] = v1.NodeInternalDNS
+
+	// GCE has two types of the internal DNS, so we need to take both
+	// into the account:
+	// https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names
+	// Zonal DNS is present for newer projects and has the following FQDN format:
+	// [INSTANCE_NAME].[ZONE].c.[PROJECT_ID].internal
+	zonalDNS := fmt.Sprintf("%s.%s.c.%s.internal", gi.ci.Name, gi.zone, gi.projectID)
+	addrs[zonalDNS] = v1.NodeInternalDNS
+
+	// Global DNS is present for older projects and has the following FQDN format:
+	// [INSTANCE_NAME].c.[PROJECT_ID].internal
+	globalDNS := fmt.Sprintf("%s.c.%s.internal", gi.ci.Name, gi.projectID)
+	addrs[globalDNS] = v1.NodeInternalDNS
+
+	// GCP provides the search paths to resolve the machine's name,
+	// so we add is as a DNS name
+	// https://cloud.google.com/compute/docs/internal-dns#resolv.conf
+	addrs[gi.ci.Name] = v1.NodeInternalDNS
+
 	return addrs
 }
 

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -160,7 +160,11 @@ func (p *Provider) get(machine *v1alpha1.Machine) (*googleInstance, error) {
 	if len(insts.Items) > 1 {
 		return nil, newError(common.InvalidConfigurationMachineError, errGotTooManyInstances)
 	}
-	return &googleInstance{insts.Items[0]}, nil
+	return &googleInstance{
+		ci:        insts.Items[0],
+		projectID: cfg.projectID,
+		zone:      cfg.zone,
+	}, nil
 }
 
 // GetCloudConfig returns the cloud provider specific cloud-config for the kubelet.


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the NodeCSRApprover controller is refusing to approve the kubelet serving CSRs because of the hostname mismatch:

```
E0721 15:50:11.376789   57460 node_csr_approver.go:78] Reconciliation of request /csr-bvrws failed: error validating the x509 certificate request: dns name '<instance-name>.c.<project-name>.internal' cannot be associated with node '<node-name>'
```

We have attempted to fix this issue in #782, however, it turned out that the Hostname field of the instance resource is empty if a hostname is not specified when creating the instance (i.e. the default hostname is being used).

There are two ways to determine the hostname if the default hostname is being used (which is our case):

* By using the metadata API. This is not suitable for machine-controller because accessing the metadata API requires accessing the instance and calling the API from the instance
* By generating it

We have decided to generate the hostname based on the rules in the [internal DNS doc](https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names). We have run into the problem with this approach because there are two types of the internal DNS: zonal and global. Those types have different FQDN/hostnames. Which type is going to be used depends on when was the Compute API enabled:

* Zonal: Default for all organizations or standalone projects that have enabled the Compute Engine API after September 06, 2018
* Global: Default for all organizations or standalone projects that have enabled the Compute Engine API before September 6, 2018.

Because we don't have a way to determine this and because we don't have easy access to the instances to use the metadata API, we decided to add both types of hostnames to the Machine object.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #781 

**Optional Release Note**:
```release-note
Add proper hostnames to the Machine object for GCP machines. Fix the issue with NodeCSRApprover refusing the approve the kubelet serving certificates for GCP nodes.
```

/assign @irozzo-1A @kron4eg 