### PR TITLE
Update Docker to 19.03.12 for Ubuntu, CentOS, RHEL

### DIFF
--- a/pkg/userdata/centos/testdata/kubelet-v1.17-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-aws-external.yaml
@@ -71,7 +71,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-aws.yaml
@@ -71,7 +71,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-mirrors.yaml
@@ -83,7 +83,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-proxy.yaml
@@ -83,7 +83,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere.yaml
@@ -75,7 +75,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/helper/helper.go
+++ b/pkg/userdata/helper/helper.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
+
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -140,7 +141,7 @@ func DockerVersionApt(kubernetesVersion *semver.Version) (string, error) {
 	}
 
 	lessThen117, _ := semver.NewConstraint("< 1.17")
-	
+
 	if lessThen117.Check(kubernetesVersion) {
 		return "5:18.09.9~3-0~ubuntu-bionic", nil
 	}
@@ -156,7 +157,7 @@ func DockerVersionYum(kubernetesVersion *semver.Version) (string, error) {
 	}
 
 	lessThen117, _ := semver.NewConstraint("< 1.17")
-	
+
 	if lessThen117.Check(kubernetesVersion) {
 		return "18.09.9-3.el7", nil
 	}

--- a/pkg/userdata/helper/helper.go
+++ b/pkg/userdata/helper/helper.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Masterminds/semver"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -130,6 +131,38 @@ func DockerConfig(insecureRegistries, registryMirrors []string) (string, error) 
 
 	b, err := json.Marshal(cfg)
 	return string(b), err
+}
+
+// DockerVersionApt returns Docker version to be installed on instances using apt (Ubuntu).
+func DockerVersionApt(kubernetesVersion *semver.Version) (string, error) {
+	if kubernetesVersion == nil {
+		return "", fmt.Errorf("invalid kubernetes version")
+	}
+
+	lessThen117, _ := semver.NewConstraint("< 1.17")
+	
+	if lessThen117.Check(kubernetesVersion) {
+		return "5:18.09.9~3-0~ubuntu-bionic", nil
+	}
+
+	// return default
+	return "5:19.03.12~3-0~ubuntu-bionic", nil
+}
+
+// DockerVersionYum returns Docker version to be installed on instances using yum (CentOS/RHEL).
+func DockerVersionYum(kubernetesVersion *semver.Version) (string, error) {
+	if kubernetesVersion == nil {
+		return "", fmt.Errorf("invalid kubernetes version")
+	}
+
+	lessThen117, _ := semver.NewConstraint("< 1.17")
+	
+	if lessThen117.Check(kubernetesVersion) {
+		return "18.09.9-3.el7", nil
+	}
+
+	// return default
+	return "19.03.12-3.el7", nil
 }
 
 func ProxyEnvironment(proxy, noProxy string) string {

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -48,6 +48,11 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("invalid kubelet version: %v", err)
 	}
 
+	dockerVersion, err := userdatahelper.DockerVersionYum(kubeletVersion)
+	if err != nil {
+		return "", fmt.Errorf("invalid docker version: %v", err)
+	}
+
 	pconfig, err := providerconfigtypes.GetConfig(req.MachineSpec.ProviderSpec)
 	if err != nil {
 		return "", fmt.Errorf("failed to get provider config: %v", err)
@@ -86,6 +91,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		ProviderSpec     *providerconfigtypes.Config
 		OSConfig         *Config
 		KubeletVersion   string
+		DockerVersion    string
 		ServerAddr       string
 		Kubeconfig       string
 		KubernetesCACert string
@@ -95,6 +101,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		ProviderSpec:     pconfig,
 		OSConfig:         rhelConfig,
 		KubeletVersion:   kubeletVersion.String(),
+		DockerVersion:    dockerVersion,
 		ServerAddr:       serverAddr,
 		Kubeconfig:       kubeconfigString,
 		KubernetesCACert: kubernetesCACert,
@@ -190,7 +197,7 @@ write_files:
 		More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473 */}}
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='{{ .DockerVersion }}'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
@@ -71,7 +71,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
@@ -71,7 +71,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
@@ -83,7 +83,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
@@ -83,7 +83,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
@@ -75,7 +75,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
-    DOCKER_VERSION='18.09.9-3.el7'
+    DOCKER_VERSION='19.03.12-3.el7'
     yum install -y docker-ce-${DOCKER_VERSION} \
       docker-ce-cli-${DOCKER_VERSION} \
       ebtables \

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -49,6 +49,11 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("invalid kubelet version: %v", err)
 	}
 
+	dockerVersion, err := userdatahelper.DockerVersionApt(kubeletVersion)
+	if err != nil {
+		return "", fmt.Errorf("invalid docker version: %v", err)
+	}
+
 	pconfig, err := providerconfigtypes.GetConfig(req.MachineSpec.ProviderSpec)
 	if err != nil {
 		return "", fmt.Errorf("failed to get providerSpec: %v", err)
@@ -88,6 +93,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		OSConfig         *Config
 		ServerAddr       string
 		KubeletVersion   string
+		DockerVersion    string
 		Kubeconfig       string
 		KubernetesCACert string
 		NodeIPScript     string
@@ -97,6 +103,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		OSConfig:         ubuntuConfig,
 		ServerAddr:       serverAddr,
 		KubeletVersion:   kubeletVersion.String(),
+		DockerVersion:    dockerVersion,
 		Kubeconfig:       kubeconfigString,
 		KubernetesCACert: kubernetesCACert,
 		NodeIPScript:     userdatahelper.SetupNodeIPEnvScript(),
@@ -251,7 +258,7 @@ write_files:
 {{- /* We need to explicitly specify docker-ce and docker-ce-cli to the same version.
 	See: https://github.com/docker/cli/issues/2533 */}}
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='{{ .DockerVersion }}'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -139,7 +139,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -137,7 +137,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -137,7 +137,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -139,7 +139,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -137,7 +137,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -137,7 +137,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/version-1.17.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.17.3.yaml
@@ -137,7 +137,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -146,7 +146,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -146,7 +146,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -137,7 +137,7 @@ write_files:
     mv /etc/fstab.noswap /etc/fstab
     swapoff -a
 
-    DOCKER_VERSION='5:18.09.9~3-0~ubuntu-bionic'
+    DOCKER_VERSION='5:19.03.12~3-0~ubuntu-bionic'
     DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install -y \
       curl \
       ca-certificates \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates Docker to 19.03.12 for Ubuntu, CentOS, and RHEL clusters running Kubernetes 1.17 and newer. The clusters running Kubernetes 1.16 and older are using Docker 18.06, as before this change.

The reason for updating Docker is that there is an issue with collecting metrics on 1.19 clusters using Docker 18.06. More details can be found in the following Kubernetes issue: https://github.com/kubernetes/kubernetes/issues/94281

**Special notes for your reviewer**:

* I've decided to go with 19.03.12 as we already use it in KubeOne.
* Flatcar is still using Docker 18.06, as there is no stable release that includes Docker 19.03. There is a beta release that comes with Docker 19.03.11. If users want to use Flatcar with Kubernetes 1.19, and utilize the metrics, they can specify the custom AMI for Flatcar Beta if they're confident using it.
* I'm not sure which version is used by SLES. It seems like SLES comes with Docker, similar to Flatcar, as I don't see that we install it manually.

**Optional Release Note**:
```release-note
Update Docker to 19.03.12 for Ubuntu, CentOS, and RHEL clusters running Kubernetes 1.17 and newer
```

/assign @kron4eg @xrstf 