### PR TITLE
Add support for setting arbitrary feature gates on the kubelet

### DIFF
--- a/pkg/apis/plugin/plugin.go
+++ b/pkg/apis/plugin/plugin.go
@@ -53,7 +53,7 @@ type UserDataRequest struct {
 	PauseImage            string
 	HyperkubeImage        string
 	KubeletRepository     string
-	KubeletFeatureGates   []string
+	KubeletFeatureGates   map[string]bool
 }
 
 // UserDataResponse contains the responded user data.

--- a/pkg/apis/plugin/plugin.go
+++ b/pkg/apis/plugin/plugin.go
@@ -53,6 +53,7 @@ type UserDataRequest struct {
 	PauseImage            string
 	HyperkubeImage        string
 	KubeletRepository     string
+	KubeletFeatureGates   []string
 }
 
 // UserDataResponse contains the responded user data.

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -128,6 +128,10 @@ type NodeSettings struct {
 	HyperkubeImage string
 	// The kubelet repository to use. Currently only Flatcar Linux uses it.
 	KubeletRepository string
+	// Translates to feature gates on the kubelet.
+	// Expected input: FeatureGateName=true|false,...
+	// Default: RotateKubeletServerCertificate=true
+	KubeletFeatureGates []string
 }
 
 type KubeconfigProvider interface {
@@ -699,6 +703,7 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 				PauseImage:            r.nodeSettings.PauseImage,
 				HyperkubeImage:        r.nodeSettings.HyperkubeImage,
 				KubeletRepository:     r.nodeSettings.KubeletRepository,
+				KubeletFeatureGates:   r.nodeSettings.KubeletFeatureGates,
 				NoProxy:               r.nodeSettings.NoProxy,
 				HTTPProxy:             r.nodeSettings.HTTPProxy,
 			}

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -129,9 +129,8 @@ type NodeSettings struct {
 	// The kubelet repository to use. Currently only Flatcar Linux uses it.
 	KubeletRepository string
 	// Translates to feature gates on the kubelet.
-	// Expected input: FeatureGateName=true|false,...
 	// Default: RotateKubeletServerCertificate=true
-	KubeletFeatureGates []string
+	KubeletFeatureGates map[string]bool
 }
 
 type KubeconfigProvider interface {

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -86,26 +86,33 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
+	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
+	if err != nil {
+		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
+	}
+
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec     *providerconfigtypes.Config
-		OSConfig         *Config
-		KubeletVersion   string
-		DockerVersion    string
-		ServerAddr       string
-		Kubeconfig       string
-		KubernetesCACert string
-		NodeIPScript     string
+		ProviderSpec        *providerconfigtypes.Config
+		OSConfig            *Config
+		KubeletVersion      string
+		DockerVersion       string
+		ServerAddr          string
+		Kubeconfig          string
+		KubernetesCACert    string
+		KubeletFeatureGates map[string]bool
+		NodeIPScript        string
 	}{
-		UserDataRequest:  req,
-		ProviderSpec:     pconfig,
-		OSConfig:         centosConfig,
-		KubeletVersion:   kubeletVersion.String(),
-		DockerVersion:    dockerVersion,
-		ServerAddr:       serverAddr,
-		Kubeconfig:       kubeconfigString,
-		KubernetesCACert: kubernetesCACert,
-		NodeIPScript:     userdatahelper.SetupNodeIPEnvScript(),
+		UserDataRequest:     req,
+		ProviderSpec:        pconfig,
+		OSConfig:            centosConfig,
+		KubeletVersion:      kubeletVersion.String(),
+		DockerVersion:       dockerVersion,
+		ServerAddr:          serverAddr,
+		Kubeconfig:          kubeconfigString,
+		KubernetesCACert:    kubernetesCACert,
+		KubeletFeatureGates: kubeletFeatureGates,
+		NodeIPScript:        userdatahelper.SetupNodeIPEnvScript(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -261,7 +268,7 @@ write_files:
 
 - path: "/etc/kubernetes/kubelet.conf"
   content: |
-{{ kubeletConfiguration "cluster.local" .DNSIPs | indent 4 }}
+{{ kubeletConfiguration "cluster.local" .DNSIPs .KubeletFeatureGates | indent 4 }}
 
 - path: "/etc/kubernetes/pki/ca.crt"
   content: |

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -86,33 +86,26 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
-	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
-	if err != nil {
-		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
-	}
-
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec        *providerconfigtypes.Config
-		OSConfig            *Config
-		KubeletVersion      string
-		DockerVersion       string
-		ServerAddr          string
-		Kubeconfig          string
-		KubernetesCACert    string
-		KubeletFeatureGates map[string]bool
-		NodeIPScript        string
+		ProviderSpec     *providerconfigtypes.Config
+		OSConfig         *Config
+		KubeletVersion   string
+		DockerVersion    string
+		ServerAddr       string
+		Kubeconfig       string
+		KubernetesCACert string
+		NodeIPScript     string
 	}{
-		UserDataRequest:     req,
-		ProviderSpec:        pconfig,
-		OSConfig:            centosConfig,
-		KubeletVersion:      kubeletVersion.String(),
-		DockerVersion:       dockerVersion,
-		ServerAddr:          serverAddr,
-		Kubeconfig:          kubeconfigString,
-		KubernetesCACert:    kubernetesCACert,
-		KubeletFeatureGates: kubeletFeatureGates,
-		NodeIPScript:        userdatahelper.SetupNodeIPEnvScript(),
+		UserDataRequest:  req,
+		ProviderSpec:     pconfig,
+		OSConfig:         centosConfig,
+		KubeletVersion:   kubeletVersion.String(),
+		DockerVersion:    dockerVersion,
+		ServerAddr:       serverAddr,
+		Kubeconfig:       kubeconfigString,
+		KubernetesCACert: kubernetesCACert,
+		NodeIPScript:     userdatahelper.SetupNodeIPEnvScript(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/pkg/userdata/centos/provider_test.go
+++ b/pkg/userdata/centos/provider_test.go
@@ -194,6 +194,10 @@ func TestUserDataGeneration(t *testing.T) {
 	}
 	provider := Provider{}
 
+	kubeletFeatureGates := map[string]bool{
+		"RotateKubeletServerCertificate": true,
+	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			emtpyProviderSpec := clusterv1alpha1.ProviderSpec{
@@ -227,6 +231,7 @@ func TestUserDataGeneration(t *testing.T) {
 				InsecureRegistries:    test.insecureRegistries,
 				RegistryMirrors:       test.registryMirrors,
 				PauseImage:            test.pauseImage,
+				KubeletFeatureGates:   kubeletFeatureGates,
 			}
 			s, err := provider.UserData(req)
 			if err != nil {

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -86,11 +86,6 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		coreosConfig.DisableUpdateEngine = true
 	}
 
-	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
-	if err != nil {
-		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
-	}
-
 	data := struct {
 		plugin.UserDataRequest
 		ProviderSpec           *providerconfigtypes.Config
@@ -98,7 +93,6 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		Kubeconfig             string
 		KubernetesCACert       string
 		KubeletVersion         string
-		KubeletFeatureGates    map[string]bool
 		InsecureHyperkubeImage bool
 		NodeIPScript           string
 	}{
@@ -108,7 +102,6 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		Kubeconfig:             kubeconfigString,
 		KubernetesCACert:       kubernetesCACert,
 		KubeletVersion:         kubeletVersion.String(),
-		KubeletFeatureGates:    kubeletFeatureGates,
 		InsecureHyperkubeImage: insecureHyperkubeImage,
 		NodeIPScript:           userdatahelper.SetupNodeIPEnvScript(),
 	}

--- a/pkg/userdata/coreos/provider.go
+++ b/pkg/userdata/coreos/provider.go
@@ -86,6 +86,11 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		coreosConfig.DisableUpdateEngine = true
 	}
 
+	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
+	if err != nil {
+		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
+	}
+
 	data := struct {
 		plugin.UserDataRequest
 		ProviderSpec           *providerconfigtypes.Config
@@ -93,6 +98,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		Kubeconfig             string
 		KubernetesCACert       string
 		KubeletVersion         string
+		KubeletFeatureGates    map[string]bool
 		InsecureHyperkubeImage bool
 		NodeIPScript           string
 	}{
@@ -102,6 +108,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		Kubeconfig:             kubeconfigString,
 		KubernetesCACert:       kubernetesCACert,
 		KubeletVersion:         kubeletVersion.String(),
+		KubeletFeatureGates:    kubeletFeatureGates,
 		InsecureHyperkubeImage: insecureHyperkubeImage,
 		NodeIPScript:           userdatahelper.SetupNodeIPEnvScript(),
 	}
@@ -296,7 +303,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-{{ kubeletConfiguration "cluster.local" .DNSIPs | indent 10 }}
+{{ kubeletConfiguration "cluster.local" .DNSIPs .KubeletFeatureGates | indent 10 }}
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/coreos/provider_test.go
+++ b/pkg/userdata/coreos/provider_test.go
@@ -437,6 +437,10 @@ func TestUserDataGeneration(t *testing.T) {
 		},
 	}
 
+	kubeletFeatureGates := map[string]bool{
+		"RotateKubeletServerCertificate": true,
+	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			rProviderSpec := test.providerSpec
@@ -477,6 +481,7 @@ func TestUserDataGeneration(t *testing.T) {
 				RegistryMirrors:       test.registryMirrors,
 				PauseImage:            test.pauseImage,
 				HyperkubeImage:        test.hyperkubeImage,
+				KubeletFeatureGates:   kubeletFeatureGates,
 			}
 
 			s, err := provider.UserData(req)

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -91,31 +91,24 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 	}
 	kubeletImage = kubeletImage + ":v" + kubeletVersion.String()
 
-	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
-	if err != nil {
-		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
-	}
-
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec        *providerconfigtypes.Config
-		FlatcarConfig       *Config
-		Kubeconfig          string
-		KubernetesCACert    string
-		KubeletImage        string
-		KubeletVersion      string
-		KubeletFeatureGates map[string]bool
-		NodeIPScript        string
+		ProviderSpec     *providerconfigtypes.Config
+		FlatcarConfig    *Config
+		Kubeconfig       string
+		KubernetesCACert string
+		KubeletImage     string
+		KubeletVersion   string
+		NodeIPScript     string
 	}{
-		UserDataRequest:     req,
-		ProviderSpec:        pconfig,
-		FlatcarConfig:       flatcarConfig,
-		Kubeconfig:          kubeconfigString,
-		KubernetesCACert:    kubernetesCACert,
-		KubeletImage:        kubeletImage,
-		KubeletVersion:      kubeletVersion.String(),
-		KubeletFeatureGates: kubeletFeatureGates,
-		NodeIPScript:        userdatahelper.SetupNodeIPEnvScript(),
+		UserDataRequest:  req,
+		ProviderSpec:     pconfig,
+		FlatcarConfig:    flatcarConfig,
+		Kubeconfig:       kubeconfigString,
+		KubernetesCACert: kubernetesCACert,
+		KubeletImage:     kubeletImage,
+		KubeletVersion:   kubeletVersion.String(),
+		NodeIPScript:     userdatahelper.SetupNodeIPEnvScript(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -91,24 +91,31 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 	}
 	kubeletImage = kubeletImage + ":v" + kubeletVersion.String()
 
+	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
+	if err != nil {
+		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
+	}
+
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec     *providerconfigtypes.Config
-		FlatcarConfig    *Config
-		Kubeconfig       string
-		KubernetesCACert string
-		KubeletImage     string
-		KubeletVersion   string
-		NodeIPScript     string
+		ProviderSpec        *providerconfigtypes.Config
+		FlatcarConfig       *Config
+		Kubeconfig          string
+		KubernetesCACert    string
+		KubeletImage        string
+		KubeletVersion      string
+		KubeletFeatureGates map[string]bool
+		NodeIPScript        string
 	}{
-		UserDataRequest:  req,
-		ProviderSpec:     pconfig,
-		FlatcarConfig:    flatcarConfig,
-		Kubeconfig:       kubeconfigString,
-		KubernetesCACert: kubernetesCACert,
-		KubeletImage:     kubeletImage,
-		KubeletVersion:   kubeletVersion.String(),
-		NodeIPScript:     userdatahelper.SetupNodeIPEnvScript(),
+		UserDataRequest:     req,
+		ProviderSpec:        pconfig,
+		FlatcarConfig:       flatcarConfig,
+		Kubeconfig:          kubeconfigString,
+		KubernetesCACert:    kubernetesCACert,
+		KubeletImage:        kubeletImage,
+		KubeletVersion:      kubeletVersion.String(),
+		KubeletFeatureGates: kubeletFeatureGates,
+		NodeIPScript:        userdatahelper.SetupNodeIPEnvScript(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -304,7 +311,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-{{ kubeletConfiguration "cluster.local" .DNSIPs | indent 10 }}
+{{ kubeletConfiguration "cluster.local" .DNSIPs .KubeletFeatureGates | indent 10 }}
 
     - path: /opt/load-kernel-modules.sh
       filesystem: root

--- a/pkg/userdata/flatcar/provider_test.go
+++ b/pkg/userdata/flatcar/provider_test.go
@@ -81,6 +81,10 @@ kPe6XoSbiLm/kxk32T0=
 			},
 		},
 	}
+
+	kubeletFeatureGates = map[string]bool{
+		"RotateKubeletServerCertificate": true,
+	}
 )
 
 // fakeCloudConfigProvider simulates cloud config provider for test.
