### PR TITLE
Use c1.small.x86 instance type on Packet

### DIFF
--- a/test/e2e/provisioning/testdata/machinedeployment-packet.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-packet.yaml
@@ -26,9 +26,9 @@ spec:
           cloudProviderSpec:
             apiKey: << PACKET_API_KEY >>
             projectID: << PACKET_PROJECT_ID >>
-            instanceType: "t1.small.x86"
+            instanceType: "c1.small.x86"
             facilities:
-            - "ewr1"
+            - "ams1"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false


### PR DESCRIPTION
**What this PR does / why we need it**:

We've used t1.small.x86 instances for running E2E tests because we
don't need large instances. The t1.small.x86 instance type is first
generation, and as the first generation is deprecated, it's not
available anymore. The c1.small.x86 instances are bit more expensive,
but it's the smallest instance type currently available. Besides that,
we now run Packet E2E tests in the Amsterdam region.

**Optional Release Note**:

```release-note
NONE
```
