### PR TITLE
Refactor the KubeVirt dns settings

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
-
 	kubevirtv1 "kubevirt.io/client-go/api/v1"
 	cdi "kubevirt.io/containerized-data-importer/pkg/apis/core/v1alpha1"
 
@@ -176,16 +174,8 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 			return nil, nil, fmt.Errorf("failed to get dns policy: %v", err)
 		}
 	}
-	dnsConfigString, err := p.configVarResolver.GetConfigVarStringValue(rawConfig.DNSConfig)
-	if err != nil {
-		return nil, nil, fmt.Errorf(`failed to get value of "dnsConfig" field: %v`, err)
-	}
-	if dnsConfigString != "" {
-		dnsConfig := &corev1.PodDNSConfig{}
-		if err := yaml.Unmarshal([]byte(dnsConfigString), &dnsConfig); err != nil {
-			return nil, nil, fmt.Errorf(`failed to unmarshal "dnsConfig" field: %v`, err)
-		}
-		config.DNSConfig = dnsConfig
+	if rawConfig.DNSConfig != nil {
+		config.DNSConfig = rawConfig.DNSConfig
 	}
 
 	return &config, &pconfig, nil

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -18,6 +18,8 @@ package types
 
 import (
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 type RawConfig struct {
@@ -29,5 +31,5 @@ type RawConfig struct {
 	PVCSize          providerconfigtypes.ConfigVarString `json:"pvcSize,omitempty"`
 	StorageClassName providerconfigtypes.ConfigVarString `json:"storageClassName,omitempty"`
 	DNSPolicy        providerconfigtypes.ConfigVarString `json:"dnsPolicy,omitempty"`
-	DNSConfig        providerconfigtypes.ConfigVarString `json:"dnsConfig,omitempty"`
+	DNSConfig        *corev1.PodDNSConfig                `json:"dnsConfig,omitempty"`
 }

--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt-dns-config.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt-dns-config.yaml
@@ -33,9 +33,8 @@ spec:
             memory: "4096M"
             dnsPolicy: "None"
             dnsConfig:
-              value: |
-                nameservers:
-                - 8.8.8.8
+              nameservers:
+              - 8.8.8.8
             kubeconfig:
               value: '<< KUBECONFIG >>'
             namespace: kube-system


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor Kubevirt DNSConfig type from being a raw string to PodDNSConfig. This config is part of kubermatic datacenter configs.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Follow up PR to this issue https://github.com/kubermatic/kubermatic/issues/6121

**Optional Release Note**:
```release-note
Support Kubevirt DNSConfig in Kubermatic 
```
