### PR TITLE
windows support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ IMAGE_TAG = \
 		$(shell echo $$(git rev-parse HEAD && if [[ -n $$(git status --porcelain) ]]; then echo '-dirty'; fi)|tr -d ' ')
 IMAGE_NAME ?= $(REGISTRY)/$(REGISTRY_NAMESPACE)/machine-controller:$(IMAGE_TAG)
 
-OS = amzn2 centos ubuntu sles rhel flatcar
+OS = amzn2 centos ubuntu sles rhel flatcar windows
 USERDATA_BIN = $(patsubst %, machine-controller-userdata-%, $(OS))
 
 .PHONY: all

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 # Features
 ## What works
 - Creation of worker nodes on AWS, Digitalocean, Openstack, Azure, Google Cloud Platform, VMWare Vsphere, Linode, Hetzner cloud and Kubevirt (experimental)
-- Using Ubuntu, Flatcar or CentOS 7 distributions ([not all distributions work on all providers](/docs/operating-system.md))
+- Using Ubuntu, Flatcar, CentOS 7 or Windows distributions ([not all distributions work on all providers](/docs/operating-system.md))
 
 ## Supported Kubernetes versions
 machine-controller tries to follow as close as possible the Kubernetes version

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ locally, the following steps are required:
 * Populate the environment variable `HZ_E2E_TOKEN` with a valid Hetzner cloud token
 * Run `make e2e-cluster` to get a simple kubeadm cluster on Hetzner
 * Run `hack/run-machine-controller.sh` to locally run the machine-controller for your freshly created cluster
+* Run `hack/run-machine-controller-containerd.sh` to locally run the machine-controller by using containerd instead of docker
 
 If you want to use an existing cluster to test against, you can simply set the `KUBECONFIG` environment variable.
 In this case, first make sure that a kubeconfig created by `make e2e-cluster` at `$(go env GOPATH)/src/github.com/kubermatic/machine-controller/.kubeconfig`

--- a/cmd/provision/README.md
+++ b/cmd/provision/README.md
@@ -6,6 +6,7 @@ The following operating systems are supported
 - Ubuntu 18.04
 - CentOS 7
 - Flatcar
+- Windows
 
 ## Requirements
 - The cluster needs to use the bootstrap token authentication

--- a/cmd/userdata/windows/main.go
+++ b/cmd/userdata/windows/main.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//
+// UserData plugin for Windows.
+//
+
+package main
+
+import (
+	"flag"
+
+	"k8s.io/klog"
+
+	"github.com/kubermatic/machine-controller/pkg/userdata/windows"
+	userdataplugin "github.com/kubermatic/machine-controller/pkg/userdata/plugin"
+)
+
+func main() {
+	// Parse flags.
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "Switch for enabling the plugin debugging")
+	flag.Parse()
+
+	// Instantiate provider and start plugin.
+	var provider = &windows.Provider{}
+	var p = userdataplugin.New(provider, debug)
+
+	if err := p.Run(); err != nil {
+		klog.Fatalf("error running Windows plugin: %v", err)
+	}
+}

--- a/docs/howto-provider.md
+++ b/docs/howto-provider.md
@@ -71,7 +71,7 @@ Provider implementations are located in individual packages in `github.com/kuber
 When retrieving the individual configuration from the provider specification a type for unmarshalling is needed. Here first the provider configuration is read and based on it the individual values of the configuration are retrieved. Typically the access data (token, ID/key combination, document with all information) alternatively can be passed via an environment variable. According
 methods of the used `providerconfig.ConfigVarResolver` do support this.
 
-For creation of new machines the support of the possible information has to be checked. The machine controller supports _CentOS_, _Flatcar_ and _Ubuntu_. In case one or more aren't supported by the cloud infrastructure the error `providerconfig.ErrOSNotSupported` has to be returned.
+For creation of new machines the support of the possible information has to be checked. The machine controller supports _CentOS_, _Flatcar_, _Ubuntu_ and _Windows_. In case one or more aren't supported by the cloud infrastructure the error `providerconfig.ErrOSNotSupported` has to be returned.
 
 ## Integrate provider into the Machine Controller
 

--- a/docs/operating-system.md
+++ b/docs/operating-system.md
@@ -4,15 +4,15 @@
 
 ### Cloud provider
 
-|   | Ubuntu | Container Linux | CentOS | Flatcar | RHEL | SLES | Amazon Linux 2 |
-|---|---|---|---|---|---|---|---|
-| AWS | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Azure | ✓ | ✓ | ✓ | ✓ | ✓ | x | x |
-| Digitalocean  | ✓ | ✓ | ✓ | x | x | x | x |
-| Google Cloud Platform | ✓ | ✓ | x | x | ✓ | x | x |
-| Hetzner | ✓ | x | ✓ | x | x | x | x |
-| Packet | ✓ | ✓ | ✓ | x | x | x | x |
-| Openstack | ✓ | ✓ | ✓ | x | ✓ | x | x |
+|   | Ubuntu | Container Linux | CentOS | Flatcar | RHEL | SLES | Amazon Linux 2 | Windows |
+|---|---|---|---|---|---|---|---|---|
+| AWS | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ? |
+| Azure | ✓ | ✓ | ✓ | ✓ | ✓ | x | x | ? |
+| Digitalocean  | ✓ | ✓ | ✓ | x | x | x | x | ? |
+| Google Cloud Platform | ✓ | ✓ | x | x | ✓ | x | x | ? |
+| Hetzner | ✓ | x | ✓ | x | x | x | x | ? |
+| Packet | ✓ | ✓ | ✓ | x | x | x | x | ? |
+| Openstack | ✓ | ✓ | ✓ | x | ✓ | x | x | ✓ |
 
 ## Configuring a operating system
 
@@ -23,6 +23,7 @@ Allowed values:
 - `rhel`
 - `sles`
 - `ubuntu`
+- `windows`
 
 OS specific settings can be set via `machine.spec.providerConfig.operatingSystemSpec`.
 
@@ -38,6 +39,7 @@ Machine controller may work with other OS versions that are not listed in the ta
 | RHEL | 8.0, 8.1 |
 | SLES |  SLES 15 SP1 |
 | Ubuntu | 18.04 LTS |
+| Windows | 2019, 20H2.3 |
 
 ### Ubuntu
 
@@ -136,4 +138,35 @@ spec:
         value:
           ...
           operatingSystem: "centos"
+```
+
+### Windows
+
+```yaml
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: machine1
+  namespace: kube-system
+spec:
+  paused: false
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  minReadySeconds: 0
+  selector:
+    matchLabels:
+      foo: bar
+  template:
+    metadata:
+      labels:
+        foo: bar
+    spec:
+      providerConfig:
+        value:
+          ...
+          operatingSystem: "windows"
 ```

