### PR TITLE
Specify resource group field for azure vnet

### DIFF
--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -237,6 +237,8 @@ subscriptionID: "<< AZURE_SUBSCRIPTION_ID >>"
 location: "westeurope"
 # Azure resource group
 resourceGroup: "<< YOUR_RESOURCE_GROUP >>"
+# Azure resource group of the vnet	
+vnetResourceGroup: "<< YOUR_VNET_RESOURCE_GROUP >>"
 # Azure availability set
 availabilitySet: "<< YOUR AVAILABILITY SET >>"
 # VM size

--- a/examples/azure-machinedeployment.yaml
+++ b/examples/azure-machinedeployment.yaml
@@ -64,6 +64,7 @@ spec:
                 key: subscriptionID
             location: "westeurope"
             resourceGroup: "<< YOUR_RESOURCE_GROUP >>"
+            vnetResourceGroup: "<< YOUR_VNET_RESOURCE_GROUP >>"
             vmSize: "Standard_F2"
             # optional disk size values in GB. If not set, the defaults for the vmSize will be used.
             osDiskSize: 30

--- a/pkg/cloudprovider/provider/azure/create_delete_resources.go
+++ b/pkg/cloudprovider/provider/azure/create_delete_resources.go
@@ -247,7 +247,7 @@ func getSubnet(ctx context.Context, c *config) (network.Subnet, error) {
 		return network.Subnet{}, fmt.Errorf("failed to create subnets client: %v", err)
 	}
 
-	return subnetsClient.Get(ctx, c.ResourceGroup, c.VNetName, c.SubnetName, "")
+	return subnetsClient.Get(ctx, c.VNetResourceGroup, c.VNetName, c.SubnetName, "")
 }
 
 func getVirtualNetwork(ctx context.Context, c *config) (network.VirtualNetwork, error) {
@@ -256,7 +256,7 @@ func getVirtualNetwork(ctx context.Context, c *config) (network.VirtualNetwork, 
 		return network.VirtualNetwork{}, err
 	}
 
-	return virtualNetworksClient.Get(ctx, c.ResourceGroup, c.VNetName, "")
+	return virtualNetworksClient.Get(ctx, c.VNetResourceGroup, c.VNetName, "")
 }
 
 func createOrUpdateNetworkInterface(ctx context.Context, ifName string, machineUID types.UID, config *config, publicIP *network.PublicIPAddress) (*network.Interface, error) {

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -74,6 +74,7 @@ type config struct {
 
 	Location          string
 	ResourceGroup     string
+	VNetResourceGroup string
 	VMSize            string
 	VNetName          string
 	SubnetName        string
@@ -216,6 +217,11 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*config, *providerconfigt
 	c.ResourceGroup, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.ResourceGroup)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get the value of \"resourceGroup\" field, error = %v", err)
+	}
+
+	c.VNetResourceGroup, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.VNetResourceGroup)
+	if err != nil || len(c.VNetResourceGroup) == 0 {
+		c.VNetResourceGroup = c.ResourceGroup
 	}
 
 	c.Location, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.Location)
@@ -784,6 +790,7 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 		AADClientID:                c.ClientID,
 		AADClientSecret:            c.ClientSecret,
 		ResourceGroup:              c.ResourceGroup,
+		VnetResourceGroup:          c.VNetResourceGroup,
 		Location:                   c.Location,
 		VNetName:                   c.VNetName,
 		SubnetName:                 c.SubnetName,
@@ -825,6 +832,10 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 
 	if c.ResourceGroup == "" {
 		return errors.New("resourceGroup is missing")
+	}
+
+	if c.VNetResourceGroup == "" {
+		c.VNetResourceGroup = c.ResourceGroup
 	}
 
 	if c.VMSize == "" {

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -221,7 +221,11 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*config, *providerconfigt
 
 	c.VNetResourceGroup, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.VNetResourceGroup)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get the value of \"VNetResourceGroup\" field, error = %v", err)
+		return nil, nil, fmt.Errorf("failed to get the value of \"vnetResourceGroup\" field, error = %v", err)
+	}
+
+	if c.VNetResourceGroup == "" {
+		c.VNetResourceGroup = c.ResourceGroup
 	}
 
 	c.Location, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.Location)
