### PR TITLE
Disable CoreOS E2E tests on GCE and DigitalOcean

### DIFF
--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -329,7 +329,7 @@ func TestGCEProvisioningE2E(t *testing.T) {
 	}
 
 	// Act. GCE does not support CentOS.
-	selector := OsSelector("ubuntu", "coreos")
+	selector := OsSelector("ubuntu")
 	params := []string{
 		fmt.Sprintf("<< GOOGLE_SERVICE_ACCOUNT >>=%s", googleServiceAccount),
 	}

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -160,7 +160,7 @@ func TestDigitalOceanProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, DO_E2E_TESTS_TOKEN environement varialbe cannot be empty")
 	}
 
-	selector := Not(OsSelector("sles", "rhel", "flatcar"))
+	selector := Not(OsSelector("sles", "rhel", "flatcar", "coreos"))
 	// act
 	params := []string{fmt.Sprintf("<< DIGITALOCEAN_TOKEN >>=%s", doToken)}
 	runScenarios(t, selector, params, DOManifest, fmt.Sprintf("do-%s", *testRunIdentifier))


### PR DESCRIPTION
**What this PR does / why we need it**:

It appears that GCE and DigitalOcean have removed the CoreOS images, causing our E2E tests to fail.

The GCE Machine object is showing the following error:

```
An error of type = InvalidConfiguration, with message = Failed to insert instance: googleapi: Error 404: The resource 'projects/coreos-cloud/global/images/family/coreos-stable' was not found, notFound occurred
```

The DigitalOcean Machine object is showing the following error:

```
failed to create machine at cloudprovider, due to POST https://api.digitalocean.com/v2/droplets: 422 You specified an invalid image for Droplet creation.
```

**Optional Release Note**:
```release-note
NONE
```