### PR TITLE
Fix releasever to 7 for RHEL and CentOS in yum docker repository

### DIFF
--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -195,6 +195,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 {{- /*	Due to DNF modules we have to do this on docker-ce repo
 		More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473 */}}
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
 {{- /* We need to explicitly specify docker-ce and docker-ce-cli to the same version.

--- a/pkg/userdata/centos/testdata/kubelet-v1.15-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.15-aws.yaml
@@ -69,6 +69,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'

--- a/pkg/userdata/centos/testdata/kubelet-v1.16-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.16-aws.yaml
@@ -69,6 +69,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-aws-external.yaml
@@ -69,6 +69,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-aws.yaml
@@ -69,6 +69,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-mirrors.yaml
@@ -81,6 +81,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere-proxy.yaml
@@ -81,6 +81,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.17-vsphere.yaml
@@ -73,6 +73,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -195,6 +195,7 @@ write_files:
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
 {{- /*	Due to DNF modules we have to do this on docker-ce repo
 		More info at: https://bugzilla.redhat.com/show_bug.cgi?id=1756473 */}}
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='{{ .DockerVersion }}'

--- a/pkg/userdata/rhel/testdata/kubelet-v1.15-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.15-aws.yaml
@@ -69,6 +69,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'

--- a/pkg/userdata/rhel/testdata/kubelet-v1.16-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.16-aws.yaml
@@ -69,6 +69,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='18.09.9-3.el7'

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws-external.yaml
@@ -69,6 +69,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
@@ -69,6 +69,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-mirrors.yaml
@@ -81,6 +81,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere-proxy.yaml
@@ -81,6 +81,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-vsphere.yaml
@@ -73,6 +73,7 @@ write_files:
 
     yum install -y yum-utils
     yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    sed -i 's/\$releasever/7/g' /etc/yum.repos.d/docker-ce.repo
     yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
 
     DOCKER_VERSION='19.03.12-3.el7'

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -177,7 +177,7 @@ func TestAWSProvisioningE2E(t *testing.T) {
 	if len(awsKeyID) == 0 || len(awsSecret) == 0 {
 		t.Fatal("unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
 	}
-	selector := Not(OsSelector("sles"))
+	selector := Not(OsSelector("coreos", "sles"))
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
 		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),
@@ -271,7 +271,7 @@ func TestAzureProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET environment variables cannot be empty")
 	}
 
-	selector := Not(OsSelector("sles"))
+	selector := Not(OsSelector("coreos", "sles"))
 	// act
 	params := []string{
 		fmt.Sprintf("<< AZURE_TENANT_ID >>=%s", azureTenantID),


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently docker introduced `docker-ce` repository for CentOS 8 it only contains docker version `19.03.13-3`. This caused a regression when using RHEL/CentOS 8, because previously we were using CentOS 7 repo indistinctly for CentOS/RHEL 7/8 but now the docker versions we were installing are no longer available in CentOS 8 repo.

As we do not have OS versioning yet the quick and dirty solution is to always use CentOS 7 repo for the docker versions that are not available on both repos.

https://download.docker.com/linux/centos/8/x86_64/stable/Packages/
https://download.docker.com/linux/centos/7/x86_64/stable/Packages/


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix docker installation for CentOS/RHEL 8
```
