### PR TITLE
Add gocache and goproxy to CI jobs

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -4,12 +4,15 @@ presubmits:
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    labels:
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
           command:
             - make
           args:
+            - download-gocache
             - all
           resources:
             requests:
@@ -19,6 +22,8 @@ presubmits:
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    labels:
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -34,6 +39,8 @@ presubmits:
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    labels:
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golangci/golangci-lint:v1.23.6
@@ -50,6 +57,8 @@ presubmits:
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    labels:
+      preset-goproxy: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/yamllint:0.1
@@ -61,16 +70,29 @@ presubmits:
             requests:
               cpu: 200m
 
+  - name: pull-machine-controller-verify-boilerplate
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    spec:
+      containers:
+        - image: python:2.7
+          command:
+            - "./hack/verify-boilerplate.sh"
+
   - name: pull-machine-controller-test
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    labels:
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
           command:
             - make
           args:
+            - download-gocache
             - test-unit
           resources:
             requests:
@@ -92,6 +114,7 @@ presubmits:
       preset-vsphere: "true"
       preset-kubevirt: "true"
       preset-alibaba: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -115,6 +138,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-rhel: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -138,6 +162,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-rhel: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -161,6 +186,7 @@ presubmits:
       preset-alibaba: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -183,6 +209,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-rhel: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -205,6 +232,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-rhel: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -226,9 +254,10 @@ presubmits:
       preset-aws: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.15.3
+        - image: golang:1.15.1
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -247,6 +276,7 @@ presubmits:
       preset-digitalocean: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -269,6 +299,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-rhel: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -292,6 +323,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-rhel: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -314,6 +346,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-rhel: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -334,6 +367,7 @@ presubmits:
     labels:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -357,6 +391,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-linode: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -379,6 +414,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-packet: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -401,6 +437,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-cherryservers: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -423,6 +460,7 @@ presubmits:
       preset-e2e-ssh: "true"
       preset-vsphere: "true"
       preset-rhel: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -444,6 +482,7 @@ presubmits:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
       preset-anexia: "true"
+      preset-goproxy: "true"
     spec:
       containers:
       - image: golang:1.15.1
@@ -465,6 +504,7 @@ presubmits:
       preset-openstack: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -485,6 +525,7 @@ presubmits:
     labels:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -498,16 +539,6 @@ presubmits:
               memory: 1Gi
               cpu: 500m
 
-  - name: pull-machine-controller-verify-boilerplate
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
-    spec:
-      containers:
-        - image: python:2.7
-          command:
-            - "./hack/verify-boilerplate.sh"
-
   - name: pull-machine-controller-e2e-aws-ebs-encryption-enabled
     always_run: true
     decorate: true
@@ -517,6 +548,7 @@ presubmits:
       preset-aws: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -538,6 +570,7 @@ presubmits:
       preset-aws: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -559,6 +592,7 @@ presubmits:
       preset-aws: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -580,6 +614,7 @@ presubmits:
       preset-aws: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -602,6 +637,7 @@ presubmits:
       preset-rhel: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -624,6 +660,7 @@ presubmits:
       preset-rhel: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -645,6 +682,7 @@ presubmits:
       preset-scaleway: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: golang:1.15.1
@@ -668,6 +706,7 @@ postsubmits:
       - ^v\d+\.\d+\.\d+.*
     labels:
       preset-docker-push: "true"
+      preset-goproxy: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/go-docker:15.1-1903-0
@@ -679,10 +718,28 @@ postsubmits:
               /usr/local/bin/entrypoint.sh &&
               docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD &&
               docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io &&
-              make docker-image-publish
+              make download-gocache docker-image-publish
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1Gi
+
+  - name: ci-push-machine-controller-upload-gocache
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    branches:
+      - ^master$
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/go-docker:15.1-1903-0
+          command:
+            - "./hack/ci-upload-gocache.sh"
           resources:
             requests:
               cpu: 100m

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,10 @@ test-unit:
 	@#The `-race` flag requires CGO
 	CGO_ENABLED=1 go test -race ./...
 
+.PHONY: build-tests
+build-tests:
+	go test -run nope ./...
+
 .PHONY: e2e-cluster
 e2e-cluster: machine-controller webhook
 	make -C test/tools/integration apply
@@ -149,3 +153,7 @@ deploy: examples/admission-cert.pem
 .PHONY: check-dependencies
 check-dependencies:
 	go mod verify
+
+.PHONY: download-gocache
+download-gocache:
+	@./hack/ci-download-gocache.sh

