### PR TITLE
Remove cloud-init flag from the Anexia provider

### DIFF
--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -222,9 +222,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, providerData *cloudprovider
 			networkInterfaces,
 		)
 
-		vm.Script = base64.StdEncoding.EncodeToString(
-			[]byte(fmt.Sprintf("anexia: true\n\n%s", userdata)),
-		)
+		vm.Script = base64.StdEncoding.EncodeToString([]byte(userdata))
 
 		sshKey, err := ssh.NewKey()
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
I was asked to remove this flag since internal changes in Anexia now make this flag counter productive.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
None

**Optional Release Note**:
```release-note
NONE
```
