### PR TITLE
Support image reference in azure

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -312,6 +312,29 @@ presubmits:
               memory: 1Gi
               cpu: 500m
 
+  - name: pull-machine-controller-e2e-azure-custom-image-reference
+    always_run: true
+    decorate: true
+    error_on_eviction: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    labels:
+      preset-azure: "true"
+      preset-hetzner: "true"
+      preset-e2e-ssh: "true"
+      preset-rhel: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: golang:1.15.1
+          command:
+            - "./hack/ci-e2e-test.sh"
+          args:
+            - "TestAzureCustomImageReferenceProvisioningE2E"
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 500m
+
   - name: pull-machine-controller-e2e-azure-redhat-satellite
     optional: true
     always_run: false

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -84,6 +84,7 @@ type config struct {
 	ImageID           string
 	Zones             []string
 	ImagePlan         *compute.Plan
+	ImageReference    *compute.ImageReference
 
 	OSDiskSize   int32
 	DataDiskSize int32
@@ -152,10 +153,19 @@ var osPlans = map[providerconfigtypes.OperatingSystem]*compute.Plan{
 	},
 }
 
-func getOSImageReference(imageID string, os providerconfigtypes.OperatingSystem) (*compute.ImageReference, error) {
-	if imageID != "" {
+func getOSImageReference(c *config, os providerconfigtypes.OperatingSystem) (*compute.ImageReference, error) {
+	if c.ImageID != "" {
 		return &compute.ImageReference{
-			ID: to.StringPtr(imageID),
+			ID: to.StringPtr(c.ImageID),
+		}, nil
+	}
+
+	if c.ImageReference != nil {
+		return &compute.ImageReference{
+			Version:   c.ImageReference.Version,
+			Sku:       c.ImageReference.Sku,
+			Offer:     c.ImageReference.Offer,
+			Publisher: c.ImageReference.Publisher,
 		}, nil
 	}
 
@@ -272,6 +282,15 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*config, *providerconfigt
 			Name:      pointer.StringPtr(rawCfg.ImagePlan.Name),
 			Publisher: pointer.StringPtr(rawCfg.ImagePlan.Publisher),
 			Product:   pointer.StringPtr(rawCfg.ImagePlan.Product),
+		}
+	}
+
+	if rawCfg.ImageReference != nil {
+		c.ImageReference = &compute.ImageReference{
+			Publisher: pointer.StringPtr(rawCfg.ImageReference.Publisher),
+			Offer:     pointer.StringPtr(rawCfg.ImageReference.Offer),
+			Sku:       pointer.StringPtr(rawCfg.ImageReference.Sku),
+			Version:   pointer.StringPtr(rawCfg.ImageReference.Version),
 		}
 	}
 
@@ -419,7 +438,7 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 }
 
 func getStorageProfile(config *config, providerCfg *providerconfigtypes.Config) (*compute.StorageProfile, error) {
-	osRef, err := getOSImageReference(config.ImageID, providerCfg.OperatingSystem)
+	osRef, err := getOSImageReference(config, providerCfg.OperatingSystem)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OSImageReference: %v", err)
 	}
@@ -862,7 +881,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to get subnet: %v", err)
 	}
 
-	_, err = getOSImageReference(c.ImageID, providerCfg.OperatingSystem)
+	_, err = getOSImageReference(c, providerCfg.OperatingSystem)
 	return err
 }
 

