### PR TITLE
Add optional use-octavia flag to OpenStack cloud config

### DIFF
--- a/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
@@ -19,6 +19,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"text/template"
 
 	"github.com/kubermatic/machine-controller/pkg/ini"
@@ -26,6 +27,9 @@ import (
 	"github.com/Masterminds/sprig"
 )
 
+//  use-octavia is enabled by default in CCM since v1.17.0, and disabled by
+//  default with the in-tree cloud provider.
+//  https://v1-18.docs.kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#load-balancer
 const (
 	cloudConfigTpl = `[Global]
 auth-url    = {{ .Global.AuthURL | iniEscape }}
@@ -42,6 +46,9 @@ subnet-id = {{ .LoadBalancer.SubnetID | iniEscape }}
 floating-network-id = {{ .LoadBalancer.FloatingNetworkID | iniEscape }}
 lb-method = {{ default "ROUND_ROBIN" .LoadBalancer.LBMethod | iniEscape }}
 lb-provider = {{ .LoadBalancer.LBProvider | iniEscape }}
+{{- if .LoadBalancer.UseOctavia }}
+use-octavia = {{ .LoadBalancer.UseOctavia | boolPtr }}
+{{- end }}
 
 {{- if .LoadBalancer.CreateMonitor }}
 create-monitor = {{ .LoadBalancer.CreateMonitor }}
@@ -76,6 +83,7 @@ type LoadBalancerOpts struct {
 	MonitorTimeout       ini.Duration `gcfg:"monitor-timeout"`
 	MonitorMaxRetries    uint         `gcfg:"monitor-max-retries"`
 	ManageSecurityGroups bool         `gcfg:"manage-security-groups"`
+	UseOctavia           *bool        `gcfg:"use-octavia"`
 }
 
 type BlockStorageOpts struct {
@@ -106,6 +114,7 @@ type CloudConfig struct {
 func CloudConfigToString(c *CloudConfig) (string, error) {
 	funcMap := sprig.TxtFuncMap()
 	funcMap["iniEscape"] = ini.Escape
+	funcMap["boolPtr"] = func(b *bool) string { return strconv.FormatBool(*b) }
 
 	tpl, err := template.New("cloud-config").Funcs(funcMap).Parse(cloudConfigTpl)
 	if err != nil {

--- a/pkg/cloudprovider/provider/openstack/types/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/openstack/types/cloudconfig_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"gopkg.in/gcfg.v1"
+	"k8s.io/utils/pointer"
 
 	"github.com/kubermatic/machine-controller/pkg/ini"
 	testhelper "github.com/kubermatic/machine-controller/pkg/test"
@@ -53,6 +54,54 @@ func TestCloudConfigToString(t *testing.T) {
 				},
 				LoadBalancer: LoadBalancerOpts{
 					ManageSecurityGroups: true,
+				},
+				Version: "1.10.0",
+			},
+		},
+		{
+			name: "use-octavia-explicitly-enabled",
+			config: &CloudConfig{
+				Global: GlobalOpts{
+					AuthURL:    "https://127.0.0.1:8443",
+					Username:   "admin",
+					Password:   "password",
+					DomainName: "Default",
+					TenantName: "Test",
+					Region:     "eu-central1",
+				},
+				BlockStorage: BlockStorageOpts{
+					BSVersion:             "v2",
+					IgnoreVolumeAZ:        true,
+					TrustDevicePath:       true,
+					NodeVolumeAttachLimit: 25,
+				},
+				LoadBalancer: LoadBalancerOpts{
+					ManageSecurityGroups: true,
+					UseOctavia:           pointer.BoolPtr(true),
+				},
+				Version: "1.10.0",
+			},
+		},
+		{
+			name: "use-octavia-explicitly-disabled",
+			config: &CloudConfig{
+				Global: GlobalOpts{
+					AuthURL:    "https://127.0.0.1:8443",
+					Username:   "admin",
+					Password:   "password",
+					DomainName: "Default",
+					TenantName: "Test",
+					Region:     "eu-central1",
+				},
+				BlockStorage: BlockStorageOpts{
+					BSVersion:             "v2",
+					IgnoreVolumeAZ:        true,
+					TrustDevicePath:       true,
+					NodeVolumeAttachLimit: 25,
+				},
+				LoadBalancer: LoadBalancerOpts{
+					ManageSecurityGroups: true,
+					UseOctavia:           pointer.BoolPtr(false),
 				},
 				Version: "1.10.0",
 			},
@@ -109,6 +158,7 @@ func TestCloudConfigToString(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			t.Logf("Marshaled config: %s\n", s)
 			nc := &CloudConfig{}
 			if err := gcfg.ReadStringInto(nc, s); err != nil {
 				t.Logf("\n%s", s)

--- a/pkg/cloudprovider/provider/openstack/types/testdata/use-octavia-explicitly-disabled.golden
+++ b/pkg/cloudprovider/provider/openstack/types/testdata/use-octavia-explicitly-disabled.golden
@@ -1,0 +1,22 @@
+[Global]
+auth-url    = "https://127.0.0.1:8443"
+username    = "admin"
+password    = "password"
+tenant-name = "Test"
+tenant-id   = ""
+domain-name = "Default"
+region      = "eu-central1"
+
+[LoadBalancer]
+lb-version = "v2"
+subnet-id = ""
+floating-network-id = ""
+lb-method = "ROUND_ROBIN"
+lb-provider = ""
+use-octavia = false
+
+[BlockStorage]
+ignore-volume-az  = true
+trust-device-path = true
+bs-version        = "v2"
+node-volume-attach-limit = 25

--- a/pkg/cloudprovider/provider/openstack/types/testdata/use-octavia-explicitly-enabled.golden
+++ b/pkg/cloudprovider/provider/openstack/types/testdata/use-octavia-explicitly-enabled.golden
@@ -1,0 +1,22 @@
+[Global]
+auth-url    = "https://127.0.0.1:8443"
+username    = "admin"
+password    = "password"
+tenant-name = "Test"
+tenant-id   = ""
+domain-name = "Default"
+region      = "eu-central1"
+
+[LoadBalancer]
+lb-version = "v2"
+subnet-id = ""
+floating-network-id = ""
+lb-method = "ROUND_ROBIN"
+lb-provider = ""
+use-octavia = true
+
+[BlockStorage]
+ignore-volume-az  = true
+trust-device-path = true
+bs-version        = "v2"
+node-volume-attach-limit = 25


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `use-octavia` flag to the OpenStack cloud config, this is a pre-requisite for:https://github.com/kubermatic/kubermatic/issues/6309

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
