### PR TITLE
Use Hyperkube Kubelet for 1.18 clusters

### DIFF
--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	lessThen118Check = "< 1.18"
+	lessThen119Check = "< 1.19"
 )
 
 // Provider is a pkg/userdata/plugin.Provider implementation.
@@ -81,12 +81,12 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 	}
 
 	kubeletImage := req.KubeletRepository
-	lessThen118, err := semver.NewConstraint(lessThen118Check)
+	lessThen119, err := semver.NewConstraint(lessThen119Check)
 	if err != nil {
 		return "", err
 	}
 
-	if lessThen118.Check(kubeletVersion) {
+	if lessThen119.Check(kubeletVersion) {
 		kubeletImage = req.HyperkubeImage
 	}
 	kubeletImage = kubeletImage + ":v" + kubeletVersion.String()

--- a/pkg/userdata/flatcar/provider_test.go
+++ b/pkg/userdata/flatcar/provider_test.go
@@ -150,8 +150,8 @@ func TestUserDataGeneration(t *testing.T) {
 			osConfig: &Config{
 				DisableAutoUpdate: true,
 			},
-			hyperkubeImage: "for-kubernetes-less-then-1.18/hyperkubeImage",
-			kubeletImage:   "for-kubernetes-more-then-1.18/kubeletImage",
+			hyperkubeImage: "for-kubernetes-less-then-1.19/hyperkubeImage",
+			kubeletImage:   "for-kubernetes-more-then-1.19/kubeletImage",
 		},
 		{
 			name: "v1.18.0",
@@ -181,8 +181,39 @@ func TestUserDataGeneration(t *testing.T) {
 			osConfig: &Config{
 				DisableAutoUpdate: true,
 			},
-			hyperkubeImage: "for-kubernetes-less-then-1.18/hyperkubeImage",
-			kubeletImage:   "for-kubernetes-more-then-1.18/kubeletImage",
+			hyperkubeImage: "for-kubernetes-less-then-1.19/hyperkubeImage",
+			kubeletImage:   "for-kubernetes-more-then-1.19/kubeletImage",
+		},
+		{
+			name: "v1.19.0",
+			providerSpec: &providerconfigtypes.Config{
+				CloudProvider: "vsphere",
+				SSHPublicKeys: []string{"ssh-rsa AAABBB", "ssh-rsa CCCDDD"},
+				Network: &providerconfigtypes.NetworkConfig{
+					CIDR:    "192.168.81.4/24",
+					Gateway: "192.168.81.1",
+					DNS: providerconfigtypes.DNSConfig{
+						Servers: []string{"8.8.8.8"},
+					},
+				},
+			},
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "v1.19.0",
+				},
+			},
+			ccProvider: &fakeCloudConfigProvider{
+				name:   "vsphere",
+				config: "{vsphere-config:true}",
+				err:    nil,
+			},
+			DNSIPs: []net.IP{net.ParseIP("10.10.10.10")},
+			osConfig: &Config{
+				DisableAutoUpdate: true,
+			},
+			hyperkubeImage: "for-kubernetes-less-then-1.19/hyperkubeImage",
+			kubeletImage:   "for-kubernetes-more-then-1.19/kubeletImage",
 		},
 	}
 

--- a/pkg/userdata/flatcar/testdata/v1.18.0.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.18.0.yaml
@@ -144,7 +144,7 @@ systemd:
           -v /var/lib/docker:/var/lib/docker \
           -v /var/lib/kubelet:/var/lib/kubelet:rshared \
           -v /var/log/pods:/var/log/pods \
-          for-kubernetes-more-then-1.18/kubeletImage:v1.18.0 \
+          for-kubernetes-less-then-1.19/hyperkubeImage:v1.18.0 \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \

--- a/pkg/userdata/flatcar/testdata/v1.19.0.yaml
+++ b/pkg/userdata/flatcar/testdata/v1.19.0.yaml
@@ -144,7 +144,7 @@ systemd:
           -v /var/lib/docker:/var/lib/docker \
           -v /var/lib/kubelet:/var/lib/kubelet:rshared \
           -v /var/log/pods:/var/log/pods \
-          for-kubernetes-less-then-1.19/hyperkubeImage:v1.17.0 \
+          for-kubernetes-more-then-1.19/kubeletImage:v1.19.0 \
           --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
           --kubeconfig=/var/lib/kubelet/kubeconfig \
           --config=/etc/kubernetes/kubelet.conf \
@@ -437,7 +437,7 @@ storage:
           tar xvf "$cni_filename"
           rm -f "$cni_filename"
           cd -
-          KUBE_VERSION="${KUBE_VERSION:-v1.17.0}"
+          KUBE_VERSION="${KUBE_VERSION:-v1.19.0}"
           kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
           kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
           kube_sum_file="$kube_dir/sha256"


### PR DESCRIPTION
**What this PR does / why we need it**:

We already use Hyperkube Kubelet for clusters running Kubernetes
1.17 and older. This PR extends this to 1.18, as there are no
Poseidon Kubelet images for the latest 1.18 releases any longer.

**Optional Release Note**:
```release-note
Use Hyperkube Kubelet for 1.18 clusters
```

/assign @kron4eg 