--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -37,7 +37,8 @@ type RawConfig struct {
 	AvailabilitySet   providerconfigtypes.ConfigVarString `json:"availabilitySet"`
 	SecurityGroupName providerconfigtypes.ConfigVarString `json:"securityGroupName"`
 	Zones             []string                            `json:"zones"`
-	ImagePlan         *ImagePlan                          `json:"imagePlan"`
+	ImagePlan         *ImagePlan                          `json:"imagePlan,omitempty"`
+	ImageReference    *ImageReference                     `json:"imageReference,omitempty"`
 
 	ImageID        providerconfigtypes.ConfigVarString `json:"imageID"`
 	OSDiskSize     int32                               `json:"osDiskSize"`
@@ -51,4 +52,12 @@ type ImagePlan struct {
 	Name      string `json:"name,omitempty"`
 	Publisher string `json:"publisher,omitempty"`
 	Product   string `json:"product,omitempty"`
+}
+
+// ImageReference specifies information about the image to use.
+type ImageReference struct {
+	Publisher string `json:"publisher,omitempty"`
+	Offer     string `json:"offer,omitempty"`
+	Sku       string `json:"sku,omitempty"`
+	Version   string `json:"version,omitempty"`
 }

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -39,27 +39,28 @@ func init() {
 }
 
 const (
-	DOManifest                   = "./testdata/machinedeployment-digitalocean.yaml"
-	AWSManifest                  = "./testdata/machinedeployment-aws.yaml"
-	AWSManifestARM               = "./testdata/machinedeployment-aws-arm-machines.yaml"
-	AWSEBSEncryptedManifest      = "./testdata/machinedeployment-aws-ebs-encryption-enabled.yaml"
-	AzureManifest                = "./testdata/machinedeployment-azure.yaml"
-	AzureRedhatSatelliteManifest = "./testdata/machinedeployment-azure.yaml"
-	GCEManifest                  = "./testdata/machinedeployment-gce.yaml"
-	HZManifest                   = "./testdata/machinedeployment-hetzner.yaml"
-	PacketManifest               = "./testdata/machinedeployment-packet.yaml"
-	LinodeManifest               = "./testdata/machinedeployment-linode.yaml"
-	VSPhereManifest              = "./testdata/machinedeployment-vsphere.yaml"
-	VSPhereDSCManifest           = "./testdata/machinedeployment-vsphere-datastore-cluster.yaml"
-	VSPhereResourcePoolManifest  = "./testdata/machinedeployment-vsphere-resource-pool.yaml"
-	ScalewayManifest             = "./testdata/machinedeployment-scaleway.yaml"
-	OSManifest                   = "./testdata/machinedeployment-openstack.yaml"
-	OSUpgradeManifest            = "./testdata/machinedeployment-openstack-upgrade.yml"
-	invalidMachineManifest       = "./testdata/machine-invalid.yaml"
-	kubevirtManifest             = "./testdata/machinedeployment-kubevirt.yaml"
-	kubevirtManifestDNSConfig    = "./testdata/machinedeployment-kubevirt-dns-config.yaml"
-	alibabaManifest              = "./testdata/machinedeployment-alibaba.yaml"
-	anexiaManifest               = "./testdata/machinedeployment-anexia.yaml"
+	DOManifest                        = "./testdata/machinedeployment-digitalocean.yaml"
+	AWSManifest                       = "./testdata/machinedeployment-aws.yaml"
+	AWSManifestARM                    = "./testdata/machinedeployment-aws-arm-machines.yaml"
+	AWSEBSEncryptedManifest           = "./testdata/machinedeployment-aws-ebs-encryption-enabled.yaml"
+	AzureManifest                     = "./testdata/machinedeployment-azure.yaml"
+	AzureRedhatSatelliteManifest      = "./testdata/machinedeployment-azure.yaml"
+	AzureCustomImageReferenceManifest = "./testdata/machinedeployment-azure-custom-image-reference.yaml"
+	GCEManifest                       = "./testdata/machinedeployment-gce.yaml"
+	HZManifest                        = "./testdata/machinedeployment-hetzner.yaml"
+	PacketManifest                    = "./testdata/machinedeployment-packet.yaml"
+	LinodeManifest                    = "./testdata/machinedeployment-linode.yaml"
+	VSPhereManifest                   = "./testdata/machinedeployment-vsphere.yaml"
+	VSPhereDSCManifest                = "./testdata/machinedeployment-vsphere-datastore-cluster.yaml"
+	VSPhereResourcePoolManifest       = "./testdata/machinedeployment-vsphere-resource-pool.yaml"
+	ScalewayManifest                  = "./testdata/machinedeployment-scaleway.yaml"
+	OSManifest                        = "./testdata/machinedeployment-openstack.yaml"
+	OSUpgradeManifest                 = "./testdata/machinedeployment-openstack-upgrade.yml"
+	invalidMachineManifest            = "./testdata/machine-invalid.yaml"
+	kubevirtManifest                  = "./testdata/machinedeployment-kubevirt.yaml"
+	kubevirtManifestDNSConfig         = "./testdata/machinedeployment-kubevirt-dns-config.yaml"
+	alibabaManifest                   = "./testdata/machinedeployment-alibaba.yaml"
+	anexiaManifest                    = "./testdata/machinedeployment-anexia.yaml"
 )
 
 var testRunIdentifier = flag.String("identifier", "local", "The unique identifier for this test run")
@@ -327,6 +328,31 @@ func TestAzureProvisioningE2E(t *testing.T) {
 		fmt.Sprintf("<< AZURE_CLIENT_SECRET >>=%s", azureClientSecret),
 	}
 	runScenarios(t, selector, params, AzureManifest, fmt.Sprintf("azure-%s", *testRunIdentifier))
+}
+
+// TestAzureCustomImageReferenceProvisioningE2E - a test suite that exercises Azure provider
+// by requesting nodes with different combination of container runtime type, container runtime version and custom Image reference.
+func TestAzureCustomImageReferenceProvisioningE2E(t *testing.T) {
+	t.Parallel()
+
+	// test data
+	azureTenantID := os.Getenv("AZURE_E2E_TESTS_TENANT_ID")
+	azureSubscriptionID := os.Getenv("AZURE_E2E_TESTS_SUBSCRIPTION_ID")
+	azureClientID := os.Getenv("AZURE_E2E_TESTS_CLIENT_ID")
+	azureClientSecret := os.Getenv("AZURE_E2E_TESTS_CLIENT_SECRET")
+	if len(azureTenantID) == 0 || len(azureSubscriptionID) == 0 || len(azureClientID) == 0 || len(azureClientSecret) == 0 {
+		t.Fatal("unable to run the test suite, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET environment variables cannot be empty")
+	}
+
+	selector := OsSelector("ubuntu")
+	// act
+	params := []string{
+		fmt.Sprintf("<< AZURE_TENANT_ID >>=%s", azureTenantID),
+		fmt.Sprintf("<< AZURE_SUBSCRIPTION_ID >>=%s", azureSubscriptionID),
+		fmt.Sprintf("<< AZURE_CLIENT_ID >>=%s", azureClientID),
+		fmt.Sprintf("<< AZURE_CLIENT_SECRET >>=%s", azureClientSecret),
+	}
+	runScenarios(t, selector, params, AzureCustomImageReferenceManifest, fmt.Sprintf("azure-%s", *testRunIdentifier))
 }
 
 // TestAzureRedhatSatelliteProvisioningE2E - a test suite that exercises Azure provider

