### PR TITLE
Create workaround for kubelet stopped posting node status bug

### DIFF
--- a/pkg/userdata/scripts/health-monitor.sh
+++ b/pkg/userdata/scripts/health-monitor.sh
@@ -30,7 +30,7 @@ set -o pipefail
 
 # We simply kill the process when there is a failure. Another systemd service will
 # automatically restart the process.
-function container_runtime_monitoring {
+function container_runtime_monitoring() {
   local -r max_attempts=5
   local attempt=1
   local -r crictl="${KUBE_HOME}/bin/crictl"
@@ -45,22 +45,22 @@ function container_runtime_monitoring {
   fi
   # Container runtime startup takes time. Make initial attempts before starting
   # killing the container runtime.
-  until timeout 60 ${healthcheck_command} > /dev/null; do
-    if (( attempt == max_attempts )); then
+  until timeout 60 "${healthcheck_command}" >/dev/null; do
+    if ((attempt == max_attempts)); then
       echo "Max attempt ${max_attempts} reached! Proceeding to monitor container runtime healthiness."
       break
     fi
     echo "$attempt initial attempt \"${healthcheck_command}\"! Trying again in $attempt seconds..."
-    sleep "$(( 2 ** attempt++ ))"
+    sleep "$((2 ** attempt++))"
   done
   while true; do
-    if ! timeout 60 ${healthcheck_command} > /dev/null; then
+    if ! timeout 60 "${healthcheck_command}" >/dev/null; then
       echo "Container runtime ${container_runtime_name} failed!"
       if [[ "$container_runtime_name" == "docker" ]]; then
-          # Dump stack of docker daemon for investigation.
-          # Log file name looks like goroutine-stacks-TIMESTAMP and will be saved to
-          # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
-          pkill -SIGUSR1 dockerd
+        # Dump stack of docker daemon for investigation.
+        # Log file name looks like goroutine-stacks-TIMESTAMP and will be saved to
+        # the exec root directory, which is /var/run/docker/ on Ubuntu and COS.
+        pkill -SIGUSR1 dockerd
       fi
       systemctl kill --kill-who=main "${container_runtime_name}"
       # Wait for a while, as we don't want to kill it again before it is really up.
@@ -71,7 +71,7 @@ function container_runtime_monitoring {
   done
 }
 
-function kubelet_monitoring {
+function kubelet_monitoring() {
   echo "Wait for 2 minutes for kubelet to be functional"
   # TODO(andyzheng0831): replace it with a more reliable method if possible.
   sleep 120
@@ -91,7 +91,6 @@ function kubelet_monitoring {
   done
 }
 
-
 ############## Main Function ################
 if [[ "$#" -ne 1 ]]; then
   echo "Usage: health-monitor.sh <container-runtime/kubelet>"
@@ -108,5 +107,5 @@ if [[ "${component}" == "container-runtime" ]]; then
 elif [[ "${component}" == "kubelet" ]]; then
   kubelet_monitoring
 else
-  echo "Health monitoring for component "${component}" is not supported!"
+  echo "Health monitoring for component ${component} is not supported!"
 fi

--- a/pkg/userdata/scripts/health-monitor.sh
+++ b/pkg/userdata/scripts/health-monitor.sh
@@ -77,10 +77,19 @@ function kubelet_monitoring() {
   sleep 120
   local -r max_seconds=10
   local output=""
-  while [ 1 ]; do
-    if ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
+  while true; do
+    local failed=false
+
+    if journalctl -u kubelet -n 1 | grep -q "use of closed network connection"; then
+      failed=true
+      echo "Kubelet stopped posting node status. Restarting"
+    elif ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
+      failed=true
       # Print the response and/or errors.
-      echo $output
+      echo "$output"
+    fi
+
+    if [[ "$failed" == "true" ]]; then
       echo "Kubelet is unhealthy!"
       systemctl kill kubelet
       # Wait for a while, as we don't want to kill it again before it is really up.


### PR DESCRIPTION
**What this PR does / why we need it**:

text by @phiphi282 
Sometimes the kubelet suddenly starts to hang and the kubelet needs to be restarted, or even the node if there is no ssh access.
This pr adds a script to cloud init to check the kubelet logs periodically and restarts the kubelet if needed.

This is because of this bug in kubernetes: kubernetes/kubernetes#87615
That will probably be fixed with the first kubernetes version that will use golang 1.16 (probably earliest version will be 1.21).

Replaces #844

```release-note
Create workaround for kubelet stopped posting node status bug
```
