### PR TITLE
Always ensure to have machine-delete-finalizer

### DIFF
--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -327,16 +327,6 @@ func (r *Reconciler) createProviderInstance(prov cloudprovidertypes.Provider, ma
 	}
 	instance, err := prov.Create(machine, r.providerData, userdata)
 	if err != nil {
-		// Remove the finalizer if creation failed. We always add it initially to be 100% sure
-		// its there if an instance was created
-		if updateMachineError := r.updateMachine(machine, func(m *clusterv1alpha1.Machine) {
-			if s := sets.NewString(m.Finalizers...); s.Has(FinalizerDeleteInstance) {
-				s.Delete(FinalizerDeleteInstance)
-			}
-		}); updateMachineError != nil {
-			return nil, fmt.Errorf("failed to remove %q finalizer with err=%q after instance creation failed with err=%q",
-				FinalizerDeleteInstance, updateMachineError, err)
-		}
 		return nil, err
 	}
 	return instance, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
After creating a new provider instance we always want to have the
machine-delete-finalizer. Possible provider specific finalizers can't be
deleted without it.

We have noted this especially for azure clusters, where the machine-controller doesn't try to run deleteCloudProvider instance because the finalizer `machine-delete-finalizer` is missing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