@@ -832,10 +836,6 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 
 	if c.ResourceGroup == "" {
 		return errors.New("resourceGroup is missing")
-	}
-
-	if c.VNetResourceGroup == "" {
-		c.VNetResourceGroup = c.ResourceGroup
 	}
 
 	if c.VMSize == "" {

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -220,8 +220,8 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*config, *providerconfigt
 	}
 
 	c.VNetResourceGroup, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.VNetResourceGroup)
-	if err != nil || len(c.VNetResourceGroup) == 0 {
-		c.VNetResourceGroup = c.ResourceGroup
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get the value of \"VNetResourceGroup\" field, error = %v", err)
 	}
 
 	c.Location, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.Location)

--- a/pkg/cloudprovider/provider/azure/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/azure/types/cloudconfig.go
@@ -28,15 +28,15 @@ type CloudConfig struct {
 	AADClientID     string `json:"aadClientId"`
 	AADClientSecret string `json:"aadClientSecret"`
 
-	ResourceGroup              string  `json:"resourceGroup"`
-	Location                   string  `json:"location"`
-	VNetName                   string  `json:"vnetName"`
-	SubnetName                 string  `json:"subnetName"`
-	RouteTableName             string  `json:"routeTableName"`
-	SecurityGroupName          string  `json:"securityGroupName" yaml:"securityGroupName"`
-	PrimaryAvailabilitySetName string  `json:"primaryAvailabilitySetName"`
-	VnetResourceGroup          *string `json:"vnetResourceGroup,omitempty"`
-	UseInstanceMetadata        bool    `json:"useInstanceMetadata"`
+	ResourceGroup              string `json:"resourceGroup"`
+	Location                   string `json:"location"`
+	VNetName                   string `json:"vnetName"`
+	SubnetName                 string `json:"subnetName"`
+	RouteTableName             string `json:"routeTableName"`
+	SecurityGroupName          string `json:"securityGroupName" yaml:"securityGroupName"`
+	PrimaryAvailabilitySetName string `json:"primaryAvailabilitySetName"`
+	VnetResourceGroup          string `json:"vnetResourceGroup"`
+	UseInstanceMetadata        bool   `json:"useInstanceMetadata"`
 }
 
 func CloudConfigToString(c *CloudConfig) (string, error) {

--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -29,6 +29,7 @@ type RawConfig struct {
 
 	Location          providerconfigtypes.ConfigVarString `json:"location"`
 	ResourceGroup     providerconfigtypes.ConfigVarString `json:"resourceGroup"`
+	VNetResourceGroup providerconfigtypes.ConfigVarString `json:"vnetResourceGroup"`
 	VMSize            providerconfigtypes.ConfigVarString `json:"vmSize"`
 	VNetName          providerconfigtypes.ConfigVarString `json:"vnetName"`
 	SubnetName        providerconfigtypes.ConfigVarString `json:"subnetName"`

--- a/test/e2e/provisioning/testdata/machinedeployment-azure-redhat-satellite.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure-redhat-satellite.yaml
@@ -33,6 +33,7 @@ spec:
             vmSize: "Standard_F2"
             # optional disk size values in GB. If not set, the defaults for the vmSize will be used.
             vnetName: "machine-controller-e2e"
+            vnetResourceGroup: ""
             subnetName: "machine-controller-e2e"
             imageID: "<< IMAGE_ID >>"
             assignPublicIP: true

--- a/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
@@ -30,6 +30,7 @@ spec:
             subscriptionID: "<< AZURE_SUBSCRIPTION_ID >>"
             location: "westeurope"
             resourceGroup: "machine-controller-e2e"
+            vnetResourceGroup: ""
             vmSize: "Standard_F2"
             # optional disk size values in GB. If not set, the defaults for the vmSize will be used.
             osDiskSize: << OS_DISK_SIZE >>


### PR DESCRIPTION
**What this PR does / why we need it**:
Support specifying a different resource groups for vnets in Azure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #836

**Optional Release Note**:
```release-note
Vnet Resource group support
```
