### PR TITLE
terraform fmt

### DIFF
--- a/test/tools/integration/hetzner.tf
+++ b/test/tools/integration/hetzner.tf
@@ -1,16 +1,16 @@
 provider "hcloud" {
-  token = "${var.hcloud_token}"
+  token = var.hcloud_token
 }
 
 resource "hcloud_ssh_key" "default" {
-  name       = "${var.hcloud_sshkey_name}"
-  public_key = "${var.hcloud_sshkey_content}"
+  name       = var.hcloud_sshkey_name
+  public_key = var.hcloud_sshkey_content
 }
 
 resource "hcloud_server" "machine-controller-test" {
-  name        = "${var.hcloud_test_server_name}"
+  name        = var.hcloud_test_server_name
   image       = "ubuntu-18.04"
   server_type = "cx21"
-  ssh_keys    = ["${hcloud_ssh_key.default.id}"]
+  ssh_keys    = [hcloud_ssh_key.default.id]
   location    = "nbg1"
 }

--- a/test/tools/integration/output.tf
+++ b/test/tools/integration/output.tf
@@ -1,3 +1,3 @@
 output "ip" {
-  value = "${hcloud_server.machine-controller-test.ipv4_address}"
+  value = hcloud_server.machine-controller-test.ipv4_address
 }

--- a/test/tools/integration/versions.tf
+++ b/test/tools/integration/versions.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 0.13"
   required_providers {
     hcloud = {
-      source = "hetznercloud/hcloud"
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.23.0"
     }
   }
-  required_version = ">= 0.13"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Terraform complains about a deprecation:

> Warning: Interpolation-only expressions are deprecated
>
>  on hetzner.tf line 2, in provider "hcloud":
>   2:   token = "${var.hcloud_token}"

Since Terraform 0.14, the `fmt` command takes care of fixing that automatically. This is what this PR does.

**Optional Release Note**:
```release-note
NONE
```
