### PR TITLE
Fix polkit rules filename for flatcar reboot.

### DIFF
--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -396,7 +396,7 @@ storage:
           ChallengeResponseAuthentication no
 
 {{- if not .FlatcarConfig.DisableAutoUpdate }}
-    - path: "/etc/polkit-1/rules.d/60-noreboot_norestart.rule"
+    - path: "/etc/polkit-1/rules.d/60-noreboot_norestart.rules"
       filesystem: root
       mode: 0644
       contents:


### PR DESCRIPTION
**What this PR does / why we need it**:

This bug was introduced in https://github.com/kubermatic/machine-controller/pull/824.
The name of the file to be created must be suffixed with `.rules` instead of `.rule`

**Optional Release Note**:

```release-note
Fix polkit rule filename to allow `core` user to rebbot machine for auto updates.
```
