### PR TITLE
Support Flatcar in Packet cloud provider

### DIFF
--- a/pkg/cloudprovider/provider/packet/provider.go
+++ b/pkg/cloudprovider/provider/packet/provider.go
@@ -429,6 +429,8 @@ func getNameForOS(os providerconfigtypes.OperatingSystem) (string, error) {
 		return "centos_7", nil
 	case providerconfigtypes.OperatingSystemCoreos:
 		return "coreos_stable", nil
+	case providerconfigtypes.OperatingSystemFlatcar:
+		return "flatcar_stable", nil
 	}
 	return "", providerconfigtypes.ErrOSNotSupported
 }

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -371,7 +371,7 @@ func TestPacketProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, PACKET_PROJECT_ID environment variable cannot be empty")
 	}
 
-	selector := Not(OsSelector("sles", "rhel", "flatcar"))
+	selector := Not(OsSelector("sles", "rhel"))
 
 	// act
 	params := []string{


### PR DESCRIPTION
To allow Flatcar to be used as one of the operating systems, we need to update `getNameForOS()` so it also accepts the input value `flatcar` in `operatingSystem` of the provider config.

### Optional Release Note:

```release-note
support Flatcar in Packet cloud provider
```