### PR TITLE
Add application credentials to openstack provider

### DIFF
--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -58,6 +58,18 @@ spec:
                 namespace: kube-system
                 name: machine-controller-openstack
                 key: identityEndpoint
+          # If empty, can be set via OS_APPLICATION_CREDENTIAL_ID env var
+            applicationCredentialID:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: applicationCredentialID
+          # If empty, can be set via OS_APPLICATION_CREDENTIAL_SECRET env var
+            applicationCredentialSecret:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: applicationCredentialSecret
           # If empty, can be set via OS_USER_NAME env var
             username:
               secretKeyRef:

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -124,8 +124,9 @@ func (p *provider) getConfigAuth(c *Config, rawConfig *openstacktypes.RawConfig)
 		klog.V(6).Infof("applicationCredentialID from configuration or environment was found.")
 		c.ApplicationCredentialSecret, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ApplicationCredentialSecret, "OS_APPLICATION_CREDENTIAL_SECRET")
 		if err != nil {
-			return fmt.Errorf("failed to get the value of \"applicationCredentialSecret\" field, error = %v", err)
+			return fmt.Errorf(`failed to get the value of "applicationCredentialSecret" field, error = %v`, err)
 		}
+		return nil
 	} else {
 		c.Username, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Username, "OS_USER_NAME")
 		if err != nil {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -124,9 +124,10 @@ func (p *provider) getConfigAuth(c *Config, rawConfig *openstacktypes.RawConfig)
 		klog.V(6).Infof("applicationCredentialID from configuration or environment was found.")
 		c.ApplicationCredentialSecret, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ApplicationCredentialSecret, "OS_APPLICATION_CREDENTIAL_SECRET")
 		if err != nil {
-			return fmt.Errorf(`failed to get the value of "applicationCredentialSecret" field, error = %v`, err)
+			return fmt.Errorf("failed to get the value of \"applicationCredentialSecret\" field, error = %v", err)
 		}
 		return nil
+	}
 	c.Username, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Username, "OS_USER_NAME")
 	if err != nil {
 		return fmt.Errorf("failed to get the value of \"username\" field, error = %v", err)

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -127,23 +127,21 @@ func (p *provider) getConfigAuth(c *Config, rawConfig *openstacktypes.RawConfig)
 			return fmt.Errorf(`failed to get the value of "applicationCredentialSecret" field, error = %v`, err)
 		}
 		return nil
-	} else {
-		c.Username, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Username, "OS_USER_NAME")
-		if err != nil {
-			return fmt.Errorf("failed to get the value of \"username\" field, error = %v", err)
-		}
-		c.Password, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Password, "OS_PASSWORD")
-		if err != nil {
-			return fmt.Errorf("failed to get the value of \"password\" field, error = %v", err)
-		}
-		c.TenantName, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantName, "OS_TENANT_NAME")
-		if err != nil {
-			return fmt.Errorf("failed to get the value of \"tenantName\" field, error = %v", err)
-		}
-		c.TenantID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantID, "OS_TENANT_ID")
-		if err != nil {
-			return fmt.Errorf("failed to get the value of \"tenantID\" field, error = %v", err)
-		}
+	c.Username, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Username, "OS_USER_NAME")
+	if err != nil {
+		return fmt.Errorf("failed to get the value of \"username\" field, error = %v", err)
+	}
+	c.Password, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Password, "OS_PASSWORD")
+	if err != nil {
+		return fmt.Errorf("failed to get the value of \"password\" field, error = %v", err)
+	}
+	c.TenantName, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantName, "OS_TENANT_NAME")
+	if err != nil {
+		return fmt.Errorf("failed to get the value of \"tenantName\" field, error = %v", err)
+	}
+	c.TenantID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantID, "OS_TENANT_ID")
+	if err != nil {
+		return fmt.Errorf("failed to get the value of \"tenantID\" field, error = %v", err)
 	}
 	return nil
 }

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -289,13 +289,15 @@ func setProviderSpec(rawConfig openstacktypes.RawConfig, s v1alpha1.ProviderSpec
 
 func getClient(c *Config) (*gophercloud.ProviderClient, error) {
 	opts := gophercloud.AuthOptions{
-		IdentityEndpoint: c.IdentityEndpoint,
-		Username:         c.Username,
-		Password:         c.Password,
-		DomainName:       c.DomainName,
-		TenantName:       c.TenantName,
-		TenantID:         c.TenantID,
-		TokenID:          c.TokenID,
+		IdentityEndpoint:            c.IdentityEndpoint,
+		Username:                    c.Username,
+		Password:                    c.Password,
+		DomainName:                  c.DomainName,
+		TenantName:                  c.TenantName,
+		TenantID:                    c.TenantID,
+		TokenID:                     c.TokenID,
+		ApplicationCredentialID:     c.ApplicationCredentialID,
+		ApplicationCredentialSecret: c.ApplicationCredentialSecret,
 	}
 
 	pc, err := goopenstack.AuthenticatedClient(opts)

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -122,7 +122,7 @@ func (p *provider) getConfigAuth(c *Config, rawConfig *openstacktypes.RawConfig)
 	c.ApplicationCredentialID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ApplicationCredentialID, "OS_APPLICATION_CREDENTIAL_ID")
 	if err == nil {
 		klog.V(6).Infof("applicationCredentialID from configuration or environment was found.")
-		c.ApplicationCredentialSecret, _ = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ApplicationCredentialSecret, "OS_APPLICATION_CREDENTIAL_SECRET")
+		c.ApplicationCredentialSecret, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ApplicationCredentialSecret, "OS_APPLICATION_CREDENTIAL_SECRET")
 		if err != nil {
 			return fmt.Errorf("failed to get the value of \"applicationCredentialSecret\" field, error = %v", err)
 		}

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -120,7 +120,10 @@ var floatingIPAssignLock = &sync.Mutex{}
 func (p *provider) getConfigAuth(c *Config, rawConfig *openstacktypes.RawConfig) error {
 	var err error
 	c.ApplicationCredentialID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ApplicationCredentialID, "OS_APPLICATION_CREDENTIAL_ID")