--- a/hack/ci-download-gocache.sh
+++ b/hack/ci-download-gocache.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Machine Controller Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+# The gocache needs a matching go version to work, so append that to the name
+GO_VERSION="$(go version|awk '{ print $3 }'|sed 's/go//g')"
+
+# Make sure we never error, this is always best-effort only
+exit_gracefully() {
+  if [ $? -ne 0 ]; then
+    echodate "Encountered error when trying to download gocache"
+  fi
+  exit 0
+}
+trap exit_gracefully EXIT
+
+if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
+  echo "env var GOCACHE_MINIO_ADDRESS unset, can not download gocache"
+  exit 0
+fi
+
+GOCACHE="$(go env GOCACHE)"
+# Make sure it actually exists
+mkdir -p "${GOCACHE}"
+
+export CACHE_VERSION="${PULL_BASE_SHA:-}"
+
+# Periodics just use their head ref
+if [[ -z "${CACHE_VERSION}" ]]; then
+  CACHE_VERSION="$(git rev-parse HEAD)"
+fi
+
+if [ -z "${PULL_NUMBER:-}" ]; then
+  # Special case: This is called in a Postubmit. Go one revision back,
+  # as there can't be a cache for the current revision
+  CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
+fi
+
+ARCHIVE_NAME="machine-controller-${CACHE_VERSION}-${GO_VERSION}.tar"
+URL="${GOCACHE_MINIO_ADDRESS}/${ARCHIVE_NAME}"
+
+# Do not go through the retry loop when there is nothing
+if ! curl --head --silent --fail "${URL}" > /dev/null; then
+  echo "Remote has no gocache ${ARCHIVE_NAME}, exiting"
+  exit 0
+fi
+
+echo "Downloading and extracting gocache"
+curl --fail --header "Content-Type: application/octet-stream" "${URL}" | tar -C $GOCACHE -xf -
+
+echo "Successfully fetched gocache into $GOCACHE"

--- a/hack/ci-e2e-test.sh
+++ b/hack/ci-e2e-test.sh
@@ -18,35 +18,35 @@ set -euo pipefail
 set -o monitor
 
 function cleanup {
-    set +e
+  set +e
 
-    # Clean up machines
-    echo "Cleaning up machines."
-    ./test/tools/integration/cleanup_machines.sh
+  # Clean up machines
+  echo "Cleaning up machines."
+  ./test/tools/integration/cleanup_machines.sh
 
-    cd test/tools/integration
-    for try in {1..20}; do
-      # Clean up master
-      echo "Cleaning up controller, attempt ${try}"
-      terraform destroy -force
-      if [[ $? == 0 ]]; then break; fi
-      echo "Sleeping for $try seconds"
-      sleep ${try}s
-    done
+  cd test/tools/integration
+  for try in {1..20}; do
+    # Clean up master
+    echo "Cleaning up controller, attempt ${try}"
+    terraform destroy -force
+    if [[ $? == 0 ]]; then break; fi
+    echo "Sleeping for $try seconds"
+    sleep ${try}s
+  done
 }
 trap cleanup EXIT
 
 # Install dependencies
 echo "Installing dependencies."
 apt update && apt install -y jq rsync unzip genisoimage
-curl --retry 5  -LO \
+curl --retry 5 --location --remote-name \
   https://storage.googleapis.com/kubernetes-release/release/v1.12.4/bin/linux/amd64/kubectl &&
 chmod +x kubectl &&
 mv kubectl /usr/local/bin
 
 # Build binaries
 echo "Building machine-controller and webhook"
-make all
+make download-gocache all
 
 # Copy individual plugins with success control.
 echo "Copying machine-controller plugins"

--- a/hack/ci-upload-gocache.sh
+++ b/hack/ci-upload-gocache.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Machine Controller Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when the script
+# receives a SIGINT
+set -o monitor
+
+cd $(dirname $0)/..
+
+if [ -z "${GOCACHE_MINIO_ADDRESS:-}" ]; then
+  echo "Fatal: env var GOCACHE_MINIO_ADDRESS unset"
+  exit 1
+fi
+
+# The gocache needs a matching go version to work, so append that to the name
+GO_VERSION="$(go version|awk '{ print $3 }'|sed 's/go//g')"
+
+GOCACHE_DIR="$(mktemp -d)"
+export GOCACHE="${GOCACHE_DIR}"
+export GIT_HEAD_HASH="$(git rev-parse HEAD|tr -d '\n')"
+
+echo "Creating cache for revision ${GIT_HEAD_HASH} / Go ${GO_VERSION} ..."
+
+echo "Building binaries"
+make all
+
+echo "Building tests"
+make build-tests
+
+echo "Creating gocache archive"
+ARCHIVE_FILE="/tmp/${GIT_HEAD_HASH}.tar"
+# No compression because that needs quite a bit of CPU
+tar -C "$GOCACHE" -cf "$ARCHIVE_FILE" .
+
+echo "Uploading gocache archive"
+curl \
+  --fail \
+  --upload-file "${ARCHIVE_FILE}" \
+  --header "Content-Type: application/octet-stream" \
+  "${GOCACHE_MINIO_ADDRESS}/machine-controller-${GIT_HEAD_HASH}-${GO_VERSION}.tar"
+
+echo "Upload complete."


### PR DESCRIPTION
**What this PR does / why we need it**:
This saves bandwidth and CPU cycles for all of our tests.

**Optional Release Note**:
```release-note
NONE
```
