### PR TITLE
WIP - Add contexts to cloudprovider interface

### DIFF
--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -106,31 +106,102 @@ func createAdmissionResponse(original, mutated runtime.Object) (*admissionv1beta
 
 type mutator func(context.Context, admissionv1beta1.AdmissionReview) (*admissionv1beta1.AdmissionResponse, error)
 
+// handleFuncFactory wraps a mutator as an HTTP HandlerFunc.
 func handleFuncFactory(mutate mutator) func(http.ResponseWriter, *http.Request) {
+	/*
+		Within the handler we create below, the actual mutation logic is
+		running in a separate goroutine. This is because sometimes some
+		cloud provider APIs are slow, very slow, and the kube-apiserver is
+		impatient and will wait at most 30 seconds (10 by default) for a
+		response.
+
+		To ensure faster responses, we use our CloudproviderCache wrapper,
+		which will cache the results based on the MachineSpec's JSON
+		representation. While this just generally speeds up responses, this
+		becomes *critical* for slow cloud providers. For those, it can happen
+		that no validation ever succeeds within the given timeout. To ensure
+		that these providers can be used at all, we must let the validation run
+		in the background, cache its result and inform the user upon a timeout
+		that the validation is still happening and they should try again later,
+		when we have cached the result.
+
+		We plan the timing below based on a 10s timeout, as this is much less
+		painful for users that would have to wait up to 30s for any kind of
+		feedback for their `kubectl apply` command.
+	*/
 	return func(w http.ResponseWriter, r *http.Request) {
-		// cancel any validation after at most 30 seconds, which is the maximum time
-		// the kube-apiserver will every wait for a webhook to answer
-		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-		defer cancel()
+		// this context is used for the validation logic
+		validationCtx := context.Background()
 
-		// We must always return an AdmissionReview with an AdmissionResponse
-		// even on error, hence the admissionExecutor  func, this makes error handling much easier
-		admissionResponse, err := admissionExecutor(ctx, r, mutate)
-		if err != nil {
-			admissionResponse = &admissionv1beta1.AdmissionResponse{}
-			admissionResponse.Result = &metav1.Status{Message: err.Error()}
+		// kube-apiserver waits for 10s by default, so we give us 9s time
+		waitCtx, waitCancel := context.WithTimeout(validationCtx, 9*time.Second)
+		defer waitCancel()
+
+		// this is where we receive the validation result or error
+		responses := make(chan *admissionv1beta1.AdmissionResponse, 1)
+		errs := make(chan error, 1)
+
+		// start the validation
+		go func() {
+			response, err := admissionExecutor(validationCtx, r, mutate)
+			if err != nil {
+				errs <- err
+			} else {
+				responses <- response
+			}
+
+			close(responses)
+			close(errs)
+		}()
+
+		var response *admissionv1beta1.AdmissionResponse
+
+		// wait for either a result to appear or the timeout kicking in
+		select {
+		// happy path: validation completed
+		case response = <-responses:
+			// nop
+
+		// validation errored
+		case err := <-errs:
+			response = &admissionv1beta1.AdmissionResponse{
+				Result: &metav1.Status{
+					Message: err.Error(),
+				},
+			}
+
+		// give up and at least produce an informative error message for the user
+		case <-waitCtx.Done():
+			klog.Warning("failed to complete admission request within deadline; processing continues in the background, but the request has to be retried")
+
+			response = &admissionv1beta1.AdmissionResponse{
+				Result: &metav1.Status{
+					Message: "validation timed out, please try again later",
+					Code:    http.StatusGatewayTimeout,
+				},
+			}
+
+		// request has been cancelled
+		case <-r.Context().Done():
+			klog.Errorf("failed to complete admission request within deadline and validation request has been cancelled already")
 		}
 
-		admissionReview := admissionv1beta1.AdmissionReview{}
-		admissionReview.Response = admissionResponse
+		// if we have a response, send it out; otherwise the request has
+		// already been cancelled and writing a response is futile
+		if response != nil {
+			admissionReview := admissionv1beta1.AdmissionReview{
+				Response: response,
+			}
 
-		resp, err := json.Marshal(admissionReview)
-		if err != nil {
-			klog.Errorf("failed to marshal admissionResponse: %v", err)
-			return
-		}
-		if _, err := w.Write(resp); err != nil {
-			klog.Errorf("failed to write admissionResponse: %v", err)
+			resp, err := json.Marshal(admissionReview)
+			if err != nil {
+				klog.Errorf("failed to marshal admissionReview: %v", err)
+				return
+			}
+
+			if _, err := w.Write(resp); err != nil {
+				klog.Errorf("failed to write admissionReview: %v", err)
+			}
 		}
 	}
 }

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -50,8 +50,8 @@ func New(listenAddress string, client ctrlruntimeclient.Client, um *userdatamana
 		client:          client,
 		userDataManager: um,
 	}
-	m.HandleFunc("/machinedeployments", handleFuncFactory(ad.mutateMachineDeployments))
-	m.HandleFunc("/machines", handleFuncFactory(ad.mutateMachines))
+	m.HandleFunc("/machinedeployments", handlerFuncFactory(ad.mutateMachineDeployments))
+	m.HandleFunc("/machines", handlerFuncFactory(ad.mutateMachines))
 	m.HandleFunc("/healthz", healthZHandler)
 
 	return &http.Server{
@@ -106,8 +106,8 @@ func createAdmissionResponse(original, mutated runtime.Object) (*admissionv1beta
 
 type mutator func(context.Context, admissionv1beta1.AdmissionReview) (*admissionv1beta1.AdmissionResponse, error)
 
-// handleFuncFactory wraps a mutator as an HTTP HandlerFunc.
-func handleFuncFactory(mutate mutator) func(http.ResponseWriter, *http.Request) {
+// handlerFuncFactory wraps a mutator as an HTTP HandlerFunc.
+func handlerFuncFactory(mutate mutator) http.HandlerFunc {
 	/*
 		Within the handler we create below, the actual mutation logic is
 		running in a separate goroutine. This is because sometimes some

--- a/pkg/admission/machinedeployments.go
+++ b/pkg/admission/machinedeployments.go
@@ -17,6 +17,7 @@ limitations under the License.
 package admission
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -26,7 +27,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
 
-func (ad *admissionData) mutateMachineDeployments(ar admissionv1beta1.AdmissionReview) (*admissionv1beta1.AdmissionResponse, error) {
+func (ad *admissionData) mutateMachineDeployments(ctx context.Context, ar admissionv1beta1.AdmissionReview) (*admissionv1beta1.AdmissionResponse, error) {
 
 	machineDeployment := clusterv1alpha1.MachineDeployment{}
 	if err := json.Unmarshal(ar.Request.Object.Raw, &machineDeployment); err != nil {
@@ -52,7 +53,7 @@ func (ad *admissionData) mutateMachineDeployments(ar admissionv1beta1.AdmissionR
 	}
 
 	if machineSpecNeedsValidation {
-		if err := ad.defaultAndValidateMachineSpec(&machineDeployment.Spec.Template.Spec); err != nil {
+		if err := ad.defaultAndValidateMachineSpec(ctx, &machineDeployment.Spec.Template.Spec); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/apis/cluster/v1alpha1/migrations/migrations.go
+++ b/pkg/apis/cluster/v1alpha1/migrations/migrations.go
@@ -292,13 +292,13 @@ func migrateMachines(ctx context.Context, client ctrlruntimeclient.Client, kubeC
 			klog.Infof("Attempting to update the UID at the cloud provider for machine.cluster.k8s.io/v1alpha1 %s", machinesV1Alpha1Machine.Name)
 			newMachineWithOldUID := finalClusterV1Alpha1Machine.DeepCopy()
 			newMachineWithOldUID.UID = machinesV1Alpha1Machine.UID
-			if err := prov.MigrateUID(newMachineWithOldUID, finalClusterV1Alpha1Machine.UID); err != nil {
+			if err := prov.MigrateUID(ctx, newMachineWithOldUID, finalClusterV1Alpha1Machine.UID); err != nil {
 				return fmt.Errorf("running the provider migration for the UID failed: %v", err)
 			}
 			// Block until we can actually GET the instance with the new UID
 			var isMigrated bool
 			for i := 0; i < 100; i++ {
-				if _, err := prov.Get(finalClusterV1Alpha1Machine, providerData); err == nil {
+				if _, err := prov.Get(ctx, finalClusterV1Alpha1Machine, providerData); err == nil {
 					isMigrated = true
 					break
 				}

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package alibaba
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -104,11 +105,11 @@ func New(configVarResolver *providerconfig.ConfigVarResolver) cloudprovidertypes
 	return &provider{configVarResolver: configVarResolver}
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+func (p *provider) AddDefaults(_ context.Context, spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
 	return spec, nil
 }
 
-func (p *provider) Validate(machineSpec v1alpha1.MachineSpec) error {
+func (p *provider) Validate(_ context.Context, machineSpec v1alpha1.MachineSpec) error {
 	c, pc, err := p.getConfig(machineSpec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %v", err)
@@ -149,7 +150,7 @@ func (p *provider) Validate(machineSpec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+func (p *provider) Get(_ context.Context, machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -195,11 +196,11 @@ func (p *provider) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.Provi
 	return nil, fmt.Errorf("instance %v is not ready", foundInstance.InstanceId)
 }
 
-func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, name string, err error) {
+func (p *provider) GetCloudConfig(_ context.Context, spec v1alpha1.MachineSpec) (config string, name string, err error) {
 	return "", "", nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(_ context.Context, machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -259,8 +260,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 	return &alibabaInstance{instance: foundInstance}, nil
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
-	foundInstance, err := p.Get(machine, data)
+func (p *provider) Cleanup(ctx context.Context, machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
+	foundInstance, err := p.Get(ctx, machine, data)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return util.RemoveFinalizerOnInstanceNotFound(finalizerInstance, machine, data)
@@ -304,7 +305,7 @@ func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]s
 	return labels, err
 }
 
-func (p *provider) MigrateUID(machine *v1alpha1.Machine, new types.UID) error {
+func (p *provider) MigrateUID(_ context.Context, machine *v1alpha1.Machine, new types.UID) error {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to decode providerconfig: %v", err)

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -367,7 +368,7 @@ func getEC2client(id, secret, region string) (*ec2.EC2, error) {
 	return ec2.New(sess), nil
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+func (p *provider) AddDefaults(_ context.Context, spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
 	_, _, rawConfig, err := p.getConfig(spec.ProviderSpec)
 	if err != nil {
 		return spec, err
@@ -382,7 +383,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	return spec, err
 }
 
-func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
+func (p *provider) Validate(_ context.Context, spec v1alpha1.MachineSpec) error {
 	config, pc, _, err := p.getConfig(spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %v", err)
@@ -476,7 +477,7 @@ func getVpc(client *ec2.EC2, id string) (*ec2.Vpc, error) {
 	return vpcOut.Vpcs[0], nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(_ context.Context, machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	config, pc, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -591,7 +592,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 	return &awsInstance{instance: runOut.Instances[0]}, nil
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
+func (p *provider) Cleanup(_ context.Context, machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
 	instance, err := p.get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
@@ -627,7 +628,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, _ *cloudprovidertypes.Prov
 	return false, nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+func (p *provider) Get(_ context.Context, machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	return p.get(machine)
 }
 
@@ -678,7 +679,7 @@ func (p *provider) get(machine *v1alpha1.Machine) (*awsInstance, error) {
 	return nil, cloudprovidererrors.ErrInstanceNotFound
 }
 
-func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, name string, err error) {
+func (p *provider) GetCloudConfig(_ context.Context, spec v1alpha1.MachineSpec) (config string, name string, err error) {
 	c, _, _, err := p.getConfig(spec.ProviderSpec)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to parse config: %v", err)
@@ -715,7 +716,7 @@ func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]s
 	return labels, err
 }
 
-func (p *provider) MigrateUID(machine *v1alpha1.Machine, new types.UID) error {
+func (p *provider) MigrateUID(ctx context.Context, machine *v1alpha1.Machine, new types.UID) error {
 	instance, err := p.get(machine)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -17,8 +17,10 @@ limitations under the License.
 package fake
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -57,12 +59,12 @@ func New(_ *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
 	return &provider{}
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+func (p *provider) AddDefaults(_ context.Context, spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
 	return spec, nil
 }
 
 // Validate returns success or failure based according to its FakeCloudProviderSpec
-func (p *provider) Validate(machinespec v1alpha1.MachineSpec) error {
+func (p *provider) Validate(_ context.Context, machinespec v1alpha1.MachineSpec) error {
 	pconfig := providerconfigtypes.Config{}
 	err := json.Unmarshal(machinespec.ProviderSpec.Value.Raw, &pconfig)
 	if err != nil {
@@ -83,24 +85,24 @@ func (p *provider) Validate(machinespec v1alpha1.MachineSpec) error {
 	return fmt.Errorf("failing validation as requested")
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+func (p *provider) Get(_ context.Context, machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	return CloudProviderInstance{}, nil
 }
 
-func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (string, string, error) {
+func (p *provider) GetCloudConfig(_ context.Context, _ v1alpha1.MachineSpec) (string, string, error) {
 	return "", "", nil
 }
 
 // Create creates a cloud instance according to the given machine
-func (p *provider) Create(_ *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, _ string) (instance.Instance, error) {
+func (p *provider) Create(_ context.Context, _ *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, _ string) (instance.Instance, error) {
 	return CloudProviderInstance{}, nil
 }
 
-func (p *provider) Cleanup(_ *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
+func (p *provider) Cleanup(_ context.Context, _ *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
 	return true, nil
 }
 
-func (p *provider) MigrateUID(machine *v1alpha1.Machine, new types.UID) error {
+func (p *provider) MigrateUID(_ context.Context, machine *v1alpha1.Machine, new types.UID) error {
 	return nil
 }
 

--- a/pkg/cloudprovider/provider/gce/service.go
+++ b/pkg/cloudprovider/provider/gce/service.go
@@ -21,10 +21,10 @@ limitations under the License.
 package gce
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"golang.org/x/oauth2"
 	"google.golang.org/api/compute/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -50,8 +50,8 @@ type service struct {
 }
 
 // connectComputeService establishes a service connection to the Compute Engine.
-func connectComputeService(cfg *config) (*service, error) {
-	svc, err := compute.New(cfg.jwtConfig.Client(oauth2.NoContext))
+func connectComputeService(ctx context.Context, cfg *config) (*service, error) {
+	svc, err := compute.New(cfg.jwtConfig.Client(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to Google Cloud: %v", err)
 	}

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -190,8 +190,9 @@ func TestCreateServer(t *testing.T) {
 				// Note that configVarResolver is not used in this test as the getConfigFunc is mocked.
 				configVarResolver: providerconfig.NewConfigVarResolver(context.Background(), fakeclient.NewFakeClient()),
 				// mock client config getter
-				clientGetter: func(c *Config) (*gophercloud.ProviderClient, error) {
+				clientGetter: func(ctx context.Context, c *Config) (*gophercloud.ProviderClient, error) {
 					pc := client.ServiceClient()
+					pc.Context = ctx
 					// endpoint locator used to redirect to local test endpoint
 					pc.ProviderClient.EndpointLocator = func(_ gophercloud.EndpointOpts) (string, error) {
 						return pc.Endpoint, nil
@@ -213,7 +214,7 @@ func TestCreateServer(t *testing.T) {
 			// It only verifies that the content of the create request matches
 			// the expectation
 			// TODO(irozzo) check the returned instance too
-			_, err := p.Create(m, tt.data, tt.userdata)
+			_, err := p.Create(context.Background(), m, tt.data, tt.userdata)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("provider.Create() or = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cloudprovider/provider/packet/provider.go
+++ b/pkg/cloudprovider/provider/packet/provider.go
@@ -17,6 +17,7 @@ limitations under the License.
 package packet
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -147,7 +148,7 @@ func (p *provider) getPacketDevice(machine *v1alpha1.Machine) (*packngo.Device, 
 	return device, client, nil
 }
 
-func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
+func (p *provider) Validate(ctx context.Context, spec v1alpha1.MachineSpec) error {
 	c, _, pc, err := p.getConfig(spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %v", err)
@@ -198,7 +199,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(ctx context.Context, machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	c, _, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -238,8 +239,8 @@ func (p *provider) Create(machine *v1alpha1.Machine, _ *cloudprovidertypes.Provi
 	return &packetDevice{device: device}, nil
 }
 
-func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
-	instance, err := p.Get(machine, data)
+func (p *provider) Cleanup(ctx context.Context, machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
+	instance, err := p.Get(ctx, machine, data)
 	if err != nil {
 		if err == cloudprovidererrors.ErrInstanceNotFound {
 			return true, nil
@@ -265,7 +266,7 @@ func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.P
 	return false, nil
 }
 
-func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+func (p *provider) AddDefaults(ctx context.Context, spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
 	_, rawConfig, _, err := p.getConfig(spec.ProviderSpec)
 	if err != nil {
 		return spec, err
@@ -278,7 +279,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	return spec, nil
 }
 
-func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+func (p *provider) Get(ctx context.Context, machine *v1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
 	device, _, err := p.getPacketDevice(machine)
 	if err != nil {
 		return nil, err
@@ -290,7 +291,7 @@ func (p *provider) Get(machine *v1alpha1.Machine, _ *cloudprovidertypes.Provider
 	return nil, cloudprovidererrors.ErrInstanceNotFound
 }
 
-func (p *provider) MigrateUID(machine *v1alpha1.Machine, newID types.UID) error {
+func (p *provider) MigrateUID(ctx context.Context, machine *v1alpha1.Machine, newID types.UID) error {
 	device, client, err := p.getPacketDevice(machine)
 	if err != nil {
 		return err
@@ -325,7 +326,7 @@ func (p *provider) MigrateUID(machine *v1alpha1.Machine, newID types.UID) error 
 	return nil
 }
 
-func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, name string, err error) {
+func (p *provider) GetCloudConfig(_ context.Context, _ v1alpha1.MachineSpec) (config string, name string, err error) {
 	return "", "", nil
 }
 

--- a/pkg/cloudprovider/provider/vsphere/provider_test.go
+++ b/pkg/cloudprovider/provider/vsphere/provider_test.go
@@ -148,6 +148,8 @@ func TestValidate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
 			model := simulator.VPX()
 			// Pod == StoragePod == StorageCluster
 			model.Pod++
@@ -169,14 +171,14 @@ func TestValidate(t *testing.T) {
 			password, _ := simulator.DefaultLogin.Password()
 			p := &provider{
 				// Note that configVarResolver is not used in this test as the getConfigFunc is mocked.
-				configVarResolver: providerconfig.NewConfigVarResolver(context.Background(), fakeclient.NewFakeClient()),
+				configVarResolver: providerconfig.NewConfigVarResolver(ctx, fakeclient.NewFakeClient()),
 			}
 			tt.args.User = username
 			tt.args.Password = password
 			tt.args.URL = vSphereURL
 			m := cloudprovidertesting.Creator{Name: "test", Namespace: "vsphere", ProviderSpecGetter: tt.args.rawProviderSpec}.
 				CreateMachine(t)
-			if err := p.Validate(m.Spec); (err != nil) != tt.wantErr {
+			if err := p.Validate(ctx, m.Spec); (err != nil) != tt.wantErr {
 				t.Errorf("provider.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/cloudprovider/types/types.go
+++ b/pkg/cloudprovider/types/types.go
@@ -31,13 +31,13 @@ import (
 // Provider exposed all required functions to interact with a cloud provider
 type Provider interface {
 	// AddDefaults will read the MachineSpec and apply defaults for provider specific fields
-	AddDefaults(spec clusterv1alpha1.MachineSpec) (clusterv1alpha1.MachineSpec, error)
+	AddDefaults(ctx context.Context, spec clusterv1alpha1.MachineSpec) (clusterv1alpha1.MachineSpec, error)
 
 	// Validate validates the given machine's specification.
 	//
 	// In case of any error a "terminal" error should be set,
 	// See v1alpha1.MachineStatus for more info
-	Validate(machinespec clusterv1alpha1.MachineSpec) error
+	Validate(ctx context.Context, machinespec clusterv1alpha1.MachineSpec) error
 
 	// Get gets a node that is associated with the given machine.
 	//
@@ -46,19 +46,19 @@ type Provider interface {
 	// See v1alpha1.MachineStatus for more info and TerminalError type
 	//
 	// In case the instance cannot be found, github.com/kubermatic/machine-controller/pkg/cloudprovider/errors/ErrInstanceNotFound will be returned
-	Get(machine *clusterv1alpha1.Machine, data *ProviderData) (instance.Instance, error)
+	Get(ctx context.Context, machine *clusterv1alpha1.Machine, data *ProviderData) (instance.Instance, error)
 
 	// GetCloudConfig will return the cloud provider specific cloud-config, which gets consumed by the kubelet
-	GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config string, name string, err error)
+	GetCloudConfig(ctx context.Context, spec clusterv1alpha1.MachineSpec) (config string, name string, err error)
 
 	// Create creates a cloud instance according to the given machine
-	Create(machine *clusterv1alpha1.Machine, data *ProviderData, userdata string) (instance.Instance, error)
+	Create(ctx context.Context, machine *clusterv1alpha1.Machine, data *ProviderData, userdata string) (instance.Instance, error)
 
 	// Cleanup will delete the instance associated with the machine and all associated resources.
 	// If all resources have been cleaned up, true will be returned.
 	// In case the cleanup involves asynchronous deletion of resources & those resources are not gone yet,
 	// false should be returned. This is to indicate that the cleanup is not done, but needs to be called again at a later point
-	Cleanup(machine *clusterv1alpha1.Machine, data *ProviderData) (bool, error)
+	Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine, data *ProviderData) (bool, error)
 
 	// MachineMetricsLabels returns labels used for the Prometheus metrics
 	// about created machines, e.g. instance type, instance size, region
@@ -69,7 +69,7 @@ type Provider interface {
 
 	// MigrateUID is called when the controller migrates types and the UID of the machine object changes
 	// All cloud providers that use Machine.UID to uniquely identify resources must implement this
-	MigrateUID(machine *clusterv1alpha1.Machine, new types.UID) error
+	MigrateUID(ctx context.Context, machine *clusterv1alpha1.Machine, new types.UID) error
 
 	// SetMetricsForMachines allows providers to provide provider-specific metrics. This may be implemented
 	// as no-op

--- a/pkg/cloudprovider/validationwrapper.go
+++ b/pkg/cloudprovider/validationwrapper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudprovider
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -37,13 +38,13 @@ func NewValidationCacheWrappingCloudProvider(actualProvider cloudprovidertypes.P
 }
 
 // AddDefaults just calls the underlying cloudproviders AddDefaults
-func (w *cachingValidationWrapper) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
-	return w.actualProvider.AddDefaults(spec)
+func (w *cachingValidationWrapper) AddDefaults(ctx context.Context, spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+	return w.actualProvider.AddDefaults(ctx, spec)
 }
 
 // Validate tries to get the validation result from the cache and if not found, calls the
 // cloudproviders Validate and saves that to the cache
-func (w *cachingValidationWrapper) Validate(spec v1alpha1.MachineSpec) error {
+func (w *cachingValidationWrapper) Validate(ctx context.Context, spec v1alpha1.MachineSpec) error {
 	result, exists, err := cache.Get(spec)
 	if err != nil {
 		return fmt.Errorf("error getting validation result from cache: %v", err)
@@ -54,7 +55,7 @@ func (w *cachingValidationWrapper) Validate(spec v1alpha1.MachineSpec) error {
 	}
 
 	klog.V(6).Infof("Got cache miss for validation")
-	err = w.actualProvider.Validate(spec)
+	err = w.actualProvider.Validate(ctx, spec)
 	if err := cache.Set(spec, err); err != nil {
 		return fmt.Errorf("failed to set cache after validation: %v", err)
 	}
@@ -63,28 +64,28 @@ func (w *cachingValidationWrapper) Validate(spec v1alpha1.MachineSpec) error {
 }
 
 // Get just calls the underlying cloudproviders Get
-func (w *cachingValidationWrapper) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (instance.Instance, error) {
-	return w.actualProvider.Get(machine, data)
+func (w *cachingValidationWrapper) Get(ctx context.Context, machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+	return w.actualProvider.Get(ctx, machine, data)
 }
 
 // GetCloudConfig just calls the underlying cloudproviders GetCloudConfig
-func (w *cachingValidationWrapper) GetCloudConfig(spec v1alpha1.MachineSpec) (string, string, error) {
-	return w.actualProvider.GetCloudConfig(spec)
+func (w *cachingValidationWrapper) GetCloudConfig(ctx context.Context, spec v1alpha1.MachineSpec) (string, string, error) {
+	return w.actualProvider.GetCloudConfig(ctx, spec)
 }
 
 // Create just calls the underlying cloudproviders Create
-func (w *cachingValidationWrapper) Create(m *v1alpha1.Machine, mcd *cloudprovidertypes.ProviderData, cloudConfig string) (instance.Instance, error) {
-	return w.actualProvider.Create(m, mcd, cloudConfig)
+func (w *cachingValidationWrapper) Create(ctx context.Context, m *v1alpha1.Machine, mcd *cloudprovidertypes.ProviderData, cloudConfig string) (instance.Instance, error) {
+	return w.actualProvider.Create(ctx, m, mcd, cloudConfig)
 }
 
 // Cleanup just calls the underlying cloudproviders Cleanup
-func (w *cachingValidationWrapper) Cleanup(m *v1alpha1.Machine, mcd *cloudprovidertypes.ProviderData) (bool, error) {
-	return w.actualProvider.Cleanup(m, mcd)
+func (w *cachingValidationWrapper) Cleanup(ctx context.Context, m *v1alpha1.Machine, mcd *cloudprovidertypes.ProviderData) (bool, error) {
+	return w.actualProvider.Cleanup(ctx, m, mcd)
 }
 
 // MigrateUID just calls the underlying cloudproviders MigrateUID
-func (w *cachingValidationWrapper) MigrateUID(m *v1alpha1.Machine, new types.UID) error {
-	return w.actualProvider.MigrateUID(m, new)
+func (w *cachingValidationWrapper) MigrateUID(ctx context.Context, m *v1alpha1.Machine, new types.UID) error {
+	return w.actualProvider.MigrateUID(ctx, m, new)
 }
 
 // MachineMetricsLabels just calls the underlying cloudproviders MachineMetricsLabels

--- a/pkg/controller/machine/machine.go
+++ b/pkg/controller/machine/machine.go
@@ -329,7 +329,7 @@ func (r *Reconciler) createProviderInstance(prov cloudprovidertypes.Provider, ma
 	if err != nil {
 		return nil, fmt.Errorf("failed to add %q finalizer: %v", FinalizerDeleteInstance, err)
 	}
-	instance, err := prov.Create(machine, r.providerData, userdata)
+	instance, err := prov.Create(r.ctx, machine, r.providerData, userdata)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +545,7 @@ func (r *Reconciler) deleteCloudProviderInstance(prov cloudprovidertypes.Provide
 	}
 
 	// Delete the instance
-	completelyGone, err := prov.Cleanup(machine, r.providerData)
+	completelyGone, err := prov.Cleanup(r.ctx, machine, r.providerData)
 	if err != nil {
 		message := fmt.Sprintf("%v. Please manually delete %s finalizer from the machine object.", err, FinalizerDeleteInstance)
 		return nil, r.updateMachineErrorIfTerminalError(machine, common.DeleteMachineError, message, err, "failed to delete machine at cloud provider")
@@ -662,7 +662,7 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 	prov cloudprovidertypes.Provider, machine *clusterv1alpha1.Machine, userdataPlugin userdataplugin.Provider, providerConfig *providerconfigtypes.Config) (*reconcile.Result, error) {
 	klog.V(6).Infof("Requesting instance for machine '%s' from cloudprovider because no associated node with status ready found...", machine.Name)
 
-	providerInstance, err := prov.Get(machine, r.providerData)
+	providerInstance, err := prov.Get(r.ctx, machine, r.providerData)
 
 	// case 2: retrieving instance from provider was not successful
 	if err != nil {
@@ -676,7 +676,7 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 				return nil, fmt.Errorf("failed to create bootstrap kubeconfig: %v", err)
 			}
 
-			cloudConfig, cloudProviderName, err := prov.GetCloudConfig(machine.Spec)
+			cloudConfig, cloudProviderName, err := prov.GetCloudConfig(r.ctx, machine.Spec)
 			if err != nil {
 				return nil, fmt.Errorf("failed to render cloud config: %v", err)
 			}

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package provisioning
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -73,7 +74,9 @@ func TestInvalidObjectsGetRejected(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		testScenario(t,
+		testScenario(
+			context.Background(),
+			t,
 			test,
 			fmt.Sprintf("invalid-machine-%v", i),
 			nil,
@@ -120,7 +123,7 @@ func TestKubevirtDNSConfigProvisioningE2E(t *testing.T) {
 		executor:          verifyCreateAndDelete,
 	}
 
-	testScenario(t, scenario, *testRunIdentifier, params, kubevirtManifestDNSConfig, false)
+	testScenario(context.Background(), t, scenario, *testRunIdentifier, params, kubevirtManifestDNSConfig, false)
 }
 
 func TestOpenstackProvisioningE2E(t *testing.T) {
@@ -301,7 +304,7 @@ func TestAWSProvisioningE2EWithEbsEncryptionEnabled(t *testing.T) {
 		kubernetesVersion: "v1.15.6",
 		executor:          verifyCreateAndDelete,
 	}
-	testScenario(t, scenario, fmt.Sprintf("aws-%s", *testRunIdentifier), params, AWSEBSEncryptedManifest, false)
+	testScenario(context.Background(), t, scenario, fmt.Sprintf("aws-%s", *testRunIdentifier), params, AWSEBSEncryptedManifest, false)
 }
 
 // TestAzureProvisioningE2E - a test suite that exercises Azure provider
@@ -360,7 +363,7 @@ func TestAzureRedhatSatelliteProvisioningE2E(t *testing.T) {
 		executor:          verifyCreateAndDelete,
 	}
 
-	testScenario(t, scenario, *testRunIdentifier, params, AzureRedhatSatelliteManifest, false)
+	testScenario(context.Background(), t, scenario, *testRunIdentifier, params, AzureRedhatSatelliteManifest, false)
 }
 
 // TestGCEProvisioningE2E - a test suite that exercises Google Cloud provider
@@ -533,7 +536,7 @@ func TestVsphereResourcePoolProvisioningE2E(t *testing.T) {
 		executor:          verifyCreateAndDelete,
 	}
 
-	testScenario(t, scenario, *testRunIdentifier, params, VSPhereResourcePoolManifest, false)
+	testScenario(context.Background(), t, scenario, *testRunIdentifier, params, VSPhereResourcePoolManifest, false)
 }
 
 // TestScalewayProvisioning - a test suite that exercises scaleway provider
@@ -607,7 +610,7 @@ func TestUbuntuProvisioningWithUpgradeE2E(t *testing.T) {
 		executor:          verifyCreateAndDelete,
 	}
 
-	testScenario(t, scenario, *testRunIdentifier, params, OSUpgradeManifest, false)
+	testScenario(context.Background(), t, scenario, *testRunIdentifier, params, OSUpgradeManifest, false)
 }
 
 // TestDeploymentControllerUpgradesMachineE2E verifies the machineDeployment controller correctly
@@ -631,7 +634,7 @@ func TestDeploymentControllerUpgradesMachineE2E(t *testing.T) {
 		kubernetesVersion: "1.16.2",
 		executor:          verifyCreateUpdateAndDelete,
 	}
-	testScenario(t, scenario, *testRunIdentifier, params, HZManifest, false)
+	testScenario(context.Background(), t, scenario, *testRunIdentifier, params, HZManifest, false)
 }
 
 func TestAnexiaProvisioningE2E(t *testing.T) {

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package provisioning
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -116,16 +117,16 @@ func runScenarios(st *testing.T, selector Selector, testParams []string, manifes
 		}
 
 		st.Run(testCase.name, func(it *testing.T) {
-			testScenario(it, testCase, cloudProvider, testParams, manifestPath, true)
+			testScenario(context.Background(), it, testCase, cloudProvider, testParams, manifestPath, true)
 		})
 	}
 }
 
 // scenarioExecutor represents an executor for a given scenario
 // args: kubeConfig, maifestPath, scenarioParams, timeout
-type scenarioExecutor func(string, string, []string, time.Duration) error
+type scenarioExecutor func(context.Context, string, string, []string, time.Duration) error
 
-func testScenario(t *testing.T, testCase scenario, cloudProvider string, testParams []string, manifestPath string, parallelize bool) {
+func testScenario(ctx context.Context, t *testing.T, testCase scenario, cloudProvider string, testParams []string, manifestPath string, parallelize bool) {
 
 	if parallelize {
 		t.Parallel()
@@ -200,7 +201,7 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 	// we decided to keep this time lower that the global timeout to prevent the following:
 	// the global timeout is set to 20 minutes and the verify tool waits up to 60 hours for a machine to show up.
 	// thus one faulty scenario prevents from showing the results for the whole group, which is confusing because it looks like all tests are broken.
-	if err := testCase.executor(kubeConfig, manifestPath, scenarioParams, 35*time.Minute); err != nil {
+	if err := testCase.executor(ctx, kubeConfig, manifestPath, scenarioParams, 35*time.Minute); err != nil {
 		t.Errorf("verify failed due to error=%v", err)
 	}
 }

--- a/test/e2e/provisioning/verify.go
+++ b/test/e2e/provisioning/verify.go
@@ -43,18 +43,18 @@ const (
 	machineReadyCheckPeriod = 15 * time.Second
 )
 
-func verifyCreateMachineFails(kubeConfig, manifestPath string, parameters []string, _ time.Duration) error {
+func verifyCreateMachineFails(ctx context.Context, kubeConfig, manifestPath string, parameters []string, _ time.Duration) error {
 	client, machine, err := prepareMachine(kubeConfig, manifestPath, parameters)
 	if err != nil {
 		return err
 	}
-	if err := client.Create(context.Background(), machine); err != nil {
+	if err := client.Create(ctx, machine); err != nil {
 		return nil
 	}
 	return fmt.Errorf("expected create of Machine %s to fail but succeeded", machine.Name)
 }
 
-func verifyCreateAndDelete(kubeConfig, manifestPath string, parameters []string, timeout time.Duration) error {
+func verifyCreateAndDelete(ctx context.Context, kubeConfig, manifestPath string, parameters []string, timeout time.Duration) error {
 
 	client, machineDeployment, err := prepareMachineDeployment(kubeConfig, manifestPath, parameters)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The admission webhook so far did not use contexts to control the lifetime of cloud provider API calls. This meant that these calls could block forever and slow the webhook down.

This PR adds an explicit context to the cloudprovider interface and uses the incoming request's context for all validation logic, cancelling all outgoing requests after a certain period of time. *However*, this leads to a problem: For slow cloud providers like Hetzner, the request is rarely processed within the kube-apiserver's timeout (10 seconds). Previously, our caching saved us (by accident?), as the validation logic continued and then cached the result long after the kube-apiserver stopped listening. And on the next admission request, it would respond with the cached result. But when the validation is cancelled thanks to the context timing out, this would not happen anymore.

I considered three approaches to generally handling slow cloud providers in the admission requests:

1. Ignore the problem, i.e. do not add contexts and keep yolo'ing. This is bad IMHO because most related Go APIs move towards having explicit contexts and it would be very nice if we can use those to actually control our logic. So far, there was no possibility to cancel a .Get() call for retrieving a machine.

    Also, I consider a cache to be optional by default, i.e. if you remove it, your application will run worse, potentially much worse, but it will still work. If we removed our caching however, the validation would never possibly work if a cloud provider is slow.

2. Be strict: Add contexts and cancel validation logic and then just blame cloud providers for being slow. This is easy, yet not very convenient for the user. I think we can do better.

3. Background processing. With this, we run a separate goroutine for each incoming request and then do some clever timeout handling. This allows us to let the validation complete on its own time and respond with a nicely worded "sorry, timeout, please try again later" to the user. Once the goroutine is done, the result is cached and the user will get a proper response.

I chose approach 3.

This makes the Hetzner tests look a bit more friendly already:

```
I1218 18:29:02  verify.go:150] Creating a new "ubuntu-1-18-10-hz-123" MachineDeployment
I1218 18:29:02  verify.go:150] Creating a new "centos-1-18-10-hz-123" MachineDeployment
I1218 18:29:02  verify.go:150] Creating a new "centos-1-19-3-hz-123" MachineDeployment
I1218 18:29:02  verify.go:150] Creating a new "centos-1-17-13-hz-123" MachineDeployment
I1218 18:29:02  verify.go:150] Creating a new "ubuntu-1-17-13-hz-123" MachineDeployment
I1218 18:29:02  verify.go:150] Creating a new "ubuntu-1-19-3-hz-123" MachineDeployment
I1218 18:29:02  verify.go:169] MachineDeployment "centos-1-19-3-hz-123" created
I1218 18:29:04  verify.go:169] MachineDeployment "centos-1-17-13-hz-123" created
W1218 18:29:11  verify.go:159] Creation of "ubuntu-1-18-10-hz-123" failed, retrying: admission webhook denied the request: validation timed out, please try again later
W1218 18:29:11  verify.go:159] Creation of "centos-1-18-10-hz-123" failed, retrying: admission webhook denied the request: validation timed out, please try again later
W1218 18:29:11  verify.go:159] Creation of "ubuntu-1-19-3-hz-123" failed, retrying: admission webhook denied the request: validation timed out, please try again later
W1218 18:29:11  verify.go:159] Creation of "ubuntu-1-17-13-hz-123" failed, retrying: admission webhook denied the request: validation timed out, please try again later
I1218 18:29:14  verify.go:169] MachineDeployment "centos-1-18-10-hz-123" created
I1218 18:29:22  verify.go:169] MachineDeployment "ubuntu-1-17-13-hz-123" created
W1218 18:29:23  verify.go:159] Creation of "ubuntu-1-18-10-hz-123" failed, retrying: admission webhook denied the request: validation timed out, please try again later
W1218 18:29:23  verify.go:159] Creation of "ubuntu-1-19-3-hz-123" failed, retrying: admission webhook denied the request: validation timed out, please try again later
I1218 18:29:26  verify.go:169] MachineDeployment "ubuntu-1-18-10-hz-123" created
I1218 18:29:26  verify.go:169] MachineDeployment "ubuntu-1-19-3-hz-123" created
```

**Optional Release Note**:
```release-note
NONE
```