-	if err == nil {
+	if err != nil {
+		return fmt.Errorf("failed to get the value of \"applicationCredentialID\" field, error = %v", err)
+	}
+	if c.ApplicationCredentialID != "" {
 		klog.V(6).Infof("applicationCredentialID from configuration or environment was found.")
 		c.ApplicationCredentialSecret, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ApplicationCredentialSecret, "OS_APPLICATION_CREDENTIAL_SECRET")
 		if err != nil {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -80,14 +80,16 @@ func New(configVarResolver *providerconfig.ConfigVarResolver) cloudprovidertypes
 }
 
 type Config struct {
-	IdentityEndpoint string
-	Username         string
-	Password         string
-	DomainName       string
-	TenantName       string
-	TenantID         string
-	TokenID          string
-	Region           string
+	IdentityEndpoint            string
+	ApplicationCredentialID     string
+	ApplicationCredentialSecret string
+	Username                    string
+	Password                    string
+	DomainName                  string
+	TenantName                  string
+	TenantID                    string
+	TokenID                     string
+	Region                      string
 
 	// Machine details
 	Image                 string
@@ -115,6 +117,36 @@ const (
 // Protects floating ip assignment
 var floatingIPAssignLock = &sync.Mutex{}
 
+func (p *provider) getConfigAuth(c *Config, rawConfig *openstacktypes.RawConfig) error {
+	var err error
+	c.ApplicationCredentialID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ApplicationCredentialID, "OS_APPLICATION_CREDENTIAL_ID")
+	if err == nil {
+		klog.V(6).Infof("applicationCredentialID from configuration or environment was found.")
+		c.ApplicationCredentialSecret, _ = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ApplicationCredentialSecret, "OS_APPLICATION_CREDENTIAL_SECRET")
+		if err != nil {
+			return fmt.Errorf("failed to get the value of \"applicationCredentialSecret\" field, error = %v", err)
+		}
+	} else {
+		c.Username, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Username, "OS_USER_NAME")
+		if err != nil {
+			return fmt.Errorf("failed to get the value of \"username\" field, error = %v", err)
+		}
+		c.Password, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Password, "OS_PASSWORD")
+		if err != nil {
+			return fmt.Errorf("failed to get the value of \"password\" field, error = %v", err)
+		}
+		c.TenantName, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantName, "OS_TENANT_NAME")
+		if err != nil {
+			return fmt.Errorf("failed to get the value of \"tenantName\" field, error = %v", err)
+		}
+		c.TenantID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantID, "OS_TENANT_ID")
+		if err != nil {
+			return fmt.Errorf("failed to get the value of \"tenantID\" field, error = %v", err)
+		}
+	}
+	return nil
+}
+
 func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigtypes.Config, *openstacktypes.RawConfig, error) {
 	if s.Value == nil {
 		return nil, nil, nil, fmt.Errorf("machine.spec.providerconfig.value is nil")
@@ -134,13 +166,10 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get the value of \"identityEndpoint\" field, error = %v", err)
 	}
-	c.Username, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Username, "OS_USER_NAME")
+	// Retrieve authentication config, username/password or application credentials
+	err = p.getConfigAuth(&c, &rawConfig)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get the value of \"username\" field, error = %v", err)
-	}
-	c.Password, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Password, "OS_PASSWORD")
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get the value of \"password\" field, error = %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to retrieve authentication credentials, error = %v", err)
 	}
 	// Ignore Region not found as Region might not be found and we can default it later
 	c.Region, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Region, "OS_REGION_NAME")
