### PR TITLE
Disable CoreOS E2E tests on AWS

### DIFF
--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -177,7 +177,7 @@ func TestAWSProvisioningE2E(t *testing.T) {
 	if len(awsKeyID) == 0 || len(awsSecret) == 0 {
 		t.Fatal("unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
 	}
-	selector := Not(OsSelector("sles"))
+	selector := Not(OsSelector("sles", "coreos"))
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
 		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR disables CoreOS E2E tests on AWS, as AWS has deleted the CoreOS AMIs. We've done the same for GCP and DigitalOcean in #822.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Relevant to #822 #823

**Optional Release Note**:
```release-note
NONE
```
