### PR TITLE
use quay.io/kubermatic/kubelet

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -153,7 +153,7 @@ func main() {
 	flag.StringVar(&nodeRegistryMirrors, "node-registry-mirrors", "", "Comma separated list of Docker image mirrors")
 	flag.StringVar(&nodePauseImage, "node-pause-image", "", "Image for the pause container including tag. If not set, the kubelet default will be used: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/")
 	flag.StringVar(&nodeHyperkubeImage, "node-hyperkube-image", "k8s.gcr.io/hyperkube-amd64", "Image for the hyperkube container excluding tag. Only has effect on Flatcar Linux, and for kubernetes < 1.18.")
-	flag.StringVar(&nodeKubeletRepository, "node-kubelet-repository", "quay.io/poseidon/kubelet", "Repository for the kubelet container. Only has effect on Flatcar Linux, and for kubernetes >= 1.18.")
+	flag.StringVar(&nodeKubeletRepository, "node-kubelet-repository", "quay.io/kubermatic/kubelet", "Repository for the kubelet container. Only has effect on Flatcar Linux, and for kubernetes >= 1.18.")
 	flag.StringVar(&nodeKubeletFeatureGates, "node-kubelet-feature-gates", "RotateKubeletServerCertificate=true", "Feature gates to set on the kubelet. Default: RotateKubeletServerCertificate=true")
 	flag.StringVar(&nodeContainerRuntime, "node-container-runtime", "docker", "container-runtime to deploy")
 	flag.BoolVar(&nodeCSRApprover, "node-csr-approver", false, "Enable NodeCSRApprover controller to automatically approve node serving certificate requests.")

--- a/docs/network-restrictions.md
+++ b/docs/network-restrictions.md
@@ -35,7 +35,7 @@ For Flatcar Linux nodes, the [hyperkube][1] or [kubelet][3] image must be access
 that kubelet is running as a docker container. For kubelet version `< 1.18` hyperkube will be used, otherwise `kubelet`
 image.
 
-By default the image `quay.io/poseidon/kubelet` will be used. If that image won't be accessible from the node, a custom
+By default the image `quay.io/kubermatic/kubelet` will be used. If that image won't be accessible from the node, a custom
 image can be specified on the machine-controller:
 ```bash
 # Do not set a tag. The tag depends on the used Kubernetes version of a machine.
@@ -54,4 +54,4 @@ If nodes require access to insecure registries, all registries must be specified
 
 [1]: https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/hyperkube
 [2]: https://github.com/coreos/coreos-kubernetes/blob/master/Documentation/kubelet-wrapper.md
-[3]: https://quay.io/poseidon/kubelet
+[3]: https://quay.io/kubermatic/kubelet


### PR DESCRIPTION
**What this PR does / why we need it**:
This replaces the default kubelet Docker image with kubermatic/kubelet. We use this repo now because it provides updates for older Kubernetes releases. This is part of https://github.com/kubermatic/kubermatic/issues/6441

**Optional Release Note**:
```release-note
Switch default kubelet Docker image to quay.io/kubermatic/kubelet
```