@@ -223,6 +227,7 @@ func TestUserDataGeneration(t *testing.T) {
 				PauseImage:            test.pauseImage,
 				HyperkubeImage:        test.hyperkubeImage,
 				KubeletRepository:     test.kubeletImage,
+				KubeletFeatureGates:   kubeletFeatureGates,
 			}
 
 			s, err := provider.UserData(req)

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -216,28 +215,6 @@ func KubeletFlags(version, cloudProvider, hostname string, dnsIPs []net.IP, exte
 	}
 
 	return b.String(), nil
-}
-
-// KubeletFeatureGates converts a feature gates slices to a map
-func KubeletFeatureGates(featureGates []string) (map[string]bool, error) {
-	featureGatesMap := map[string]bool{}
-	for _, featureGate := range featureGates {
-		featureGateArr := strings.Split(featureGate, "=")
-		if len(featureGateArr) != 2 {
-			return nil, fmt.Errorf("invalid kubelet feature gate: %q", featureGate)
-		}
-		featureGateEnable, err := strconv.ParseBool(featureGateArr[1])
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse kubelet feature gate: %q", featureGate)
-		}
-
-		featureGatesMap[featureGateArr[0]] = featureGateEnable
-	}
-	if len(featureGatesMap) == 0 {
-		featureGatesMap["RotateKubeletServerCertificate"] = true
-	}
-
-	return featureGatesMap, nil
 }
 
 // KubeletHealthCheckSystemdUnit kubelet health checking systemd unit

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -86,33 +86,26 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
-	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
-	if err != nil {
-		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
-	}
-
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec        *providerconfigtypes.Config
-		OSConfig            *Config
-		KubeletVersion      string
-		DockerVersion       string
-		ServerAddr          string
-		Kubeconfig          string
-		KubernetesCACert    string
-		KubeletFeatureGates map[string]bool
-		NodeIPScript        string
+		ProviderSpec     *providerconfigtypes.Config
+		OSConfig         *Config
+		KubeletVersion   string
+		DockerVersion    string
+		ServerAddr       string
+		Kubeconfig       string
+		KubernetesCACert string
+		NodeIPScript     string
 	}{
-		UserDataRequest:     req,
-		ProviderSpec:        pconfig,
-		OSConfig:            rhelConfig,
-		KubeletVersion:      kubeletVersion.String(),
-		DockerVersion:       dockerVersion,
-		ServerAddr:          serverAddr,
-		Kubeconfig:          kubeconfigString,
-		KubernetesCACert:    kubernetesCACert,
-		KubeletFeatureGates: kubeletFeatureGates,
-		NodeIPScript:        userdatahelper.SetupNodeIPEnvScript(),
+		UserDataRequest:  req,
+		ProviderSpec:     pconfig,
+		OSConfig:         rhelConfig,
+		KubeletVersion:   kubeletVersion.String(),
+		DockerVersion:    dockerVersion,
+		ServerAddr:       serverAddr,
+		Kubeconfig:       kubeconfigString,
+		KubernetesCACert: kubernetesCACert,
+		NodeIPScript:     userdatahelper.SetupNodeIPEnvScript(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/pkg/userdata/rhel/provider_test.go
+++ b/pkg/userdata/rhel/provider_test.go
@@ -194,6 +194,10 @@ func TestUserDataGeneration(t *testing.T) {
 	}
 	provider := Provider{}
 
+	kubeletFeatureGates := map[string]bool{
+		"RotateKubeletServerCertificate": true,
+	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			emtpyProviderSpec := clusterv1alpha1.ProviderSpec{
@@ -227,6 +231,7 @@ func TestUserDataGeneration(t *testing.T) {
 				InsecureRegistries:    test.insecureRegistries,
 				RegistryMirrors:       test.registryMirrors,
 				PauseImage:            test.pauseImage,
+				KubeletFeatureGates:   kubeletFeatureGates,
 			}
 			s, err := provider.UserData(req)
 			if err != nil {

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -82,31 +82,24 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
-	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
-	if err != nil {
-		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
-	}
-
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec        *providerconfigtypes.Config
-		OSConfig            *Config
-		ServerAddr          string
-		KubeletVersion      string
-		Kubeconfig          string
-		KubernetesCACert    string
-		KubeletFeatureGates map[string]bool
-		NodeIPScript        string
+		ProviderSpec     *providerconfigtypes.Config
+		OSConfig         *Config
+		ServerAddr       string
+		KubeletVersion   string
+		Kubeconfig       string
+		KubernetesCACert string
+		NodeIPScript     string
 	}{
-		UserDataRequest:     req,
-		ProviderSpec:        pconfig,
-		OSConfig:            slesConfig,
-		ServerAddr:          serverAddr,
-		KubeletVersion:      kubeletVersion.String(),
-		Kubeconfig:          kubeconfigString,
-		KubernetesCACert:    kubernetesCACert,
-		KubeletFeatureGates: kubeletFeatureGates,
-		NodeIPScript:        userdatahelper.SetupNodeIPEnvScript(),
+		UserDataRequest:  req,
+		ProviderSpec:     pconfig,
+		OSConfig:         slesConfig,
+		ServerAddr:       serverAddr,
+		KubeletVersion:   kubeletVersion.String(),
+		Kubeconfig:       kubeconfigString,
+		KubernetesCACert: kubernetesCACert,
+		NodeIPScript:     userdatahelper.SetupNodeIPEnvScript(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -82,24 +82,31 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
+	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
+	if err != nil {
+		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
+	}
+
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec     *providerconfigtypes.Config
-		OSConfig         *Config
-		ServerAddr       string
-		KubeletVersion   string
-		Kubeconfig       string
-		KubernetesCACert string
-		NodeIPScript     string
+		ProviderSpec        *providerconfigtypes.Config
+		OSConfig            *Config
+		ServerAddr          string
+		KubeletVersion      string
+		Kubeconfig          string
+		KubernetesCACert    string
+		KubeletFeatureGates map[string]bool
+		NodeIPScript        string
 	}{
-		UserDataRequest:  req,
-		ProviderSpec:     pconfig,
-		OSConfig:         slesConfig,
-		ServerAddr:       serverAddr,
-		KubeletVersion:   kubeletVersion.String(),
-		Kubeconfig:       kubeconfigString,
-		KubernetesCACert: kubernetesCACert,
-		NodeIPScript:     userdatahelper.SetupNodeIPEnvScript(),
+		UserDataRequest:     req,
+		ProviderSpec:        pconfig,
+		OSConfig:            slesConfig,
+		ServerAddr:          serverAddr,
+		KubeletVersion:      kubeletVersion.String(),
+		Kubeconfig:          kubeconfigString,
+		KubernetesCACert:    kubernetesCACert,
+		KubeletFeatureGates: kubeletFeatureGates,
+		NodeIPScript:        userdatahelper.SetupNodeIPEnvScript(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)
@@ -241,7 +248,7 @@ write_files:
 
 - path: "/etc/kubernetes/kubelet.conf"
   content: |
-{{ kubeletConfiguration "cluster.local" .DNSIPs | indent 4 }}
+{{ kubeletConfiguration "cluster.local" .DNSIPs .KubeletFeatureGates | indent 4 }}
 
 - path: "/etc/profile.d/opt-bin-path.sh"
   permissions: "0644"

--- a/pkg/userdata/sles/provider_test.go
+++ b/pkg/userdata/sles/provider_test.go
@@ -85,6 +85,10 @@ kPe6XoSbiLm/kxk32T0=
 			},
 		},
 	}
+
+	kubeletFeatureGates = map[string]bool{
+		"RotateKubeletServerCertificate": true,
+	}
 )
 
 const (
@@ -442,6 +446,7 @@ func TestUserDataGeneration(t *testing.T) {
 				InsecureRegistries:    test.insecureRegistries,
 				RegistryMirrors:       test.registryMirrors,
 				PauseImage:            test.pauseImage,
+				KubeletFeatureGates:   kubeletFeatureGates,
 			}
 			s, err := provider.UserData(req)
 			if err != nil {

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -87,33 +87,26 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		return "", fmt.Errorf("error extracting cacert: %v", err)
 	}
 
-	kubeletFeatureGates, err := userdatahelper.KubeletFeatureGates(req.KubeletFeatureGates)
-	if err != nil {
-		return "", fmt.Errorf("error extracting kubelet feature gates: %v", err)
-	}
-
 	data := struct {
 		plugin.UserDataRequest
-		ProviderSpec        *providerconfigtypes.Config
-		OSConfig            *Config
-		ServerAddr          string
-		KubeletVersion      string
-		DockerVersion       string
-		Kubeconfig          string
-		KubernetesCACert    string
-		KubeletFeatureGates map[string]bool
-		NodeIPScript        string
+		ProviderSpec     *providerconfigtypes.Config
+		OSConfig         *Config
+		ServerAddr       string
+		KubeletVersion   string
+		DockerVersion    string
+		Kubeconfig       string
+		KubernetesCACert string
+		NodeIPScript     string
 	}{
-		UserDataRequest:     req,
-		ProviderSpec:        pconfig,
-		OSConfig:            ubuntuConfig,
-		ServerAddr:          serverAddr,
-		KubeletVersion:      kubeletVersion.String(),
-		DockerVersion:       dockerVersion,
-		Kubeconfig:          kubeconfigString,
-		KubernetesCACert:    kubernetesCACert,
-		KubeletFeatureGates: kubeletFeatureGates,
-		NodeIPScript:        userdatahelper.SetupNodeIPEnvScript(),
+		UserDataRequest:  req,
+		ProviderSpec:     pconfig,
+		OSConfig:         ubuntuConfig,
+		ServerAddr:       serverAddr,
+		KubeletVersion:   kubeletVersion.String(),
+		DockerVersion:    dockerVersion,
+		Kubeconfig:       kubeconfigString,
+		KubernetesCACert: kubernetesCACert,
+		NodeIPScript:     userdatahelper.SetupNodeIPEnvScript(),
 	}
 	b := &bytes.Buffer{}
 	err = tmpl.Execute(b, data)

--- a/pkg/userdata/ubuntu/provider_test.go
+++ b/pkg/userdata/ubuntu/provider_test.go
@@ -84,6 +84,10 @@ kPe6XoSbiLm/kxk32T0=
 			},
 		},
 	}
