### PR TITLE
fix missing machine metrics

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -374,6 +374,9 @@ func (bs *controllerBootstrap) Start(ctx context.Context) error {
 		return fmt.Errorf("migration of providerConfig field to providerSpec field failed: %v", err)
 	}
 
+	machineCollector := machinecontroller.NewMachineCollector(ctx, bs.mgr.GetClient())
+	metrics.Registry.MustRegister(machineCollector)
+
 	if err := machinecontroller.Add(
 		ctx,
 		bs.mgr,


### PR DESCRIPTION
**What this PR does / why we need it**:
In my last update I accidentally removed this call for the machine collector.

**Optional Release Note**:
```release-note
Fix missing machine_controller_machines metric
```
