### PR TITLE
Implement a configurable timeout for OpenStack

### DIFF
--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -13,6 +13,8 @@ stringData:
   domainName: << OS_DOMAIN_NAME >>
   tenantName: << OS_TENANT_NAME >>
   region: << OS_REGION_NAME >>
+  instanceReadyCheckPeriod: << INSTANCE_READY_CHECK_PERIOD >>
+  instanceReadyCheckTimeout: << INSTANCE_READY_TIMEOUT >>
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/machinesv1alpha1machine/openstack.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/machinesv1alpha1machine/openstack.yaml
@@ -35,7 +35,7 @@ spec:
           namespace: kube-system
           name: machine-controller-openstack
           key: domainName
-    # If empty, ca be set via OS_TENANT_NAME env var
+   # If empty, ca be set via OS_TENANT_NAME env var
       tenantName:
         secretKeyRef:
           namespace: kube-system
@@ -58,6 +58,10 @@ spec:
       network: ""
       # Only required if the network has more than one subnet
       subnet: ""
+      # Can be increased for slower OpenStack setups. No values below 1m (60s) possible as this makes no sense.
+      instanceReadyCheckPeriod: 2m
+      # Can be increased for slower OpenStack setups. No values below 1m (60s) possible as this makes no sense.
+      instanceReadyCheckTimeout: 2m
       # the list of tags you would like to attach to the instance
       tags:
         tagKey: tagValue

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/openstack.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/openstack.yaml
@@ -25,6 +25,8 @@ spec:
             name: machine-controller-openstack
             namespace: kube-system
         image: Ubuntu 16.04 amd64
+        instanceReadyCheckPeriod: 2m
+        instanceReadyCheckTimeout: 2m
         network: ""
         password:
           secretKeyRef:

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"testing"
 	"text/template"
+	"time"
 
 	cloudprovidertesting "github.com/kubermatic/machine-controller/pkg/cloudprovider/testing"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
