### PR TITLE
Add Anexia Cloud Provider Spec to Machine-Controller 

### DIFF
--- a/examples/anexia-machinedeployment.yaml
+++ b/examples/anexia-machinedeployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: anexia-machinedeployment
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: anexia-machinedeployment
+  template:
+    metadata:
+      labels:
+        name: anexia-machinedeployment
+    spec:
+      providerSpec:
+        value:
+          cloudProvider: anexia
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProviderSpec:
+            # If empty, can be set via ANXCLOUD_TOKEN env var
+            token:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-anexia
+                key: token
+            vlanID: "<< ANEXIA_VLAN_ID >>"
+            # Currently only the flatcar template is supported: 12c28aa7-604d-47e9-83fb-5f1d1f1837b3
+            templateID: "<< ANEXIA_TEMPLATE_ID >>"
+            locationID: "<< ANEXIA_LOCATION_ID >>"
+            cpus: 4
+            memory: 4096
+            diskSize: 20
+          # Flatcar is the only supported operating system
+          operatingSystem: "flatcar"
+          operatingSystemSpec:
+            # Force cloud-init instead of ignition. Anexia supports cloud-init only.
+            provisioningUtility: "cloud-init"
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+      versions:
+        kubelet: "1.19.1"

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+)
+
+type RawConfig struct {
+	Token      providerconfigtypes.ConfigVarString `json:"token,omitempty"`
+	VlanID     providerconfigtypes.ConfigVarString `json:"vlanID"`
+	LocationID providerconfigtypes.ConfigVarString `json:"locationID"`
+	TemplateID providerconfigtypes.ConfigVarString `json:"templateID"`
+	CPUs       int                                 `json:"cpus"`
+	Memory     int                                 `json:"memory"`
+	DiskSize   int                                 `json:"diskSize"`
+}

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -56,6 +56,7 @@ const (
 	CloudProviderVsphere      CloudProvider = "vsphere"
 	CloudProviderFake         CloudProvider = "fake"
 	CloudProviderAlibaba      CloudProvider = "alibaba"
+	CloudProviderAnexia       CloudProvider = "anexia"
 )
 
 var (
@@ -85,6 +86,7 @@ var (
 		CloudProviderVsphere,
 		CloudProviderFake,
 		CloudProviderAlibaba,
+		CloudProviderAnexia,
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**: 
This PR adds the cloud provider spec and configs to the machine controller. Next step will be to the full implementation of the provider api in addition to the e2e tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
