### PR TITLE
Fix hanging reboot on auto update.

### DIFF
--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -395,6 +395,7 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
+{{- if not .FlatcarConfig.DisableAutoUpdate }}
     - path: "/etc/polkit-1/rules.d/60-noreboot_norestart.rule"
       filesystem: root
       mode: 0644
@@ -410,6 +411,7 @@ storage:
                   }
               }
           });
+{{- end }}
 
     - path: /etc/docker/daemon.json
       filesystem: root

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -395,6 +395,22 @@ storage:
           PasswordAuthentication no
           ChallengeResponseAuthentication no
 
+    - path: "/etc/polkit-1/rules.d/60-noreboot_norestart.rule"
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          polkit.addRule(function(action, subject) {
+              if (action.id == "org.freedesktop.login1.reboot" ||
+                  action.id == "org.freedesktop.login1.reboot-multiple-sessions") {
+                  if (subject.user == "core") {
+                      return polkit.Result.YES;
+                  } else {
+                      return polkit.Result.AUTH_ADMIN;
+                  }
+              }
+          });
+
     - path: /etc/docker/daemon.json
       filesystem: root
       mode: 0644


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the polkit permission required for the user to reboot the machine. The user runs [flatcar-update-operator ](https://github.com/kinvolk/flatcar-linux-update-operator)and needs permissions to reboot the machine when flatcar-update-controller receives a signal for the OS to update.

**Special notes for your reviewer**:
The polkit rule is based on this issue on flatcar-update-operator https://github.com/kinvolk/flatcar-linux-update-operator/issues/18. There was no need to add the second rule for dbus since only the core user must be allowed to reboot the machine.

### Testing:
Login with the user `core` in a flatcar machine and try to send the message that the update operator and send a dbus message to reboot the machine:
```
dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1 "org.freedesktop.login1.Manager.Reboot" boolean:true
```
The machine does not reboot if the changes are not applied and the following message is printed to stderr:
```
Error org.freedesktop.DBus.Error.InteractiveAuthorizationRequired: Interactive authentication required.
```

Apply the file added by this PR on the machines as root:
```
cat <<EOF >/etc/polkit-1/rules.d/60-noreboot_norestart.rules
polkit.addRule(function(action, subject) {
  if (action.id == "org.freedesktop.login1.reboot" ||
    action.id == "org.freedesktop.login1.reboot-multiple-sessions") {
      if (subject.user == "core") {
        return polkit.Result.YES;
      } else {
        return polkit.Result.AUTH_ADMIN;
      }
  }
});
```
Restart polkit and dbus:
```
systemctl restart dbus
systemctl restart polkit
```
Send the message again:
```
dbus-send --system --print-reply --dest=org.freedesktop.login1 /org/freedesktop/login1
```
Now, the machine should be rebooted.

**Release notes**
```release-note
NONE
```