+
+	kubeletFeatureGates = map[string]bool{
+		"RotateKubeletServerCertificate": true,
+	}
 )
 
 const (
@@ -441,6 +445,7 @@ func TestUserDataGeneration(t *testing.T) {
 				InsecureRegistries:    test.insecureRegistries,
 				RegistryMirrors:       test.registryMirrors,
 				PauseImage:            test.pauseImage,
+				KubeletFeatureGates:   kubeletFeatureGates,
 			}
 			s, err := provider.UserData(req)
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for setting (enabling and disabling) arbitrary feature gates on the Kubelet. This is useful in scenarios when an user needs to enable some cluster features that are disabled by default and/or provider-specific, such as CSI Migration.

The feature gates are enabled by setting the `--node-kubelet-feature-gates` flag on machine-controller. The feature gates are provided in the same format as to other Kubernetes components, i.e. key/value pair where the key is the feature gate name and the value is `true` or `false`. Currently, the feature gates are set on **all** machines/nodes, i.e. it's not possible to do it for a subset of machines.

Example usage: `./machine-controller --node-kubelet-feature-gates=CSIMigration=true,CSIMigrationAWS=true ...`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Relevant to https://github.com/kubermatic/kubeone/issues/616

**Optional Release Note**:
```release-note
Add the --node-kubelet-feature-gates flag to allow setting arbitrary feature gates on the kubelet
```

/assign @kron4eg 