--- a/docs/vsphere.md
+++ b/docs/vsphere.md
@@ -209,6 +209,12 @@ CentOS 7 image can be found at the following link: <https://cloud.centos.org/cen
 
 Follow [qcow2](#create-template-vm-from-qcow2) template VM creation guide.
 
+#### Windows
+
+Windows Server 2019 images (testing only and registration required) can be found at the following link: <https://www.microsoft.com/evalcenter/evaluate-windows-server-2019>.
+Windows Server Semi-Annual images can be found only within the VLSC or Visual Studio Subscription portal.
+More information at the following link: <https://docs.microsoft.com/windows-server/get-started-19/servicing-channels-19>.
+
 ## Provider configuration
 
 VSphere provider accepts the following configuration parameters:

--- a/examples/windows-openstack-machinedeployment.yaml
+++ b/examples/windows-openstack-machinedeployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # If you change the namespace/name, you must also
+  # adjust the rbac rules
+  name: machine-controller-openstack
+  namespace: kube-system
+type: Opaque
+stringData:
+  identityEndpoint: << OS_AUTH_URL >>
+  username: << OS_USERNAME >>
+  password: << OS_PASSWORD >>
+  domainName: << OS_DOMAIN_NAME >>
+  tenantName: << OS_TENANT_NAME >>
+  region: << OS_REGION_NAME >>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: machine-controller
+  namespace: kube-system
+data:
+  securityGroup: external-ssh
+  sshPublicKey: "<< YOUR_PUBLIC_KEY >>"
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: openstack-machinedeployment
+  namespace: kube-system
+spec:
+  paused: false
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  minReadySeconds: 0
+  selector:
+    matchLabels:
+      foo: bar
+  template:
+    metadata:
+      labels:
+        foo: bar
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - configMapKeyRef:
+                  namespace: kube-system
+                  name: machine-controller
+                  key: sshPublicKey
+          cloudProvider: "openstack"
+          cloudProviderSpec:
+          # If empty, can be set via OS_AUTH_URL env var
+            identityEndpoint:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: identityEndpoint
+          # If empty, can be set via OS_USER_NAME env var
+            username:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: username
+          # If empty, can be set via OS_PASSWORD env var
+            password:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: password
+          # If empty, can be set via OS_DOMAIN_NAME env var
+            domainName:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: domainName
+          # If empty, can be set via OS_TENANT_NAME env var
+            tenantName:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: tenantName
+            # Only required if there is more than one region to choose from
+            region:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: region
+            instanceReadyCheckPeriod: 5s
+            instanceReadyCheckTimeout: 5m
+            image: "Windows Server 2019 Standard Core - Latest"
+            flavor: "m1.small"
+            securityGroups:
+              - configMapKeyRef:
+                  namespace: kube-system
+                  name: machine-controller
+                  key: securityGroup
+            # The machine won't get a floating ip if you leave this empty
+            floatingIpPool: "ext-net"
+            # Only required if there is more than one AZ to choose from
+            availabilityZone: ""
+            # Only required if there is more than one network available
+            network: ""
+            # the list of metadata you would like to attach to the instance
+            tags:
+              tagKey: tagValue
+          operatingSystem: "windows"
+          operatingSystemSpec:
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+      versions:
+        kubelet: 1.20.1

--- a/hack/run-machine-controller-containerd.sh
+++ b/hack/run-machine-controller-containerd.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Machine Controller Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Use a special env variable for machine-controller only
+MC_KUBECONFIG=${MC_KUBECONFIG:-$(dirname $0)/../.kubeconfig}
+# If you want to use the default kubeconfig `export MC_KUBECONFIG=$KUBECONFIG`
+
+make -C $(dirname $0)/.. build-machine-controller
+$(dirname $0)/../machine-controller \
+  -node-container-runtime=containerd \
+  -kubeconfig=$MC_KUBECONFIG \
+  -worker-count=50 \
+  -logtostderr \
+  -v=6 \
+  -cluster-dns=172.16.0.10 \
+  -enable-profiling \
+  -metrics-address=0.0.0.0:8080 \
+  -health-probe-address=0.0.0.0:8085

--- a/image-builder/build.sh
+++ b/image-builder/build.sh
@@ -23,7 +23,7 @@ TARGET_OS=""
 
 usage() {
   echo -e "usage:"
-  echo -e "\t$0 --target-os centos7|debian9|ubuntu-xenial|ubuntu-bionic [--release K8S-RELEASE]"
+  echo -e "\t$0 --target-os centos7|debian9|ubuntu-xenial|ubuntu-bionic|windows-20H2.3 [--release K8S-RELEASE]"
 }
 
 while [ $# -gt 0 ]; do
@@ -34,7 +34,7 @@ while [ $# -gt 0 ]; do
       ;;
     --target-os)
       if [[ -z "$2" ]]; then
-        echo "You must specify target OS. Currently 'centos7' is supported."
+        echo "You must specify a target OS."
         exit 1
       fi
       TARGET_OS="$2"
@@ -127,6 +127,11 @@ get_debian9_image() {
   mv "$TEMPDIR/debian-9-openstack-amd64.qcow2" "$SCRIPT_DIR/downloads/debian-9-openstack-amd64.qcow2"
 }
 
+build_windows_image() {
+  . "$SCRIPT_DIR/windows/check.sh"
+  . "$SCRIPT_DIR/windows/build.sh"
+}
+
 get_ubuntu_image() {
   local UBUNTU_CLOUD_IMAGE_SIGNING_KEY_FINGERPRINT="D2EB44626FDDC30B513D5BB71A5D6C4C7DB87C81"
   local RELEASE="$1"
@@ -203,6 +208,11 @@ case $TARGET_OS in
       get_ubuntu_image bionic
     fi
     ;;
+  windows-20H2.3)
+    CLEAN_IMAGE="$SCRIPT_DIR/windows/output/Win Server STD CORE 20H2.3 English/*"
+    if [[ ! -f "$CLEAN_IMAGE"]]; then
+      build_windows_image
+    fi
   *)
     usage
     exit 1

--- a/image-builder/windows/.gitattributes
+++ b/image-builder/windows/.gitattributes
@@ -1,0 +1,3 @@
+*               text=auto   eol=lf
+*.ps1           text        eol=crlf
+*.bat           text        eol=crlf

--- a/image-builder/windows/.gitignore
+++ b/image-builder/windows/.gitignore
@@ -1,0 +1,70 @@
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows shortcuts
+*.lnk
+
+Autounattend.xml
+virtio-win.iso
+driver/
+scripts/Set-ProductKey.ps1

--- a/image-builder/windows/Autounattend-env.xml
+++ b/image-builder/windows/Autounattend-env.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-International-Core-WinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SetupUILanguage>
+                <UILanguage>en-US</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+        </component>
+        <component name="Microsoft-Windows-PnpCustomizationsWinPE" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <DriverPaths>
+                <PathAndCredentials wcm:keyValue="1" wcm:action="add">
+                    <Path>A:\VIOSTOR\2K19\AMD64</Path>
+                </PathAndCredentials>
+                <PathAndCredentials wcm:keyValue="2" wcm:action="add">
+                    <Path>A:\VIOSCSI\2K19\AMD64</Path>
+                </PathAndCredentials>
+                <PathAndCredentials wcm:keyValue="3" wcm:action="add">
+                    <Path>A:\NETKVM\2K19\AMD64</Path>
+                </PathAndCredentials>
+            </DriverPaths>
+        </component>
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <!-- https://docs.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-setup-diskconfiguration-disk-createpartitions-createpartition-type -->
+            <DiskConfiguration>
+                <WillShowUI>OnError</WillShowUI>
+                <Disk wcm:action="add">
+                    <DiskID>0</DiskID>
+                    <WillWipeDisk>true</WillWipeDisk>
+                    <CreatePartitions>
+                        <!-- System partition -->
+                        <CreatePartition wcm:action="add">
+                            <Order>1</Order>
+                            <Type>Primary</Type>
+                            <Size>300</Size>
+                        </CreatePartition>
+                        <!-- Windows partition -->
+                        <CreatePartition wcm:action="add">
+                            <Order>2</Order>
+                            <Type>Primary</Type>
+                            <Extend>true</Extend>
+                        </CreatePartition>
+                    </CreatePartitions>
+                    <ModifyPartitions>
+                        <!-- System partition -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>1</Order>
+                            <PartitionID>1</PartitionID>
+                            <Label>System</Label>
+                            <Format>NTFS</Format>
+                            <Active>true</Active>
+                        </ModifyPartition>
+                        <!-- Windows partition -->
+                        <ModifyPartition wcm:action="add">
+                            <Order>2</Order>
+                            <PartitionID>2</PartitionID>
+                            <Label>Windows</Label>
+                            <Letter>C</Letter>
+                            <Format>NTFS</Format>
+                        </ModifyPartition>
+                    </ModifyPartitions>
+                </Disk>
+            </DiskConfiguration>
+            <ImageInstall>
+                <OSImage>
+                    <InstallFrom>
+                        <MetaData wcm:action="add">
+                            <Key>/IMAGE/NAME </Key>
+                            <Value>Windows Server SERVERSTANDARDACORE</Value>
+                        </MetaData>
+                    </InstallFrom>
+                    <InstallTo>
+                        <DiskID>0</DiskID>
+                        <PartitionID>2</PartitionID>
+                    </InstallTo>
+                    <WillShowUI>OnError</WillShowUI>
+                </OSImage>
+            </ImageInstall>
+            <UserData>
+                <!-- Product Key from http://technet.microsoft.com/en-us/library/jj612867.aspx -->
+                <!-- <ProductKey>
+                    Do not uncomment the Key element if you are using trial ISOs
+                    You must uncomment the Key element (and optionally insert your own key) if you are using retail or volume license ISOs
+                    <Key>XXXXX-XXXXX-XXXXX-XXXXX-XXXXX</Key>
+                    <WillShowUI>OnError</WillShowUI>
+                </ProductKey> -->
+                <AcceptEula>$win_accept_eula</AcceptEula>
+                <FullName>$win_register_username</FullName>
+                <Organization>$win_register_organization</Organization>
+            </UserData>
+        </component>
+    </settings>
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <OEMInformation>
+                <HelpCustomized>false</HelpCustomized>
+            </OEMInformation>
+            <ComputerName>*</ComputerName>
+            <TimeZone>$win_timezone</TimeZone>
+            <RegisteredOwner />
+        </component>
+        <component name="Microsoft-Windows-Security-SPP-UX" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <SkipAutoActivation>true</SkipAutoActivation>
+        </component>
+        <component name="Microsoft-Windows-Deployment" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <RunSynchronous>
+                <RunSynchronousCommand wcm:action="add">
+                    <Order>1</Order>
+                    <Path>net user administrator /active:yes</Path>
+                </RunSynchronousCommand>
+            </RunSynchronous>
+        </component>
+    </settings>
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <AutoLogon>
+                <Password>
+                    <Value>$win_admin_password</Value>
+                    <PlainText>true</PlainText>
+                </Password>
+                <Enabled>true</Enabled>
+                <Username>administrator</Username>
+            </AutoLogon>
+            <FirstLogonCommands>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                    <Description>Set Execution Policy 64 Bit</Description>
+                    <Order>1</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\SysWOW64\WindowsPowerShell\v1.0\powershell.exe -Command "Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force"</CommandLine>
+                    <Description>Set Execution Policy 32 Bit</Description>
+                    <Order>2</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c winrm quickconfig -q</CommandLine>
+                    <Description>winrm quickconfig -q</Description>
+                    <Order>3</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes </CommandLine>
+                    <Description>WinRM adv firewall enable</Description>
+                    <Order>4</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ /v HideFileExt /t REG_DWORD /d 0 /f</CommandLine>
+                    <Order>5</Order>
+                    <Description>Show file extensions in Explorer</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\Console /v QuickEdit /t REG_DWORD /d 1 /f</CommandLine>
+                    <Order>6</Order>
+                    <Description>Enable QuickEdit mode</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\ /v StartMenuAdminTools /t REG_DWORD /d 1 /f</CommandLine>
+                    <Order>7</Order>
+                    <Description>Show Administrative Tools in Start Menu</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\Power\ /v HibernateFileSizePercent /t REG_DWORD /d 0 /f</CommandLine>
+                    <Order>8</Order>
+                    <Description>Zero Hibernation File</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD HKLM\SYSTEM\CurrentControlSet\Control\Power\ /v HibernateEnabled /t REG_DWORD /d 0 /f</CommandLine>
+                    <Order>9</Order>
+                    <Description>Disable Hibernation Mode</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>cmd.exe /c wmic useraccount where "name='Administrator'" set PasswordExpires=FALSE</CommandLine>
+                    <Order>10</Order>
+                    <Description>Disable password expiration for Administrator user</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\reg.exe ADD "HKLM\SOFTWARE\Policies\Microsoft\Internet Explorer\Main" /v DisableFirstRunCustomize /t REG_DWORD /d 1 /f</CommandLine>
+                    <Order>11</Order>
+                    <Description>Disable Internet Explorer First Run Dialog to allow Invoke-WebRequest to function correctly</Description>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\Install-GuestTools.ps1</CommandLine>
+                    <Description>Install Guest Tools</Description>
+                    <Order>12</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\Enable-MicrosoftUpdates.ps1</CommandLine>
+                    <Description>Enable MicrosoftUpdates</Description>
+                    <Order>13</Order>
+                </SynchronousCommand>
+                <SynchronousCommand wcm:action="add">
+                    <CommandLine>%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe -File a:\Install-OpenSSH.ps1</CommandLine>
+                    <Description>Install OpenSSH</Description>
+                    <Order>14</Order>
+                </SynchronousCommand>
+            </FirstLogonCommands>
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <NetworkLocation>Home</NetworkLocation>
+                <ProtectYourPC>1</ProtectYourPC>
+            </OOBE>
+            <TimeZone>$win_timezone</TimeZone>
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>$win_admin_password</Value>
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+                <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value>$win_admin_password</Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Group>administrators</Group>
+                        <DisplayName>Administrator</DisplayName>
+                        <Name>administrator</Name>
+                        <Description>Local administrator</Description>
+                    </LocalAccount>
+                </LocalAccounts>
+            </UserAccounts>
+            <RegisteredOwner />
+        </component>
+    </settings>
+    <settings pass="offlineServicing">
+        <component name="Microsoft-Windows-LUA-Settings" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <EnableLUA>false</EnableLUA>
+        </component>
+    </settings>
+    <cpi:offlineImage xmlns:cpi="urn:schemas-microsoft-com:cpi" cpi:source="wim:c:/wim/install.wim#Windows Server SERVERSTANDARDACORE"/>
+</unattend>

--- a/image-builder/windows/README.md
+++ b/image-builder/windows/README.md
@@ -1,0 +1,35 @@
+# Windows Images
+
+## Dependency versions
+
+* [Packer](https://github.com/hashicorp/packer) `1.6.5` or greater is required.
+* [Packer-Provisioner-Windows-Update](https://github.com/rgl/packer-provisioner-windows-update) `0.11.0` or greater is required.
+* envsubs
+* 7z
+* wget
+* bash
+* qemu-img
+
+## Customizations
+
+* [Enable-MicrosoftUpdates](./scripts/Enable-MicrosoftUpdates.ps1): Enables Updates for other Microsoft Products to be downloaded together with Windows Updates
+* [Install-GuestTools](./scripts/Install-GuestTools.ps1): Installs guest tools for the used hypervisor. Currently only VirtIO (QEMU/KVM)
+* [Install-PowerShellCore](./scripts/Install-PowerShellCore.ps1): Installs the most recent version of PowerShell. So that it can be utilized for administrative tasks and for remoting over SSH (instead of only WinRM).
+* [Install-OpenSSH](./scripts/Install-OpenSSH.ps1): Installs the most recent version of OpenSSH so that we can connect using ssh.
+* [Set-WindowsTimeZone](./scripts/Set-WindowsTimeZone.ps1): This script sets the time zone to UTC. The time zone is also set within the Autounattend.xml, but that has profen to be unreliable in recent builds of windows 10 and windows server.
+* [Set-ProductKey](./scripts/Set-ProductKey.ps1): This script injects the product key and activates windows. In former versions of windows the product key was usualy provided via the Autounattend.xml, but that fails in some cases with recent builds of windows 10 and windows server.
+* [Configure-WindowsSecurity](./scripts/Configure-WindowsSecurity.ps1): Configures windows to a base level of security so that it isn't an immediate target when deployed with public ip and no security group (firewall) restrictions in front of it.
+  * Hardening Windows Defender settings (To change use PowerShell commands).
+  * Enabling SmartScreen to protect against accidental execution of malicious files.
+  * Disable IPv6 Privacy Extension and Interface Identifier Randomization. These are unsuitable for servers anyway, but cause problems within OpenStack environments esp. in combination with PortSecurity.
+  * Enforce NLA (Network Level Authentication) for RDP
+  * Enable RDP (it's recommended to tunnel it through SSH though)
+  * Enable ICMP Echo Requests (allow to "ping" the server)
+  * Disable Auto Logon that we used while installing windows until we were able to connect via SSH.
+  * Enable CPU vulnerability Mitigations for Spectre, Meltdown, ...
+  * Enforce strong security for TLS to prevent attacks and comply with many certifications of enterprises.
+  * Enable SCHANNEL eventLogging, log failed connection attempts to the EventLog for later analysis or usage in a SIEM environment by the user.
+* [Enable-InsecureWinRM](./scripts/Enable-InsecureWinRM.ps1): Sadly this is required because the windows update provider that we use to install windows updates while building does not support SSH and needs to connect over insecure WinRM.
+* [Enable-SecureWinRM](./scripts/Enable-SecureWinRM.ps1): Secures WinRM again after installing windows updates using the packer provider.
+* [Start-CleanUp](./scripts/Start-CleanUp.ps1): Clean up after installing windows updates. Delete Windows Update Server Id. So that if a wsus is used not all VMs deployed from this template "share the same name" and to reduce storage requirements of the final image.
+* [Install-CloudbaseInit](./scripts/Install-CloudbaseInit.ps1): Installs Cloudbase-Init. [Cloudbase-Init](https://cloudbase.it/cloudbase-init/) is a version of cloud-init for windows provided by Cloudbase.

--- a/image-builder/windows/Win_Server_STD_CORE_20H2.3_64Bit_English.json
+++ b/image-builder/windows/Win_Server_STD_CORE_20H2.3_64Bit_English.json
@@ -1,0 +1,77 @@
+{
+  "builders": [
+    {
+      "accelerator": "kvm",
+      "communicator": "ssh",
+      "cpus": 2,
+      "disable_vnc": true,
+      "disk_interface": "virtio",
+      "disk_size": "20G",
+      "display": "none",
+      "headless": true,
+      "floppy_dirs": [
+        "./driver/qemu/NetKVM",
+        "./driver/qemu/vioscsi",
+        "./driver/qemu/viostor"
+      ],
+      "floppy_files": [
+        "./Autounattend.xml",
+        "./scripts/Enable-MicrosoftUpdates.ps1",
+        "./scripts/Install-GuestTools.ps1",
+        "./scripts/Install-PowerShellCore.ps1",
+        "./scripts/Install-OpenSSH.ps1"
+      ],
+      "format": "qcow2",
+      "iso_checksum": "{{env `qemu_iso_checksum`}}",
+      "iso_url": "{{env `qemu_iso_path`}}",
+      "memory": 4096,
+      "net_device": "virtio-net",
+      "output_directory": "output/{{env `qemu_vm_name`}}",
+      "shutdown_command": "shutdown /s /t 20 /f",
+      "ssh_password": "{{env `win_admin_password`}}",
+      "ssh_timeout": "2h",
+      "ssh_username": "{{env `win_admin_username`}}",
+      "type": "qemu",
+      "vm_name": "{{env `qemu_vm_name`}}",
+      "winrm_insecure": true,
+      "winrm_password": "{{env `win_admin_password`}}",
+      "winrm_username": "{{env `win_admin_username`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "powershell $ErrorActionPreference='Stop';$ProgressPreference='SilentlyContinue';. {{.Vars}};. {{.Path}};",
+      "scripts": [
+        "./scripts/Set-WindowsTimeZone.ps1",
+        "./scripts/Set-ProductKey.ps1",
+        "./scripts/Configure-WindowsSecurity.ps1",
+        "./scripts/Enable-InsecureWinRM.ps1"
+      ],
+      "type": "powershell"
+    },
+    {
+      "filters": [
+        "exclude:$_.Title -like '*Preview*'",
+        "exclude:$_.Title -like '*Silverlight*'",
+        "include:$_.Title -like '*Cumulative Update for .NET Framework*'",
+        "include:$_.Title -like '*Cumulative Update for Windows*'",
+        "include:$_.AutoSelectOnWebSites"
+      ],
+      "type": "windows-update"
+    },
+    {
+      "restart_check_command": "powershell -command \"\u0026 {Write-Output 'restarted.'}\"",
+      "restart_timeout": "2h",
+      "type": "windows-restart"
+    },
+    {
+      "execute_command": "powershell $ErrorActionPreference='Stop';$ProgressPreference='SilentlyContinue';. {{.Vars}};. {{.Path}};",
+      "scripts": [
+        "./scripts/Enable-SecureWinRM.ps1",
+        "./scripts/Start-CleanUp.ps1",
+        "./scripts/Install-CloudbaseInit.ps1"
+      ],
+      "type": "powershell"
+    }
+  ]
+}

--- a/image-builder/windows/build.sh
+++ b/image-builder/windows/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+export qemu_iso_path="https://s3-bucket-path-to/SW_DVD9_Win_Server_STD_CORE_20H2.3_64Bit_English_SAC_DC_STD_MLF_-2_X22-50889.ISO"
+export qemu_iso_checksum="sha256:c82bca6d1188c2ec60de46822a1a04ebbdd4062ccbdf50a73161ad9746516e33"
+export qemu_vm_name="Win Server STD CORE 20H2.3 English"
+export win_admin_username="Administrator"
+export win_admin_password="pGWd9B0dMZD0XkwumBnJ"
+export win_accept_eula="false"
+export win_register_username="User Name"
+export win_register_organization="Organization Name"
+export win_timezone="UTC"
+# using KMS client setup key as placeholder (https://docs.microsoft.com/en-us/windows-server/get-started/kmsclientkeys)
+export win_product_key="N2KJX-J94YW-TQVFB-DG9YT-724CC"
+
+mkdir -p output
+cat Autounattend-env.xml | envsubst > Autounattend.xml
+cat scripts/Set-ProductKey-env.ps1 | envsubst > scripts/Set-ProductKey.ps1
+
+# Download qemu drivers
+mkdir -p driver/virtio-win
+# TODO: Use WHQL Signed Drivers if user has a RHEL subscription
+wget "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win.iso"
+7z x -o"driver/virtio-win" virtio-win.iso
+rm -f virtio-win.iso
+mkdir -p driver/qemu/NetKVM
+mkdir -p driver/qemu/vioscsi
+mkdir -p driver/qemu/viostor
+mv driver/virtio-win/NetKVM/2k19/amd64/*.{"cat","dll","inf","sys"} driver/qemu/NetKVM/
+mv driver/virtio-win/vioscsi/2k19/amd64/*.{"cat","inf","sys"} driver/qemu/vioscsi/
+mv driver/virtio-win/viostor/2k19/amd64/*.{"cat","inf","sys"} driver/qemu/viostor/
+rm -rf driver/virtio-win
+
+packer build -timestamp-ui Win_Server_STD_CORE_20H2.3_64Bit_English.json

--- a/image-builder/windows/check.sh
+++ b/image-builder/windows/check.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+if [ ! -x "$(which wget)" ]; then
+  echo "wget not found"
+  exit 1
+fi
+
+if [ ! -x "$(which bash)" ]; then
+  echo "bash not found"
+  exit 1
+fi
+
+if [ ! -x "$(which 7z)" ]; then
+  echo "7z not found"
+  exit 1
+fi
+
+if [ ! -x "$(which packer)" ]; then
+  echo "packer not found"
+  exit 1
+fi
+
+if [ ! -x "$(which packer-provisioner-windows-update)" ]; then
+  echo "packer-provisioner-windows-update not found."
+  echo "Download from: https://github.com/rgl/packer-provisioner-windows-update/releases"
+  exit 1
+fi
+
+if [ ! -x "$(which envsubst)" ]; then
+  echo "envsubst not found"
+  exit 1
+fi
+
+if [ ! -x "$(which qemu-img)" ]; then
+  echo "qemu-img not found"
+  exit 1
+fi

--- a/image-builder/windows/ci-script-validation.ps1
+++ b/image-builder/windows/ci-script-validation.ps1
@@ -1,0 +1,27 @@
+#Requires -Version 6
+
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+# Enable newer TLS protocols. Default still is Tls1.0 and older...
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+# Workaround for automatically detecting proxy settings:
+[System.AppContext]::SetSwitch("System.Net.Http.UseSocketsHttpHandler", $false)
+
+Install-Package -Name PowerShellGet,PSScriptAnalyzer -Force -WarningAction SilentlyContinue -Scope CurrentUser
+Import-Module PSScriptAnalyzer
+
+$excludeRules = @(
+    "PSAvoidUsingConvertToSecureStringWithPlainText"
+    "PSAvoidUsingEmptyCatchBlock"
+    "PSProvideCommentHelp"
+    "PSUseShouldProcessForStateChangingFunctions"
+)
+
+$issues = Invoke-ScriptAnalyzer -Path "$((Get-Location).Path)/scripts/" -ExcludeRule $excludeRules
+if ($null -ne $issues) {
+    $issues | Format-Table -AutoSize | Out-String | Write-Error -Category SyntaxError
+}

--- a/image-builder/windows/scripts/Configure-WindowsSecurity.ps1
+++ b/image-builder/windows/scripts/Configure-WindowsSecurity.ps1
@@ -1,0 +1,57 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+# Windows Defender
+Set-MpPreference `
+  -CheckForSignaturesBeforeRunningScan $true `
+  -DisableBehaviorMonitoring $false
+  -DisableCatchupFullScan $false `
+  -DisableCatchupQuickScan $false `
+  -DisableEmailScanning $false `
+  -DisableIntrusionPreventionSystem $false `
+  -DisableIOAVProtection $false `
+  -DisableRealtimeMonitoring $false `
+  -DisableRemovableDriveScanning $false `
+  -SubmitSamplesConsent 0 `
+  -UILockdown $true
+
+# SmartScreen
+New-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System' -Name EnableSmartScreen -Value 1 -PropertyType DWord -Force
+New-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System' -Name ShellSmartScreenLevel -Value 'Warn' -PropertyType String -Force
+
+# Disable IPv6 Privacy Extension and Interface Identifier Randomization
+# (Workaround for OpenStack connectivity issues)
+# https://www.sami-lehtinen.net/blog/how-to-persistently-disable-ipv6-privacy-addressing-on-windows-2012-r2-server
+Set-NetIPv6Protocol -RandomizeIdentifiers Disabled -UseTemporaryAddresses Disabled
+
+# Set RDP security level to require NLA
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp\' -Name "UserAuthentication" -Value 1
+
+# Enable RDP
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\' -Name "fDenyTSConnections" -Value 0
+Enable-NetFirewallRule -Group '@FirewallAPI.dll,-28752'
+
+# Enable ICMP Echo Requests
+Get-NetFirewallRule -Group "@FirewallAPI.dll,-28502" | Where-Object Name -like "*ICMP*" | Enable-NetFirewallRule
+
+# Disable Auto Logon
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name "AutoAdminLogon" -Value "0" -Type String
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name "DefaultUsername" -Value "" -Type String
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name "DefaultPassword" -Value "" -Type String
+
+# Enable CPU Vulnerability Mitigations e.g. Spectre, Meltdown, ...
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management' -Name 'FeatureSettingsOverride' -Value 8264
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management' -Name 'FeatureSettingsOverrideMask' -Value 3
+
+# Configure TLS to only use strong protocols and ciphers
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Invoke-WebRequest -Uri "https://www.nartac.com/Downloads/IISCrypto/IISCryptoCli.exe" -OutFile "IISCryptoCli.exe" -UseBasicParsing
+Unblock-File "IISCryptoCli.exe"
+.\IISCryptoCli.exe /template strict
+Remove-File "IISCryptoCli.exe"
+
+# Enable SCHANNEL EventLogging
+Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL" -name 'EventLogging' -value '0x00000001' -Type 'DWord' -Force

--- a/image-builder/windows/scripts/Enable-InsecureWinRM.ps1
+++ b/image-builder/windows/scripts/Enable-InsecureWinRM.ps1
@@ -1,0 +1,20 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+winrm quickconfig -q
+winrm quickconfig -transport:http
+Set-Item -Path WSMan:\localhost\MaxTimeoutms -Value 1800000
+Get-ChildItem -Path WSMan:\localhost\Listener `
+  | Where-Object { (Get-ChildItem "$($_.PSPath)\Transport").Value.Equals("HTTP") } `
+  | ForEach-Object { Set-Item -Path "$($_.PSPath)\Port" -Value 5985 -Force }
+Set-Item -Path WSMan:\localhost\Client\Auth\Basic -Value $true
+Set-Item -Path WSMan:\localhost\Service\Auth\Basic -Value $true
+Set-Item -Path WSMan:\localhost\Service\AllowUnencrypted -Value $true
+Set-Item -Path WSMan:\localhost\Shell\MaxMemoryPerShellMB -Value 800
+Get-NetFirewallRule -Group "@FirewallAPI.dll,-30267" | Enable-NetFirewallRule # "Windows Remote Management"
+Stop-Service -Name WinRM -Force
+Set-Service -Name WinRM -StartupType Automatic
+Start-Service -Name WinRM

--- a/image-builder/windows/scripts/Enable-MicrosoftUpdates.ps1
+++ b/image-builder/windows/scripts/Enable-MicrosoftUpdates.ps1
@@ -1,0 +1,10 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+Stop-Service -Name 'wuauserv'
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update' -Name "EnableFeaturedSoftware" -Value 1 -Force
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update' -Name "UserAuthentication" -Value 1 -Force
+(New-Object -ComObject Microsoft.Update.ServiceManager).AddService2("7971f918-a847-4430-9279-4a52d1efe18d",7,"" )

--- a/image-builder/windows/scripts/Enable-SecureWinRM.ps1
+++ b/image-builder/windows/scripts/Enable-SecureWinRM.ps1
@@ -1,0 +1,20 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+winrm quickconfig -q
+winrm quickconfig -transport:http
+Set-Item -Path WSMan:\localhost\MaxTimeoutms -Value 1800000
+Get-ChildItem -Path WSMan:\localhost\Listener `
+  | Where-Object { (Get-ChildItem "$($_.PSPath)\Transport").Value.Equals("HTTP") } `
+  | ForEach-Object { Set-Item -Path "$($_.PSPath)\Port" -Value 5985 -Force }
+Set-Item -Path WSMan:\localhost\Client\Auth\Basic -Value $false
+Set-Item -Path WSMan:\localhost\Service\Auth\Basic -Value $false
+Set-Item -Path WSMan:\localhost\Service\AllowUnencrypted -Value $false
+Set-Item -Path WSMan:\localhost\Shell\MaxMemoryPerShellMB -Value 800
+Get-NetFirewallRule -Group "@FirewallAPI.dll,-30267" | Enable-NetFirewallRule # "Windows Remote Management"
+Stop-Service -Name WinRM -Force
+Set-Service -Name WinRM -StartupType Automatic
+Start-Service -Name WinRM

--- a/image-builder/windows/scripts/Install-CloudbaseInit.ps1
+++ b/image-builder/windows/scripts/Install-CloudbaseInit.ps1
@@ -1,0 +1,93 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+[bool]$isQEMUKVM = (Get-CimInstance -ClassName Win32_ComputerSystem).Manufacturer.Equals('QEMU')
+
+if ($isQEMUKVM) {
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  $TempFile = Join-Path -Path $env:TEMP -ChildPath 'CloudbaseInitSetup_x64.msi'
+  $TempFileQ = '"' + $TempFile + '"'
+  $latestVersionURL = (ConvertFrom-Json -InputObject (Invoke-WebRequest -Uri 'https://api.github.com/repos/cloudbase/cloudbase-init/releases/latest' -UseBasicParsing).Content).assets.where{$_.name.EndsWith("x64.msi")}.browser_download_url
+  Invoke-WebRequest -Uri $latestVersionURL -OutFile $TempFile -UseBasicParsing
+  Get-Package -ProviderName msi | Where-Object Name -like 'CloudbaseInit*' | Uninstall-Package -Force -PackageManagementProvider msi
+  $MSIArguments = @(
+    '/i'
+    $TempFileQ
+    '/qn'
+    '/norestart'
+  )
+  Start-Process -FilePath 'msiexec.exe' -ArgumentList $MSIArguments -Wait -NoNewWindow
+  Remove-Item -Path $TempFile -Force
+
+  $configUnattend = @'
+[DEFAULT]
+username=Administrator
+groups=Administrators
+inject_user_password=true
+config_drive_raw_hhd=true
+config_drive_cdrom=true
+config_drive_vfat=true
+bsdtar_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\bsdtar.exe
+mtools_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\
+verbose=true
+debug=true
+logdir=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\log\
+logfile=cloudbase-init-unattend.log
+default_log_levels=comtypes=INFO,suds=INFO,iso8601=WARN,requests=WARN
+logging_serial_port_settings=COM1,115200,N,8
+mtu_use_dhcp_config=true
+ntp_use_dhcp_config=true
+local_scripts_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\
+check_latest_version=true
+allow_reboot=true
+stop_service_on_exit=false
+use_eventlog=true
+activate_windows=false
+set_kms_product_key=false
+first_logon_behaviour=no
+add_metadata_private_ip_route=true
+enable_automatic_updates=true
+trim_enabled=true
+metadata_report_provisioning_started=true
+metadata_report_provisioning_completed=true
+# https://cloudbase-init.readthedocs.io/en/latest/config.html
+'@
+  $config = @'
+[DEFAULT]
+username=Administrator
+groups=Administrators
+inject_user_password=true
+config_drive_raw_hhd=true
+config_drive_cdrom=true
+config_drive_vfat=true
+bsdtar_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\bsdtar.exe
+mtools_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\
+verbose=true
+debug=true
+logdir=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\log\
+logfile=cloudbase-init.log
+default_log_levels=comtypes=INFO,suds=INFO,iso8601=WARN,requests=WARN
+logging_serial_port_settings=COM1,115200,N,8
+mtu_use_dhcp_config=true
+ntp_use_dhcp_config=true
+local_scripts_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\
+check_latest_version=true
+allow_reboot=true
+stop_service_on_exit=false
+use_eventlog=true
+activate_windows=false
+set_kms_product_key=false
+first_logon_behaviour=no
+add_metadata_private_ip_route=true
+enable_automatic_updates=true
+trim_enabled=true
+metadata_report_provisioning_started=true
+metadata_report_provisioning_completed=true
+# https://cloudbase-init.readthedocs.io/en/latest/config.html
+'@
+  $config | Out-File -FilePath "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf\cloudbase-init.conf" -Encoding ascii -Force
+  $configUnattend | Out-File -FilePath "C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf\cloudbase-init-unattend.conf" -Encoding ascii -Force
+}

--- a/image-builder/windows/scripts/Install-GuestTools.ps1
+++ b/image-builder/windows/scripts/Install-GuestTools.ps1
@@ -1,0 +1,44 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+function Install-Virtio {
+  param()
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  $isoUrl = 'https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/latest-virtio/virtio-win.iso'
+  $tempFile = Join-Path -Path $env:TEMP -ChildPath 'virtio-win.iso'
+  [System.Net.WebClient]::new().DownloadFile($isoUrl, $tempFile)
+  $null = Get-Package -ProviderName msi | Where-Object Name -like 'Virtio-win-guest-tools' | Uninstall-Package -Force -PackageManagementProvider msi
+  Start-Sleep -Seconds 5
+
+  $mount = Mount-DiskImage -ImagePath "$TempFile" -StorageType ISO
+  $mountDriveLetter = ($mount | Get-Volume).DriveLetter
+  # Import Trusted Publisher certificate
+  $importedCerts = Import-Certificate -FilePath 'E:\amd64\2k19\vioscsi.cat' -CertStoreLocation Cert:\LocalMachine\TrustedPublisher
+  # The import also imported the ca certificates as trusted publishers.
+  # Therefore delete all imported certificates again except for the one that we actually want.
+  $importedCerts.Where{$_.Thumbprint -ne 'F01DAC89598C52D94FE8CA91187E1853947D115A'}.PSPath | Remove-Item
+  $Arguments = @(
+    '/i'
+    "$($isoDriveLetter):\virtio-win-gt-x64.msi"
+    'ADDLOCAL=ALL'
+    'REMOVE=FE_spice_Agent,FE_RHEV_Agent'
+    '/qn'
+    '/quiet'
+    '/norestart'
+  )
+  Start-Process -FilePath 'C:\Windows\System32\msiexec.exe' -ArgumentList $Arguments -Wait -NoNewWindow
+
+  Start-Sleep -Seconds 5
+  if (Test-Path -Path $TempFile) {
+    Remove-Item -Path $TempFile -Force
+  }
+}
+
+[bool]$isQEMU = (Get-CimInstance -ClassName Win32_ComputerSystem).Manufacturer.Equals('QEMU')
+
+if ($isQEMU) {
+    Install-Virtio
+}

--- a/image-builder/windows/scripts/Install-OpenSSH.ps1
+++ b/image-builder/windows/scripts/Install-OpenSSH.ps1
@@ -1,0 +1,47 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$OpenSSHTempFile = Join-Path -Path $env:TEMP -ChildPath 'openssh.zip'
+$OpenSSHInstallPath = 'C:/Program Files/OpenSSH-Win64'
+$latestVersionURL = (ConvertFrom-Json -InputObject (Invoke-WebRequest -Uri 'https://api.github.com/repos/PowerShell/Win32-OpenSSH/releases/latest' -UseBasicParsing).Content).assets.where{$_.name -eq 'OpenSSH-Win64.zip'}.browser_download_url
+Invoke-WebRequest -Uri $latestVersionURL -OutFile $OpenSSHTempFile -UseBasicParsing
+if (Test-Path -Path $OpenSSHInstallPath) {
+  if ([bool](Get-Service -Name 'sshd' -ErrorAction SilentlyContinue)) {
+    Stop-Service -Name 'sshd' -Force
+    Get-CimInstance -ClassName Win32_Service -Filter "Name='sshd'" | Remove-CimInstance -Confirm:$false
+  }
+  Get-Process -Name 'sshd' -ErrorAction SilentlyContinue | Stop-Process -Force
+  Push-Location -Path $OpenSSHInstallPath
+  try { ./uninstall-sshd.ps1 } catch {}
+  Pop-Location
+  Remove-Item -Path $OpenSSHInstallPath -Recurse -Force
+}
+Expand-Archive -Path $OpenSSHTempFile -DestinationPath $OpenSSHInstallPath -Force
+Move-Item -Path "$OpenSSHInstallPath/OpenSSH-Win64/*" -Destination $OpenSSHInstallPath -Force
+Remove-Item -Path "$OpenSSHInstallPath/OpenSSH-Win64" -Force
+Remove-Item -Path $OpenSSHTempFile -Force
+Push-Location -Path $OpenSSHInstallPath
+./install-sshd.ps1
+Pop-Location
+New-Item -Path $env:ProgramData -Name 'ssh' -ItemType Directory -Force
+$path = [Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::Machine) -split ';'
+if ($path -notcontains $OpenSSHInstallPath) { $path += $OpenSSHInstallPath }
+[Environment]::SetEnvironmentVariable('Path', $path -join ';', [System.EnvironmentVariableTarget]::Machine)
+try { Remove-NetFirewallRule -Name 'sshd' } catch {}
+New-NetFirewallRule -Name 'sshd' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+@'
+Port 22
+AuthorizedKeysFile  .ssh/authorized_keys
+PasswordAuthentication yes
+PubkeyAuthentication yes
+Subsystem sftp  sftp-server.exe
+Subsystem powershell  pwsh.exe -sshs -NoLogo -NoProfile
+'@ | Out-File -Path "C:/ProgramData/ssh/sshd_config" -Force -Encoding ascii
+Set-Service -Name 'sshd' -StartupType Automatic
+Set-Service -Name 'ssh-agent' -StartupType Automatic
+Start-Service -Name 'sshd'
+Start-Service -Name 'ssh-agent'

--- a/image-builder/windows/scripts/Install-PowerShellCore.ps1
+++ b/image-builder/windows/scripts/Install-PowerShellCore.ps1
@@ -1,0 +1,25 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$pwshInstallPath = 'C:/Program Files/PowerShell/7'
+$pwshTempFile = Join-Path -Path $env:TEMP -ChildPath 'PWSH.msi'
+$pwshTempFileQ = '"' + $pwshTempFile + '"'
+$newVersionJson = ConvertFrom-Json -InputObject (Invoke-WebRequest -Uri 'https://api.github.com/repos/PowerShell/PowerShell/releases/latest' -UseBasicParsing).Content
+$newVersionURL = $newVersionJson.assets.where{$_.name -like 'PowerShell-*-win-x64.msi'}.browser_download_url
+Invoke-WebRequest -Uri $newVersionURL -OutFile $pwshTempFile -UseBasicParsing
+Get-Package -ProviderName msi -Name "PowerShell *" | ForEach-Object { $_ | Uninstall-Package -Force -PackageManagementProvider msi | Out-Null }
+$installArguments = @('/i', $pwshTempFileQ, '/qn', '/norestart')
+Start-Process -FilePath 'msiexec.exe' -ArgumentList $installArguments -Wait -NoNewWindow
+Remove-Item -Path $pwshTempFile -Force
+Push-Location -Path $pwshInstallPath
+$pwshInstallRemotingScriptPath = '"' + "$pwshInstallPath\Install-PowerShellRemoting.ps1" + '"'
+$pwshSetupRemoting = @('-NoLogo', '-NonInteractive', '-ExecutionPolicy', 'RemoteSigned', '-NoProfile', '-File', $pwshInstallRemotingScriptPath, '-Force')
+Start-Process -FilePath '.\pwsh.exe' -ArgumentList $pwshSetupRemoting -Wait -NoNewWindow
+Pop-Location
+$path = [Environment]::GetEnvironmentVariable('Path', [System.EnvironmentVariableTarget]::Machine) -split ';'
+if ($path -notcontains $pwshInstallPath) { $path += $pwshInstallPath }
+[Environment]::SetEnvironmentVariable('Path', $path -join ';', [System.EnvironmentVariableTarget]::Machine)

--- a/image-builder/windows/scripts/Set-ProductKey-env.ps1
+++ b/image-builder/windows/scripts/Set-ProductKey-env.ps1
@@ -1,0 +1,18 @@
+# envsubst will replace "$${a}" with a single dollar sign.
+$${a}ProgressPreference="SilentlyContinue"
+$${a}DebugPreference="SilentlyContinue"
+$${a}WarningPreference="Continue"
+$${a}ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+Start-Process "C:\Windows\System32\cscript.exe" -ArgumentList @("C:\Windows\System32\slmgr.vbs", "/ipk", "$win_product_key") -NoNewWindow -Wait
+
+Start-Sleep -Seconds 5
+
+Start-Process "C:\Windows\System32\cscript.exe" -ArgumentList @("C:\Windows\System32\slmgr.vbs", "/ato") -NoNewWindow -Wait
+
+Start-Sleep -Seconds 5
+
+# Debug output
+Start-Process "C:\Windows\System32\cscript.exe" -ArgumentList @("C:\Windows\System32\slmgr.vbs", "/dli") -NoNewWindow -Wait
+Start-Process "C:\Windows\System32\cscript.exe" -ArgumentList @("C:\Windows\System32\slmgr.vbs", "/dlv") -NoNewWindow -Wait

--- a/image-builder/windows/scripts/Set-WindowsTimeZone.ps1
+++ b/image-builder/windows/scripts/Set-WindowsTimeZone.ps1
@@ -1,0 +1,9 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+# This script is necessary because setting the timezone
+# via the Autounattend.xml file alone isn't reliable anymore.
+Set-TimeZone -Id "UTC"

--- a/image-builder/windows/scripts/Start-CleanUp.ps1
+++ b/image-builder/windows/scripts/Start-CleanUp.ps1
@@ -1,0 +1,24 @@
+$ProgressPreference="SilentlyContinue"
+$DebugPreference="SilentlyContinue"
+$WarningPreference="Continue"
+$ErrorActionPreference="Stop"
+Set-StrictMode -Version 2
+
+Stop-Service -Name "wuauserv","BITS","DoSvc" -Force -ErrorAction SilentlyContinue
+
+try {
+  Get-ScheduledTask -TaskName packer* | Unregister-ScheduledTask -Confirm:$false
+} catch {}
+
+if([bool](Test-Path -Path 'C:\Windows\SoftwareDistribution\Download' )) {
+  try {
+    Remove-Item -Recurse -Force -Path 'C:\Windows\SoftwareDistribution\Download'
+  } catch [System.IO.DirectoryNotFoundException] {}
+}
+
+# Remove-ItemProperty throws if the value doesn't exist (even if `-Force` is used).
+# therefore we're going to make sure they exist by setting all of them to $null first.
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate' -Name 'PingID' -Value $null -Force -PassThru | Remove-ItemProperty -Force -Name 'PingID'
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate' -Name 'AccountDomainSid' -Value $null -Force -PassThru | Remove-ItemProperty -Force -Name 'AccountDomainSid'
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate' -Name 'SusClientId' -Value $null -Force -PassThru | Remove-ItemProperty -Force -Name 'SusClientId'
+Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate' -Name 'SusClientIDValidation' -Value $null -Force -PassThru | Remove-ItemProperty -Force -Name 'SusClientIDValidation'

--- a/pkg/containerruntime/containerd.go
+++ b/pkg/containerruntime/containerd.go
@@ -168,12 +168,14 @@ systemctl enable --now containerd
 	// grpc: address = "\\\\.\\pipe\\containerd-containerd"
 	// bin_dir = "C:\\Program Files\\containerd\\cni\\bin"
     // conf_dir = "C:\\Program Files\\containerd\\cni\\conf"
-	containerdAptTemplate = template.Must(template.New("containerd-windows").Parse(`
+	containerdWindowsTemplate = template.Must(template.New("containerd-windows").Parse(`
 Set-Location -Path "$env:tmp"
 Start-Process -FilePath "curl.exe" -ArgumentList @("-OL", "https://github.com/containerd/containerd/releases/download/v{{ .ContainerdVersion }}/containerd-{{ .ContainerdVersion }}-windows-amd64.tar.gz") -Wait
 Start-Process -FilePath "tar.exe" -ArgumentList @("xvf", ".\containerd-{{ .ContainerdVersion }}-windows-amd64.tar.gz") -Wait
 
-Copy-Item -Path ".\bin\" -Destination "$env:ProgramFiles\containerd" -Recurse -Force
+Stop-Service -Name "containerd" -Force -ErrorAction SilentlyContinue
+
+Copy-Item -Path ".\bin\*" -Destination "$env:ProgramFiles\containerd" -Recurse -Force
 Set-Location -Path "$env:ProgramFiles\containerd\"
 .\containerd.exe config default | Out-File -PSPath "config.toml" -Encoding ascii
 

--- a/pkg/containerruntime/containerruntime.go
+++ b/pkg/containerruntime/containerruntime.go
@@ -27,9 +27,9 @@ const (
 )
 
 type Engine interface {
-	KubeletFlags() []string
+	KubeletFlags(os types.OperatingSystem) []string
 	ScriptFor(os types.OperatingSystem) (string, error)
-	ConfigFileName() string
+	ConfigFileName(os types.OperatingSystem) string
 	Config() (string, error)
 }
 

--- a/pkg/containerruntime/docker.go
+++ b/pkg/containerruntime/docker.go
@@ -52,7 +52,7 @@ func (eng *Docker) ConfigFileName(os types.OperatingSystem) string {
 
 func (eng *Docker) KubeletFlags(os types.OperatingSystem) []string {
 	switch os {
-	case type.OperatingSystemWindows:
+	case types.OperatingSystemWindows:
 		return []string{
 			"--container-runtime=docker",
 			"--container-runtime-endpoint=npipe:////./pipe/docker_engine",

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -39,6 +39,7 @@ const (
 	OperatingSystemSLES         OperatingSystem = "sles"
 	OperatingSystemRHEL         OperatingSystem = "rhel"
 	OperatingSystemFlatcar      OperatingSystem = "flatcar"
+	OperatingSystemWindows      OperatingSystem = "windows"
 )
 
 type CloudProvider string
@@ -71,6 +72,7 @@ var (
 		OperatingSystemSLES,
 		OperatingSystemRHEL,
 		OperatingSystemFlatcar,
+		OperatingSystemWindows,
 	}
 
 	// AllCloudProviders is a slice containing all supported cloud providers.

--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -114,9 +114,9 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		Kubeconfig:                     kubeconfigString,
 		KubernetesCACert:               kubernetesCACert,
 		NodeIPScript:                   userdatahelper.SetupNodeIPEnvScript(),
-		ExtraKubeletFlags:              crEngine.KubeletFlags(),
+		ExtraKubeletFlags:              crEngine.KubeletFlags(providerconfigtypes.OperatingSystemAmazonLinux2),
 		ContainerRuntimeScript:         crScript,
-		ContainerRuntimeConfigFileName: crEngine.ConfigFileName(),
+		ContainerRuntimeConfigFileName: crEngine.ConfigFileName(providerconfigtypes.OperatingSystemAmazonLinux2),
 		ContainerRuntimeConfig:         crConfig,
 	}
 

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -114,9 +114,9 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		Kubeconfig:                     kubeconfigString,
 		KubernetesCACert:               kubernetesCACert,
 		NodeIPScript:                   userdatahelper.SetupNodeIPEnvScript(),
-		ExtraKubeletFlags:              crEngine.KubeletFlags(),
+		ExtraKubeletFlags:              crEngine.KubeletFlags(providerconfigtypes.OperatingSystemCentOS),
 		ContainerRuntimeScript:         crScript,
-		ContainerRuntimeConfigFileName: crEngine.ConfigFileName(),
+		ContainerRuntimeConfigFileName: crEngine.ConfigFileName(providerconfigtypes.OperatingSystemCentOS),
 		ContainerRuntimeConfig:         crConfig,
 	}
 

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -120,7 +120,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		KubeletImage:       kubeletImage,
 		KubeletVersion:     kubeletVersion.String(),
 		NodeIPScript:       userdatahelper.SetupNodeIPEnvScript(),
-		ExtraKubeletFlags:  crEngine.KubeletFlags(),
+		ExtraKubeletFlags:  crEngine.KubeletFlags(providerconfigtypes.OperatingSystemFlatcar),
 		InsecureRegistries: req.ContainerRuntime.InsecureRegistries,
 		RegistryMirrors:    req.ContainerRuntime.RegistryMirrors,
 	}

--- a/pkg/userdata/flatcar/provider_test.go
+++ b/pkg/userdata/flatcar/provider_test.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 //
-// UserData plugin for CentOS.
+// UserData plugin for Flatcar.
 //
 
 package flatcar

--- a/pkg/userdata/helper/helper.go
+++ b/pkg/userdata/helper/helper.go
@@ -289,11 +289,11 @@ if ($DEFAULT_IF_IPS.Count -eq 0) {
 	} | Select-Object -ExpandProperty IPAddress
 }
 [string]$DEFAULT_IF_IP = if ($DEFAULT_IF_IPS.Count -eq 1) {
-	$DEFAULT_IF_IPS[0] | Wrte-Output
+	$DEFAULT_IF_IPS[0] | Write-Output
 } else {
 	[string]$ipv6 = $DEFAULT_IF_IPS | Where-Object { $_ -like "*:*" } | Select-Object -First 1
 	if ([String]::IsNullOrEmpty($ipv6)) {
-		// Node doesn't have an usable IPv6 address
+		# Node doesn't have an usable IPv6 address
 		$DEFAULT_IF_IPS | Where-Object { $_ -like "*.*" } | Select-Object -First 1 | Write-Output
 	} else {
 		$ipv6 | Write-Output

--- a/pkg/userdata/manager/manager.go
+++ b/pkg/userdata/manager/manager.go
@@ -50,6 +50,7 @@ var (
 		providerconfigtypes.OperatingSystemRHEL,
 		providerconfigtypes.OperatingSystemSLES,
 		providerconfigtypes.OperatingSystemUbuntu,
+		providerconfigtypes.OperatingSystemWindows,
 	}
 )
 

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -114,9 +114,9 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		Kubeconfig:                     kubeconfigString,
 		KubernetesCACert:               kubernetesCACert,
 		NodeIPScript:                   userdatahelper.SetupNodeIPEnvScript(),
-		ExtraKubeletFlags:              crEngine.KubeletFlags(),
+		ExtraKubeletFlags:              crEngine.KubeletFlags(providerconfigtypes.OperatingSystemRHEL),
 		ContainerRuntimeScript:         crScript,
-		ContainerRuntimeConfigFileName: crEngine.ConfigFileName(),
+		ContainerRuntimeConfigFileName: crEngine.ConfigFileName(providerconfigtypes.OperatingSystemRHEL),
 		ContainerRuntimeConfig:         crConfig,
 	}
 

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -114,9 +114,9 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		Kubeconfig:                     kubeconfigString,
 		KubernetesCACert:               kubernetesCACert,
 		NodeIPScript:                   userdatahelper.SetupNodeIPEnvScript(),
-		ExtraKubeletFlags:              crEngine.KubeletFlags(),
+		ExtraKubeletFlags:              crEngine.KubeletFlags(providerconfigtypes.OperatingSystemUbuntu),
 		ContainerRuntimeScript:         crScript,
-		ContainerRuntimeConfigFileName: crEngine.ConfigFileName(),
+		ContainerRuntimeConfigFileName: crEngine.ConfigFileName(providerconfigtypes.OperatingSystemUbuntu),
 		ContainerRuntimeConfig:         crConfig,
 	}
 

--- a/pkg/userdata/windows/provider.go
+++ b/pkg/userdata/windows/provider.go
@@ -169,7 +169,6 @@ write_files:
 {{ .ContainerRuntimeScript | indent 6 }}
       New-Item -ItemType Directory -Force C:/var/lib/kubelet/etc/kubernetes/manifests
       New-Item -ItemType Directory -Force C:/proc
-      Invoke-WebRequest -Uri "https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/PrepareNode.ps1" -UseBasicParsing -OutFile "C:/k/PrepareNode.ps1"
       Install-WindowsFeature Containers
       Rename-Computer -Force -NewName "{{ .MachineSpec.Name }}"
       # Register stage 002 for next startup
@@ -209,7 +208,8 @@ write_files:
       if ([bool](Test-Path -Path "C:/var/lib/kubelet/etc/kubernetes/pki")) {
         cmd /c rmdir "C:/var/lib/kubelet/etc/kubernetes/pki"
       }
-      # TODO: Curently the next comman fails if docker is used as runtime but Hyper-V isn't present.
+      Invoke-WebRequest -Uri "https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/PrepareNode.ps1" -UseBasicParsing -OutFile "C:/k/PrepareNode.ps1"
+      # TODO: Curently the next command fails if docker is used as runtime but Hyper-V isn't present.
       # But hyper-V fails to install if no nested virtualization feature is present...
       C:/k/PrepareNode.ps1 -KubernetesVersion "v{{ .KubeletVersion }}" -ContainerRuntime "{{ .ContainerRuntimeName }}"
       # set kubelet nodeip environment variable
@@ -322,127 +322,4 @@ write_files:
     permissions: "0644"
     content: |
 {{ .KubernetesCACert | indent 6 }}
-  - path: {{ .ContainerRuntimeConfigFileName }}
-    permissions: "0644"
-    content: |
-      version = 2
-      root = "C:\\ProgramData\\containerd\\root"
-      state = "C:\\ProgramData\\containerd\\state"
-      plugin_dir = ""
-      disabled_plugins = []
-      required_plugins = []
-      oom_score = 0
-      
-      [grpc]
-        address = "\\\\.\\pipe\\containerd-containerd"
-        tcp_address = ""
-        tcp_tls_cert = ""
-        tcp_tls_key = ""
-        uid = 0
-        gid = 0
-        max_recv_message_size = 16777216
-        max_send_message_size = 16777216
-      
-      [ttrpc]
-        address = ""
-        uid = 0
-        gid = 0
-      
-      [debug]
-        address = ""
-        uid = 0
-        gid = 0
-        level = ""
-      
-      [metrics]
-        address = ""
-        grpc_histogram = false
-      
-      [cgroup]
-        path = ""
-      
-      [timeouts]
-        "io.containerd.timeout.shim.cleanup" = "5s"
-        "io.containerd.timeout.shim.load" = "5s"
-        "io.containerd.timeout.shim.shutdown" = "3s"
-        "io.containerd.timeout.task.state" = "2s"
-      
-      [plugins]
-        [plugins."io.containerd.gc.v1.scheduler"]
-          pause_threshold = 0.02
-          deletion_threshold = 0
-          mutation_threshold = 100
-          schedule_delay = "0s"
-          startup_delay = "100ms"
-        [plugins."io.containerd.grpc.v1.cri"]
-          disable_tcp_service = true
-          stream_server_address = "127.0.0.1"
-          stream_server_port = "0"
-          stream_idle_timeout = "4h0m0s"
-          enable_selinux = false
-          selinux_category_range = 0
-          sandbox_image = "mcr.microsoft.com/oss/kubernetes/pause:1.4.0"     
-          stats_collect_period = 10
-          systemd_cgroup = false
-          enable_tls_streaming = false
-          max_container_log_line_size = 16384
-          disable_cgroup = false
-          disable_apparmor = false
-          restrict_oom_score_adj = false
-          max_concurrent_downloads = 3
-          disable_proc_mount = false
-          unset_seccomp_profile = ""
-          tolerate_missing_hugetlb_controller = false
-          disable_hugetlb_controller = false
-          ignore_image_defined_volumes = false
-          [plugins."io.containerd.grpc.v1.cri".containerd]
-            snapshotter = "windows"
-            default_runtime_name = "runhcs-wcow-process"
-            no_pivot = false
-            disable_snapshot_annotations = false
-            discard_unpacked_layers = false
-            [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime] 
-              runtime_type = ""
-              runtime_engine = ""
-              runtime_root = ""
-              privileged_without_host_devices = false
-              base_runtime_spec = ""
-            [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
-              runtime_type = ""
-              runtime_engine = ""
-              runtime_root = ""
-              privileged_without_host_devices = false
-              base_runtime_spec = ""
-            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
-              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process]
-                runtime_type = "io.containerd.runhcs.v1"
-                runtime_engine = ""
-                runtime_root = ""
-                privileged_without_host_devices = false
-                base_runtime_spec = ""
-          [plugins."io.containerd.grpc.v1.cri".cni]
-            bin_dir = "C:\\Program Files\\containerd\\cni\\bin"
-            conf_dir = "C:\\Program Files\\containerd\\cni\\conf"
-            max_conf_num = 1
-            conf_template = ""
-          [plugins."io.containerd.grpc.v1.cri".registry]
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-              [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-                endpoint = ["https://registry-1.docker.io"]
-          [plugins."io.containerd.grpc.v1.cri".image_decryption]
-            key_model = ""
-          [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
-            tls_cert_file = ""
-            tls_key_file = ""
-        [plugins."io.containerd.internal.v1.opt"]
-          path = "C:\\ProgramData\\containerd\\root\\opt"
-        [plugins."io.containerd.internal.v1.restart"]
-          interval = "10s"
-        [plugins."io.containerd.metadata.v1.bolt"]
-          content_sharing_policy = "shared"
-        [plugins."io.containerd.runtime.v2.task"]
-          platforms = ["windows/amd64", "linux/amd64"]
-        [plugins."io.containerd.service.v1.diff-service"]
-          default = ["windows", "windows-lcow"]
-
 `

--- a/pkg/userdata/windows/provider.go
+++ b/pkg/userdata/windows/provider.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//
+// UserData plugin for Windows.
+//
+
+package windows
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/plugin"
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	userdatahelper "github.com/kubermatic/machine-controller/pkg/userdata/helper"
+)
+
+// Provider is a pkg/userdata/plugin.Provider implementation.
+type Provider struct{}
+
+// UserData renders user-data template to string.
+func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
+	tmpl, err := template.New("user-data").Funcs(userdatahelper.TxtFuncMap()).Parse(userDataTemplate)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse user-data template: %w", err)
+	}
+
+	kubeletVersion, err := semver.NewVersion(req.MachineSpec.Versions.Kubelet)
+	if err != nil {
+		return "", fmt.Errorf("invalid kubelet version: %w", err)
+	}
+
+	pconfig, err := providerconfigtypes.GetConfig(req.MachineSpec.ProviderSpec)
+	if err != nil {
+		return "", fmt.Errorf("failed to get provider config: %w", err)
+	}
+
+	if pconfig.OverwriteCloudConfig != nil {
+		req.CloudConfig = *pconfig.OverwriteCloudConfig
+	}
+
+	if pconfig.Network != nil {
+		return "", errors.New("static IP config is not supported with Windows")
+	}
+
+	windowsConfig, err := LoadConfig(pconfig.OperatingSystemSpec)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse OperatingSystemSpec: %w", err)
+	}
+
+	serverAddr, err := userdatahelper.GetServerAddressFromKubeconfig(req.Kubeconfig)
+	if err != nil {
+		return "", fmt.Errorf("error extracting server address from kubeconfig: %w", err)
+	}
+
+	kubeconfigString, err := userdatahelper.StringifyKubeconfig(req.Kubeconfig)
+	if err != nil {
+		return "", err
+	}
+
+	kubernetesCACert, err := userdatahelper.GetCACert(req.Kubeconfig)
+	if err != nil {
+		return "", fmt.Errorf("error extracting cacert: %w", err)
+	}
+
+	crEngine := req.ContainerRuntime.Engine(kubeletVersion)
+	crScript, err := crEngine.ScriptFor(providerconfigtypes.OperatingSystemWindows)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate container runtime install script: %w", err)
+	}
+
+	crConfig, err := crEngine.Config()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate container runtime config: %w", err)
+	}
+
+	data := struct {
+		plugin.UserDataRequest
+		ProviderSpec                   *providerconfigtypes.Config
+		OSConfig                       *Config
+		KubeletVersion                 string
+		ServerAddr                     string
+		Kubeconfig                     string
+		KubernetesCACert               string
+		NodeIPScript                   string
+    ExtraKubeletFlags              []string
+    ContainerRuntimeName           string
+		ContainerRuntimeScript         string
+		ContainerRuntimeConfigFileName string
+		ContainerRuntimeConfig         string
+	}{
+		UserDataRequest:                req,
+		ProviderSpec:                   pconfig,
+    OSConfig:                       windowsConfig,
+		KubeletVersion:                 kubeletVersion.String(),
+		ServerAddr:                     serverAddr,
+		Kubeconfig:                     kubeconfigString,
+		KubernetesCACert:               kubernetesCACert,
+		NodeIPScript:                   userdatahelper.SetupWinNodeIPEnvScript(),
+    ExtraKubeletFlags:              crEngine.KubeletFlags(providerconfigtypes.OperatingSystemWindows),
+    ContainerRuntimeName:           req.ContainerRuntime.String(),
+		ContainerRuntimeScript:         crScript,
+		ContainerRuntimeConfigFileName: crEngine.ConfigFileName(providerconfigtypes.OperatingSystemWindows),
+		ContainerRuntimeConfig:         crConfig,
+	}
+
+	buf := strings.Builder{}
+	if err = tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("failed to execute user-data template: %w", err)
+	}
+
+	return userdatahelper.CleanupTemplateOutput(buf.String())
+}
+
+// UserData template.
+const userDataTemplate = `#cloud-config
+set_hostname: {{ .MachineSpec.Name }}
+
+users:
+  - name: Administrator
+    primary_group: Users
+    groups: Administrators
+{{- if ne (len .ProviderSpec.SSHPublicKeys) 0 }}
+    inactive: False
+    ssh_authorized_keys:
+{{- range .ProviderSpec.SSHPublicKeys }}
+      - "{{ . }}"
+{{- end }}
+{{- else }}
+    inactive: True
+{{- end }}
+
+runcmd:
+  - 'call powershell -File C:\setup-node.ps1 -NoLogo -ExecutionPolicy ByPass -OutputFormat Text -InputFormat Text -NonInteractive'
+
+write_files:
+  - path: C:\setup-node.ps1
+    permissions: '0644'
+    content: |
+{{ .ContainerRuntimeScript | indent 6 }}
+      Invoke-WebRequest -Uri "https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/PrepareNode.ps1" -UseBasicParsing -OutFile "C:/k/PrepareNode.ps1"
+      C:/k/PrepareNode.ps1 -KubernetesVersion "v{{ .KubeletVersion }}" -ContainerRuntime "{{ .ContainerRuntimeName }}"
+      # set kubelet nodeip environment variable
+      C:/k/setup_net_env.ps1
+  - path: "C:/k/cloud-config"
+    permissions: "0600"
+    content: |
+{{ .CloudConfig | indent 6 }}
+  - path: "C:/k/setup_net_env.ps1"
+    permissions: "0755"
+    content: |
+{{ .NodeIPScript | indent 6 }}
+  - path: "C:/k/bootstrap-kubelet.conf"
+    permissions: "0600"
+    content: |
+{{ .Kubeconfig | indent 6 }}
+  - path: "C:/k/kubelet.conf"
+    content: |
+{{ kubeletConfiguration "cluster.local" .DNSIPs .KubeletFeatureGates | indent 6 }}
+  - path: "C:/k/pki/ca.crt"
+    content: |
+{{ .KubernetesCACert | indent 6 }}
+  - path: {{ .ContainerRuntimeConfigFileName }}
+    permissions: "0644"
+    content: |
+{{ /* TODO: .ContainerRuntimeConfig | indent 6 */ }}
+      version = 2
+      root = "C:\\ProgramData\\containerd\\root"
+      state = "C:\\ProgramData\\containerd\\state"
+      plugin_dir = ""
+      disabled_plugins = []
+      required_plugins = []
+      oom_score = 0
+      
+      [grpc]
+        address = "\\\\.\\pipe\\containerd-containerd"
+        tcp_address = ""
+        tcp_tls_cert = ""
+        tcp_tls_key = ""
+        uid = 0
+        gid = 0
+        max_recv_message_size = 16777216
+        max_send_message_size = 16777216
+      
+      [ttrpc]
+        address = ""
+        uid = 0
+        gid = 0
+      
+      [debug]
+        address = ""
+        uid = 0
+        gid = 0
+        level = ""
+      
+      [metrics]
+        address = ""
+        grpc_histogram = false
+      
+      [cgroup]
+        path = ""
+      
+      [timeouts]
+        "io.containerd.timeout.shim.cleanup" = "5s"
+        "io.containerd.timeout.shim.load" = "5s"
+        "io.containerd.timeout.shim.shutdown" = "3s"
+        "io.containerd.timeout.task.state" = "2s"
+      
+      [plugins]
+        [plugins."io.containerd.gc.v1.scheduler"]
+          pause_threshold = 0.02
+          deletion_threshold = 0
+          mutation_threshold = 100
+          schedule_delay = "0s"
+          startup_delay = "100ms"
+        [plugins."io.containerd.grpc.v1.cri"]
+          disable_tcp_service = true
+          stream_server_address = "127.0.0.1"
+          stream_server_port = "0"
+          stream_idle_timeout = "4h0m0s"
+          enable_selinux = false
+          selinux_category_range = 0
+          sandbox_image = "mcr.microsoft.com/oss/kubernetes/pause:1.4.0"     
+          stats_collect_period = 10
+          systemd_cgroup = false
+          enable_tls_streaming = false
+          max_container_log_line_size = 16384
+          disable_cgroup = false
+          disable_apparmor = false
+          restrict_oom_score_adj = false
+          max_concurrent_downloads = 3
+          disable_proc_mount = false
+          unset_seccomp_profile = ""
+          tolerate_missing_hugetlb_controller = false
+          disable_hugetlb_controller = false
+          ignore_image_defined_volumes = false
+          [plugins."io.containerd.grpc.v1.cri".containerd]
+            snapshotter = "windows"
+            default_runtime_name = "runhcs-wcow-process"
+            no_pivot = false
+            disable_snapshot_annotations = false
+            discard_unpacked_layers = false
+            [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime] 
+              runtime_type = ""
+              runtime_engine = ""
+              runtime_root = ""
+              privileged_without_host_devices = false
+              base_runtime_spec = ""
+            [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+              runtime_type = ""
+              runtime_engine = ""
+              runtime_root = ""
+              privileged_without_host_devices = false
+              base_runtime_spec = ""
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runhcs-wcow-process]
+                runtime_type = "io.containerd.runhcs.v1"
+                runtime_engine = ""
+                runtime_root = ""
+                privileged_without_host_devices = false
+                base_runtime_spec = ""
+          [plugins."io.containerd.grpc.v1.cri".cni]
+            bin_dir = "C:\\Program Files\\containerd\\cni\\bin"
+            conf_dir = "C:\\Program Files\\containerd\\cni\\conf"
+            max_conf_num = 1
+            conf_template = ""
+          [plugins."io.containerd.grpc.v1.cri".registry]
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+              [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+                endpoint = ["https://registry-1.docker.io"]
+          [plugins."io.containerd.grpc.v1.cri".image_decryption]
+            key_model = ""
+          [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+            tls_cert_file = ""
+            tls_key_file = ""
+        [plugins."io.containerd.internal.v1.opt"]
+          path = "C:\\ProgramData\\containerd\\root\\opt"
+        [plugins."io.containerd.internal.v1.restart"]
+          interval = "10s"
+        [plugins."io.containerd.metadata.v1.bolt"]
+          content_sharing_policy = "shared"
+        [plugins."io.containerd.runtime.v2.task"]
+          platforms = ["windows/amd64", "linux/amd64"]
+        [plugins."io.containerd.service.v1.diff-service"]
+          default = ["windows", "windows-lcow"]
+
+`

--- a/pkg/userdata/windows/provider.go
+++ b/pkg/userdata/windows/provider.go
@@ -202,6 +202,7 @@ write_files:
       $null = Start-Process "C:\Windows\System32\cscript.exe" -ArgumentList @("C:\Windows\System32\slmgr.vbs", "/ato")
       # Disable IPv6 Privacy Extension (causes conflicts with Portsecurity implementations)
       Set-NetIPv6Protocol -RandomizeIdentifiers Disabled -UseTemporaryAddresses Disabled
+      Start-Service kubelet
       exit 0
   - path: C:/k/Install-PowerShellCore.ps1
     permissions: '0644'

--- a/pkg/userdata/windows/provider_test.go
+++ b/pkg/userdata/windows/provider_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//
+// UserData plugin for Windows.
+//
+
+package windows
+
+import (
+	"flag"
+	"net"
+	"testing"
+
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"github.com/kubermatic/machine-controller/pkg/apis/plugin"
+	"github.com/kubermatic/machine-controller/pkg/containerruntime"
+	testhelper "github.com/kubermatic/machine-controller/pkg/test"
+	"github.com/kubermatic/machine-controller/pkg/userdata/convert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+var (
+	update = flag.Bool("update", false, "update testdata files")
+
+	pemCertificate = `-----BEGIN CERTIFICATE-----
+MIIEWjCCA0KgAwIBAgIJALfRlWsI8YQHMA0GCSqGSIb3DQEBBQUAMHsxCzAJBgNV
+BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEUMBIG
+A1UEChMLQnJhZGZpdHppbmMxEjAQBgNVBAMTCWxvY2FsaG9zdDEdMBsGCSqGSIb3
+DQEJARYOYnJhZEBkYW5nYS5jb20wHhcNMTQwNzE1MjA0NjA1WhcNMTcwNTA0MjA0
+NjA1WjB7MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBG
+cmFuY2lzY28xFDASBgNVBAoTC0JyYWRmaXR6aW5jMRIwEAYDVQQDEwlsb2NhbGhv
+c3QxHTAbBgkqhkiG9w0BCQEWDmJyYWRAZGFuZ2EuY29tMIIBIjANBgkqhkiG9w0B
+AQEFAAOCAQ8AMIIBCgKCAQEAt5fAjp4fTcekWUTfzsp0kyih1OYbsGL0KX1eRbSS
+R8Od0+9Q62Hyny+GFwMTb4A/KU8mssoHvcceSAAbwfbxFK/+s51TobqUnORZrOoT
+ZjkUygbyXDSK99YBbcR1Pip8vwMTm4XKuLtCigeBBdjjAQdgUO28LENGlsMnmeYk
+JfODVGnVmr5Ltb9ANA8IKyTfsnHJ4iOCS/PlPbUj2q7YnoVLposUBMlgUb/CykX3
+mOoLb4yJJQyA/iST6ZxiIEj36D4yWZ5lg7YJl+UiiBQHGCnPdGyipqV06ex0heYW
+caiW8LWZSUQ93jQ+WVCH8hT7DQO1dmsvUmXlq/JeAlwQ/QIDAQABo4HgMIHdMB0G
+A1UdDgQWBBRcAROthS4P4U7vTfjByC569R7E6DCBrQYDVR0jBIGlMIGigBRcAROt
+hS4P4U7vTfjByC569R7E6KF/pH0wezELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+MRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQKEwtCcmFkZml0emluYzES
+MBAGA1UEAxMJbG9jYWxob3N0MR0wGwYJKoZIhvcNAQkBFg5icmFkQGRhbmdhLmNv
+bYIJALfRlWsI8YQHMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAG6h
+U9f9sNH0/6oBbGGy2EVU0UgITUQIrFWo9rFkrW5k/XkDjQm+3lzjT0iGR4IxE/Ao
+eU6sQhua7wrWeFEn47GL98lnCsJdD7oZNhFmQ95Tb/LnDUjs5Yj9brP0NWzXfYU4
+UK2ZnINJRcJpB8iRCaCxE8DdcUF0XqIEq6pA272snoLmiXLMvNl3kYEdm+je6voD
+58SNVEUsztzQyXmJEhCpwVI0A6QCjzXj+qvpmw3ZZHi8JwXei8ZZBLTSFBki8Z7n
+sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
+kPe6XoSbiLm/kxk32T0=
+-----END CERTIFICATE-----`
+)
+
+// fakeCloudConfigProvider simulates cloud config provider for test.
+type fakeCloudConfigProvider struct {
+	config string
+	name   string
+	err    error
+}
+
+func (p *fakeCloudConfigProvider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config string, name string, err error) {
+	return p.config, p.name, p.err
+}
+
+// userDataTestCase contains the data for a table-driven test.
+type userDataTestCase struct {
+	name                  string
+	spec                  clusterv1alpha1.MachineSpec
+	clusterDNSIPs         []net.IP
+	cloudProviderName     *string
+	externalCloudProvider bool
+	httpProxy             string
+	noProxy               string
+	insecureRegistries    []string
+	registryMirrors       []string
+	pauseImage            string
+	containerruntime      string
+}
+
+// TestUserDataGeneration runs the data generation for different
+// environments.
+func TestUserDataGeneration(t *testing.T) {
+	t.Parallel()
+
+	tests := []userDataTestCase{
+		{
+			name: "kubelet-v1.17-aws",
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.17.16",
+				},
+			},
+		},
+		{
+			name: "kubelet-v1.17-aws-external",
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.17.16",
+				},
+			},
+			externalCloudProvider: true,
+		},
+		{
+			name: "kubelet-v1.17-vsphere",
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.17.16",
+				},
+			},
+			cloudProviderName: stringPtr("vsphere"),
+		},
+		{
+			name: "kubelet-v1.17-vsphere-proxy",
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.17.16",
+				},
+			},
+			cloudProviderName:  stringPtr("vsphere"),
+			httpProxy:          "http://192.168.100.100:3128",
+			noProxy:            "192.168.1.0",
+			insecureRegistries: []string{"192.168.100.100:5000", "10.0.0.1:5000"},
+			pauseImage:         "192.168.100.100:5000/kubernetes/pause:v3.1",
+		},
+		{
+			name: "kubelet-v1.17-vsphere-mirrors",
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.17.16",
+				},
+			},
+			cloudProviderName: stringPtr("vsphere"),
+			httpProxy:         "http://192.168.100.100:3128",
+			noProxy:           "192.168.1.0",
+			registryMirrors:   []string{"https://registry.docker-cn.com"},
+			pauseImage:        "192.168.100.100:5000/kubernetes/pause:v3.1",
+		},
+		{
+			name: "kubelet-v1.18-aws",
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.18.14",
+				},
+			},
+		},
+		{
+			name: "kubelet-v1.19-aws",
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.19.4",
+				},
+			},
+		},
+		{
+			name: "kubelet-v1.20-aws",
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.20.1",
+				},
+			},
+		},
+	}
+
+	defaultCloudProvider := &fakeCloudConfigProvider{
+		name:   "aws",
+		config: "{aws-config:true}",
+		err:    nil,
+	}
+	kubeconfig := &clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"": {
+				Server:                   "https://server:443",
+				CertificateAuthorityData: []byte(pemCertificate),
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"": {
+				Token: "my-token",
+			},
+		},
+	}
+	provider := Provider{}
+
+	kubeletFeatureGates := map[string]bool{
+		"RotateKubeletServerCertificate": true,
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			emtpyProviderSpec := clusterv1alpha1.ProviderSpec{
+				Value: &runtime.RawExtension{},
+			}
+			test.spec.ProviderSpec = emtpyProviderSpec
+			var cloudProvider *fakeCloudConfigProvider
+			if test.cloudProviderName != nil {
+				cloudProvider = &fakeCloudConfigProvider{
+					name:   *test.cloudProviderName,
+					config: "{config:true}",
+					err:    nil,
+				}
+			} else {
+				cloudProvider = defaultCloudProvider
+			}
+			cloudConfig, cloudProviderName, err := cloudProvider.GetCloudConfig(test.spec)
+			if err != nil {
+				t.Fatalf("failed to get cloud config: %v", err)
+			}
+
+			req := plugin.UserDataRequest{
+				MachineSpec:           test.spec,
+				Kubeconfig:            kubeconfig,
+				CloudConfig:           cloudConfig,
+				CloudProviderName:     cloudProviderName,
+				DNSIPs:                test.clusterDNSIPs,
+				ExternalCloudProvider: test.externalCloudProvider,
+				HTTPProxy:             test.httpProxy,
+				NoProxy:               test.noProxy,
+				PauseImage:            test.pauseImage,
+				KubeletFeatureGates:   kubeletFeatureGates,
+				ContainerRuntime: containerruntime.Get(
+					test.containerruntime,
+					containerruntime.WithInsecureRegistries(test.insecureRegistries),
+					containerruntime.WithRegistryMirrors(test.registryMirrors),
+				),
+			}
+
+			s, err := provider.UserData(req)
+			if err != nil {
+				t.Errorf("error getting userdata: '%v'", err)
+			}
+
+			// Check if we can gzip it.
+			if _, err := convert.GzipString(s); err != nil {
+				t.Fatal(err)
+			}
+			goldenName := test.name + ".yaml"
+			testhelper.CompareOutput(t, goldenName, s, *update)
+		})
+	}
+}
+
+// stringPtr returns pointer to given string.
+func stringPtr(a string) *string {
+	return &a
+}

--- a/pkg/userdata/windows/windows.go
+++ b/pkg/userdata/windows/windows.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windows
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Config contains specific configuration for Windows.
+type Config struct {
+	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
+}
+
+// LoadConfig retrieves the Windows configuration from raw data.
+func LoadConfig(r runtime.RawExtension) (*Config, error) {
+	cfg := Config{}
+	if len(r.Raw) == 0 {
+		return &cfg, nil
+	}
+	if err := json.Unmarshal(r.Raw, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// Spec return the configuration as raw data.
+func (cfg *Config) Spec() (*runtime.RawExtension, error) {
+	ext := &runtime.RawExtension{}
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	ext.Raw = b
+	return ext, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Adding support for windows images

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #904

**Special notes for your reviewer**:
There are currently a few parts that are marked "TODO" as I'm not quite sure how to address these. I'm going to look into them again, but I'd appreciate some help there.

- [ ] `docs/operating-system.md`: List of cloud providers that support/provide windows images.
- [ ] `pkg/containerruntime/containerruntime.go`: Does the change to the Engine interface break others?
- [ ] `pkg/containerruntime/docker.go`: Installing docker on windows requires a restart before the service can be started. ~I don't know how to implement that.~
- [ ] ContainerRuntimeConfig: Currently only the default configuration is written. The templating function is unused. I got a bit confused there with all the options.
- [ ] `pkg/userdata/windows/provider_test.go`: Currently just a renamed copy of another distros test. Aka. still needs to be implemented (as does the test data)
- [x] I don't know how to build and run machine-controller locally right now. Therefore this code is completely untested.
- [ ] currently I only wrote about acquiring the windows images from Microsoft directly (registration required and no perma links). Maybe we could use vagrant, but Microsoft itself only published a Windows 10 with edge version a few years ago and pulling images from "some random 3rd party" may not be the best decision (regarding security and legal aspects). https://app.vagrantup.com/Microsoft
- [x] kubelet connects to control plane
- [x] network cni is working
- [x] hostname is set correctly
- [x] hostname is registered correctly
- [x] containerd runtime working
- [x] (containerd) node is fully online and operational (e.g. can start a pod)
- [ ] docker runtime working
- [ ] (docker) node is fully online and operational (e.g. can start a pod)
- [ ] Hyper-V "isolation" (aka. Microsoft labeling VMs as container) support
- [ ] testing the scripts for finding timing and environmentally dependent issues
- [ ] optimizing the scripts
- [ ] Implement ARM64 support

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for Windows Nodes.
```
