### PR TITLE
upgrade terraform to 0.13.5

### DIFF
--- a/test/tools/integration/Makefile
+++ b/test/tools/integration/Makefile
@@ -29,7 +29,7 @@ endif
 .PHONY: terraform
 terraform:
 	@if ! which terraform; then \
-		curl https://releases.hashicorp.com/terraform/0.11.11/terraform_0.11.11_linux_amd64.zip \
+		curl https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip \
 			--retry 5 \
 			-o	/tmp/terraform.zip && \
 		unzip -n /tmp/terraform.zip terraform && \

--- a/test/tools/integration/versions.tf
+++ b/test/tools/integration/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    hcloud = {
+      source = "hetznercloud/hcloud"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
E2E tests are broken due to some conflicts in api versions which terraform is using.

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