@@ -187,14 +216,6 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 
 	// We ignore errors here because the OS domain is only required when using Identity API V3
 	c.DomainName, _ = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.DomainName, "OS_DOMAIN_NAME")
-	c.TenantName, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantName, "OS_TENANT_NAME")
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get the value of \"tenantName\" field, error = %v", err)
-	}
-	c.TenantID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantID, "OS_TENANT_ID")
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to get the value of \"tenantID\" field, error = %v", err)
-	}
 	c.TokenID, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.TokenID)
 	if err != nil {
 		return nil, nil, nil, err
@@ -372,20 +393,26 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to parse config: %v", err)
 	}
 
-	if c.Username == "" {
-		return errors.New("username must be configured")
-	}
+	if c.ApplicationCredentialID == "" {
+		if c.Username == "" {
+			return errors.New("username must be configured")
+		}
 
-	if c.Password == "" {
-		return errors.New("password must be configured")
+		if c.Password == "" {
+			return errors.New("password must be configured")
+		}
+
+		if c.TenantID == "" && c.TenantName == "" {
+			return errors.New("either tenantID or tenantName must be configured")
+		}
+	} else {
+		if c.ApplicationCredentialSecret == "" {
+			return errors.New("applicationCredentialSecret must be configured in conjunction with applicationCredentialID")
+		}
 	}
 
 	if c.DomainName == "" {
 		return errors.New("domainName must be configured")
-	}
-
-	if c.TenantID == "" && c.TenantName == "" {
-		return errors.New("either tenantID or tenantName must be configured")
 	}
 
 	if c.Image == "" {

--- a/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
@@ -33,10 +33,15 @@ import (
 const (
 	cloudConfigTpl = `[Global]
 auth-url    = {{ .Global.AuthURL | iniEscape }}
+{{- if .Global.ApplicationCredentialID }}
+application-credential-id     = {{ .Global.ApplicationCredentialID | iniEscape }}
+application-credential-secret = {{ .Global.ApplicationCredentialSecret | iniEscape }}
+{{- else }}
 username    = {{ .Global.Username | iniEscape }}
 password    = {{ .Global.Password | iniEscape }}
 tenant-name = {{ .Global.TenantName | iniEscape }}
 tenant-id   = {{ .Global.TenantID | iniEscape }}
+{{- end }}
 domain-name = {{ .Global.DomainName | iniEscape }}
 region      = {{ .Global.Region | iniEscape }}
 
@@ -94,13 +99,15 @@ type BlockStorageOpts struct {
 }
 
 type GlobalOpts struct {
-	AuthURL    string `gcfg:"auth-url"`
-	Username   string
-	Password   string
-	TenantName string `gcfg:"tenant-name"`
-	TenantID   string `gcfg:"tenant-id"`
-	DomainName string `gcfg:"domain-name"`
-	Region     string
+	AuthURL                     string `gcfg:"auth-url"`
+	Username                    string
+	Password                    string
+	ApplicationCredentialID     string `gcfg:"application-credential-id"`
+	ApplicationCredentialSecret string `gcfg:"application-credential-secret"`
+	TenantName                  string `gcfg:"tenant-name"`
+	TenantID                    string `gcfg:"tenant-id"`
+	DomainName                  string `gcfg:"domain-name"`
+	Region                      string
 }
 
 // CloudConfig is used to read and store information from the cloud configuration file

--- a/pkg/cloudprovider/provider/openstack/types/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/openstack/types/cloudconfig_test.go
@@ -149,6 +149,38 @@ func TestCloudConfigToString(t *testing.T) {
 				Version:      "1.10.0",
 			},
 		},
+		{
+			name: "use-application-credentials",
+			config: &CloudConfig{
+				Global: GlobalOpts{
+					AuthURL:                     "https://127.0.0.1:8443",
+					ApplicationCredentialID:     "app-cred-id",
+					ApplicationCredentialSecret: "app-cred-secret",
+					DomainName:                  "Default",
+					Region:                      "eu-central1",
+				},
+				BlockStorage: BlockStorageOpts{},
+				LoadBalancer: LoadBalancerOpts{},
+				Version:      "1.10.0",
+			},
+		},
+		{
+			name: "use-application-credentials-ignore-userpass",
+			config: &CloudConfig{
+				Global: GlobalOpts{
+					AuthURL:                     "https://127.0.0.1:8443",
+					ApplicationCredentialID:     "app-cred-id",
+					ApplicationCredentialSecret: "app-cred-secret",
+					Username:                    "admin",
+					Password:                    "password",
+					DomainName:                  "Default",
+					Region:                      "eu-central1",
+				},
+				BlockStorage: BlockStorageOpts{},
+				LoadBalancer: LoadBalancerOpts{},
+				Version:      "1.10.0",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/cloudprovider/provider/openstack/types/testdata/use-application-credentials-ignore-userpass.golden
+++ b/pkg/cloudprovider/provider/openstack/types/testdata/use-application-credentials-ignore-userpass.golden
@@ -1,0 +1,18 @@
+[Global]
+auth-url    = "https://127.0.0.1:8443"
+application-credential-id     = "app-cred-id"
+application-credential-secret = "app-cred-secret"
+domain-name = "Default"
+region      = "eu-central1"
+
+[LoadBalancer]
+lb-version = "v2"
+subnet-id = ""
+floating-network-id = ""
+lb-method = "ROUND_ROBIN"
+lb-provider = ""
+
+[BlockStorage]
+ignore-volume-az  = false
+trust-device-path = false
+bs-version        = "auto"

--- a/pkg/cloudprovider/provider/openstack/types/testdata/use-application-credentials.golden
+++ b/pkg/cloudprovider/provider/openstack/types/testdata/use-application-credentials.golden
@@ -1,0 +1,18 @@
+[Global]
+auth-url    = "https://127.0.0.1:8443"
+application-credential-id     = "app-cred-id"
+application-credential-secret = "app-cred-secret"
+domain-name = "Default"
+region      = "eu-central1"
+
+[LoadBalancer]
+lb-version = "v2"
+subnet-id = ""
+floating-network-id = ""
+lb-method = "ROUND_ROBIN"
+lb-provider = ""
+
+[BlockStorage]
+ignore-volume-az  = false
+trust-device-path = false
+bs-version        = "auto"

--- a/pkg/cloudprovider/provider/openstack/types/types.go
+++ b/pkg/cloudprovider/provider/openstack/types/types.go
@@ -22,16 +22,18 @@ import (
 
 type RawConfig struct {
 	// Auth details
-	IdentityEndpoint          providerconfigtypes.ConfigVarString `json:"identityEndpoint,omitempty"`
-	Username                  providerconfigtypes.ConfigVarString `json:"username,omitempty"`
-	Password                  providerconfigtypes.ConfigVarString `json:"password,omitempty"`
-	DomainName                providerconfigtypes.ConfigVarString `json:"domainName,omitempty"`
-	TenantName                providerconfigtypes.ConfigVarString `json:"tenantName,omitempty"`
-	TenantID                  providerconfigtypes.ConfigVarString `json:"tenantID,omitempty"`
-	TokenID                   providerconfigtypes.ConfigVarString `json:"tokenId,omitempty"`
-	Region                    providerconfigtypes.ConfigVarString `json:"region,omitempty"`
-	InstanceReadyCheckPeriod  providerconfigtypes.ConfigVarString `json:"instanceReadyCheckPeriod,omitempty"`
-	InstanceReadyCheckTimeout providerconfigtypes.ConfigVarString `json:"instanceReadyCheckTimeout,omitempty"`
+	IdentityEndpoint            providerconfigtypes.ConfigVarString `json:"identityEndpoint,omitempty"`
+	Username                    providerconfigtypes.ConfigVarString `json:"username,omitempty"`
+	Password                    providerconfigtypes.ConfigVarString `json:"password,omitempty"`
+	ApplicationCredentialID     providerconfigtypes.ConfigVarString `json:"applicationCredentialID,omitempty"`
+	ApplicationCredentialSecret providerconfigtypes.ConfigVarString `json:"applicationCredentialSecret,omitempty"`
+	DomainName                  providerconfigtypes.ConfigVarString `json:"domainName,omitempty"`
+	TenantName                  providerconfigtypes.ConfigVarString `json:"tenantName,omitempty"`
+	TenantID                    providerconfigtypes.ConfigVarString `json:"tenantID,omitempty"`
+	TokenID                     providerconfigtypes.ConfigVarString `json:"tokenId,omitempty"`
+	Region                      providerconfigtypes.ConfigVarString `json:"region,omitempty"`
+	InstanceReadyCheckPeriod    providerconfigtypes.ConfigVarString `json:"instanceReadyCheckPeriod,omitempty"`
+	InstanceReadyCheckTimeout   providerconfigtypes.ConfigVarString `json:"instanceReadyCheckTimeout,omitempty"`
 
 	// Machine details
 	Image                 providerconfigtypes.ConfigVarString   `json:"image"`


### PR DESCRIPTION
Signed-off-by: Happy2C0de <46957159+Happy2C0de@users.noreply.github.com>

**What this PR does / why we need it**:
Add support for openstack application credentials

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #899

**Special notes for your reviewer**:
Addition of `getConfigAuth` function in provider.go limits the cyclomatic complexity that was reached with a direct integration into `getConfig` function. From my point of view, excluding the retrieval of authentication information makes sense.

Please to proper e2e tests.

**Optional Release Note**:
```release-note
Add application credentials support to the Openstack provider
```
