### PR TITLE
fix openstack instanceReadyPeriod/Timeout

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -154,13 +154,17 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		return nil, nil, nil, fmt.Errorf("failed to get the value of \"InstanceReadyCheckPeriod\" field, error = %v", err)
 	}
 
-	c.InstanceReadyCheckPeriod, err = time.ParseDuration(instanceReadyCheckPeriodStr)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to parse the value of \"InstanceReadyCheckPeriod\" field (%s), error = %v", instanceReadyCheckPeriodStr, err)
-	}
+	if instanceReadyCheckPeriodStr != "" {
+		c.InstanceReadyCheckPeriod, err = time.ParseDuration(instanceReadyCheckPeriodStr)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to parse the value of \"InstanceReadyCheckPeriod\" field (%s), error = %v", instanceReadyCheckPeriodStr, err)
+		}
 
-	if c.InstanceReadyCheckPeriod < 60*time.Second {
-		c.InstanceReadyCheckPeriod = 120 * time.Second
+		if c.InstanceReadyCheckPeriod < 0 {
+			c.InstanceReadyCheckPeriod = 5 * time.Second
+		}
+	} else {
+		c.InstanceReadyCheckPeriod = 5 * time.Second
 	}
 
 	instanceReadyCheckTimeoutStr, err := p.configVarResolver.GetConfigVarStringValue(rawConfig.InstanceReadyCheckTimeout)
@@ -168,13 +172,17 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		return nil, nil, nil, fmt.Errorf("failed to get the value of \"InstanceReadyCheckTimeout\" field, error = %v", err)
 	}
 
-	c.InstanceReadyCheckTimeout, err = time.ParseDuration(instanceReadyCheckTimeoutStr)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to parse the value of \"InstanceReadyCheckTimeout\" field (%s), error = %v", instanceReadyCheckTimeoutStr, err)
-	}
+	if instanceReadyCheckTimeoutStr != "" {
+		c.InstanceReadyCheckTimeout, err = time.ParseDuration(instanceReadyCheckTimeoutStr)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("failed to parse the value of \"InstanceReadyCheckTimeout\" field (%s), error = %v", instanceReadyCheckTimeoutStr, err)
+		}
 
-	if c.InstanceReadyCheckPeriod < 60*time.Second {
-		c.InstanceReadyCheckPeriod = 120 * time.Second
+		if c.InstanceReadyCheckTimeout < 0 {
+			c.InstanceReadyCheckTimeout = 10 * time.Second
+		}
+	} else {
+		c.InstanceReadyCheckTimeout = 10 * time.Second
 	}
 
 	// We ignore errors here because the OS domain is only required when using Identity API V3

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
@@ -36,7 +36,7 @@ spec:
             network: "<< NETWORK_NAME >>"
             rootDiskSizeGB: 10
             rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
-            instanceReadyCheckPeriod: 2m
+            instanceReadyCheckPeriod: 5s
             instanceReadyCheckTimeout: 2m
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
@@ -34,7 +34,7 @@ spec:
             domainName: "<< DOMAIN_NAME >>"
             region: "<< REGION >>"
             network: "<< NETWORK_NAME >>"
-            instanceReadyCheckPeriod: 2m
+            instanceReadyCheckPeriod: 5s
             instanceReadyCheckTimeout: 2m
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the defaulting logic for Openstack instanceReadyPeriod/Timeout. 

**Optional Release Note**:
```release-note
None 
```