@@ -120,6 +121,8 @@ func (o openstackProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 		"nodeVolumeAttachLimit": null,
 		"password": "this_is_a_password",
 		"region": "eu-de",
+		"instanceReadyCheckPeriod": "2m",
+		"instanceReadyCheckTimeout": "2m",
 		{{- if .RootDiskSizeGB }}
 		"rootDiskSizeGB": {{ .RootDiskSizeGB }},
 		{{- end }}
@@ -196,7 +199,7 @@ func TestCreateServer(t *testing.T) {
 					return pc.ProviderClient, nil
 				},
 				// mock server readiness checker
-				serverReadinessWaiter: func(computeClient *gophercloud.ServiceClient, serverID string) error {
+				serverReadinessWaiter: func(computeClient *gophercloud.ServiceClient, serverID string, instanceReadyCheckPeriod time.Duration, instanceReadyCheckTimeout time.Duration) error {
 					return nil
 				},
 			}

--- a/pkg/cloudprovider/provider/openstack/types/types.go
+++ b/pkg/cloudprovider/provider/openstack/types/types.go
@@ -22,14 +22,16 @@ import (
 
 type RawConfig struct {
 	// Auth details
-	IdentityEndpoint providerconfigtypes.ConfigVarString `json:"identityEndpoint,omitempty"`
-	Username         providerconfigtypes.ConfigVarString `json:"username,omitempty"`
-	Password         providerconfigtypes.ConfigVarString `json:"password,omitempty"`
-	DomainName       providerconfigtypes.ConfigVarString `json:"domainName,omitempty"`
-	TenantName       providerconfigtypes.ConfigVarString `json:"tenantName,omitempty"`
-	TenantID         providerconfigtypes.ConfigVarString `json:"tenantID,omitempty"`
-	TokenID          providerconfigtypes.ConfigVarString `json:"tokenId,omitempty"`
-	Region           providerconfigtypes.ConfigVarString `json:"region,omitempty"`
+	IdentityEndpoint          providerconfigtypes.ConfigVarString `json:"identityEndpoint,omitempty"`
+	Username                  providerconfigtypes.ConfigVarString `json:"username,omitempty"`
+	Password                  providerconfigtypes.ConfigVarString `json:"password,omitempty"`
+	DomainName                providerconfigtypes.ConfigVarString `json:"domainName,omitempty"`
+	TenantName                providerconfigtypes.ConfigVarString `json:"tenantName,omitempty"`
+	TenantID                  providerconfigtypes.ConfigVarString `json:"tenantID,omitempty"`
+	TokenID                   providerconfigtypes.ConfigVarString `json:"tokenId,omitempty"`
+	Region                    providerconfigtypes.ConfigVarString `json:"region,omitempty"`
+	InstanceReadyCheckPeriod  providerconfigtypes.ConfigVarString `json:"instanceReadyCheckPeriod,omitempty"`
+	InstanceReadyCheckTimeout providerconfigtypes.ConfigVarString `json:"instanceReadyCheckTimeout,omitempty"`
 
 	// Machine details
 	Image                 providerconfigtypes.ConfigVarString   `json:"image"`

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -130,7 +130,7 @@ func TestOpenstackProvisioningE2E(t *testing.T) {
 	osNetwork := os.Getenv("OS_NETWORK_NAME")
 
 	if osAuthURL == "" || osUsername == "" || osPassword == "" || osDomain == "" || osRegion == "" || osTenant == "" {
-		t.Fatal("unable to run test suite, all of OS_AUTH_URL, OS_USERNAME, OS_PASSOWRD, OS_REGION, OS_TENANT and OS_DOMAIN must be set!")
+		t.Fatal("unable to run test suite, all of OS_AUTH_URL, OS_USERNAME, OS_PASSOWRD, OS_REGION, and OS_TENANT OS_DOMAIN must be set!")
 	}
 
 	params := []string{
@@ -502,7 +502,7 @@ func TestUbuntuProvisioningWithUpgradeE2E(t *testing.T) {
 	osNetwork := os.Getenv("OS_NETWORK_NAME")
 
 	if osAuthURL == "" || osUsername == "" || osPassword == "" || osDomain == "" || osRegion == "" || osTenant == "" {
-		t.Fatal("unable to run test, all of OS_AUTH_URL, OS_USERNAME, OS_PASSOWRD, OS_REGION, OS_TENANT and OS_DOMAIN must be set!")
+		t.Fatal("unable to run test suite, all of OS_AUTH_URL, OS_USERNAME, OS_PASSOWRD, OS_REGION, and OS_TENANT OS_DOMAIN must be set!")
 	}
 
 	params := []string{
@@ -514,6 +514,7 @@ func TestUbuntuProvisioningWithUpgradeE2E(t *testing.T) {
 		fmt.Sprintf("<< TENANT_NAME >>=%s", osTenant),
 		fmt.Sprintf("<< NETWORK_NAME >>=%s", osNetwork),
 	}
+
 	scenario := scenario{
 		name:              "Ubuntu upgrade",
 		osName:            "ubuntu",

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
@@ -36,6 +36,8 @@ spec:
             network: "<< NETWORK_NAME >>"
             rootDiskSizeGB: 10
             rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
+            instanceReadyCheckPeriod: 2m
+            instanceReadyCheckTimeout: 2m
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: true

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
@@ -34,6 +34,8 @@ spec:
             domainName: "<< DOMAIN_NAME >>"
             region: "<< REGION >>"
             network: "<< NETWORK_NAME >>"
+            instanceReadyCheckPeriod: 2m
+            instanceReadyCheckTimeout: 2m
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Make instanceReadyCheckTimeout for OpenStack Provider configurable

**Which issue(s) this PR fixes** 
#819 

**Special notes for your reviewer**:
This haven't been tested properly yet.
It is still work in progress.

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[action required] instanceReadyCheckTimeout `instanceReadyCheckPeriod` and `instanceReadyCheckTimeout` are now configurable to allow alternative Timeouts and Re-Tries. 120s is the default 

```