--- a/test/e2e/provisioning/testdata/machinedeployment-azure-custom-image-reference.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure-custom-image-reference.yaml
@@ -1,0 +1,60 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: << MACHINE_NAME >>
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: << MACHINE_NAME >>
+  template:
+    metadata:
+      labels:
+        name: << MACHINE_NAME >>
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProvider: "azure"
+          cloudProviderSpec:
+            tenantID: "<< AZURE_TENANT_ID >>"
+            clientID: "<< AZURE_CLIENT_ID >>"
+            clientSecret: "<< AZURE_CLIENT_SECRET >>"
+            subscriptionID: "<< AZURE_SUBSCRIPTION_ID >>"
+            location: "westeurope"
+            resourceGroup: "machine-controller-e2e"
+            vnetResourceGroup: ""
+            vmSize: "Standard_F2"
+            # optional disk size values in GB. If not set, the defaults for the vmSize will be used.
+            osDiskSize: << OS_DISK_SIZE >>
+            dataDiskSize: << DATA_DISK_SIZE >>
+            vnetName: "machine-controller-e2e"
+            subnetName: "machine-controller-e2e"
+            routeTableName: "machine-controller-e2e"
+            imageID: "<< IMAGE_ID >>"
+            imageReference:
+              publisher: "Canonical"
+              offer: "0001-com-ubuntu-server-focal"
+              sku: "20_04-lts"
+              version: "latest"
+            assignPublicIP: false
+            zones:
+              - "1"
+          operatingSystem: "<< OS_NAME >>"
+          operatingSystemSpec:
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+            # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
+            # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
+      versions:
+        kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
Support azure custom image reference. This is needed in order to create worker nodes that run ubuntu 20.04 e.g and to support other os versions. The current `image_id` field doesn't work with public images and it only works with custom images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
```release-note
Image Reference Support in Azure
```
