### PR TITLE
Adding initial baremetal provider structure

### DIFF
--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/baremetal"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/fake"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/gce"
@@ -87,6 +88,10 @@ var (
 		},
 		providerconfigtypes.CloudProviderAnexia: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
 			return anexia.New(cvr)
+		},
+		providerconfigtypes.CloudProviderBaremetal: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
+			// TODO(MQ): add a baremetal driver.
+			return baremetal.New(cvr)
 		},
 	}
 )

--- a/pkg/cloudprovider/provider/baremetal/plugins/driver.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/driver.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import "context"
+
+type Driver string
+
+// PluginDriver manages the communications between the machine controller cloud provider and the bare metal env.
+type PluginDriver interface {
+	GetServer(ctx context.Context, serverID, macAddress, ipAddress string) (Server, error)
+	ProvisionServer(context.Context, Server) (string, error)
+	DeprovisionServer(serverID string) (string, error)
+}
+
+// Server represents the server/instance which exists in the bare metal env.
+type Server interface {
+	GetName() string
+	GetID() string
+	GetIPAddress() string
+	GetMACAddress() string
+	GetStatus() string
+}

--- a/pkg/cloudprovider/provider/baremetal/provider.go
+++ b/pkg/cloudprovider/provider/baremetal/provider.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baremetal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/baremetal/plugins"
+	baremetaltypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/baremetal/types"
+	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type bareMetalServer struct {
+	server plugins.Server
+}
+
+func (b bareMetalServer) Name() string {
+	return b.server.GetName()
+}
+
+func (b bareMetalServer) ID() string {
+	return b.server.GetID()
+}
+
+func (b bareMetalServer) Addresses() map[string]corev1.NodeAddressType {
+	return map[string]corev1.NodeAddressType{
+		b.server.GetIPAddress(): corev1.NodeInternalIP,
+	}
+}
+
+func (b bareMetalServer) Status() instance.Status {
+	return instance.StatusRunning
+}
+
+type provider struct {
+	configVarResolver *providerconfig.ConfigVarResolver
+}
+
+// New returns a new BareMetal provider
+func New(configVarResolver *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
+	return &provider{
+		configVarResolver: configVarResolver,
+	}
+}
+
+type Config struct {
+	driver     plugins.Driver
+	driverSpec runtime.RawExtension
+}
+
+func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigtypes.Config, *baremetaltypes.RawConfig, error) {
+	if s.Value == nil {
+		return nil, nil, nil, fmt.Errorf("machine.spec.providerconfig.value is nil")
+	}
+	pconfig := providerconfigtypes.Config{}
+	err := json.Unmarshal(s.Value.Raw, &pconfig)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	if pconfig.OperatingSystemSpec.Raw == nil {
+		return nil, nil, nil, errors.New("operatingSystemSpec in the MachineDeployment cannot be empty")
+	}
+
+	rawConfig := baremetaltypes.RawConfig{}
+	if err := json.Unmarshal(pconfig.CloudProviderSpec.Raw, &rawConfig); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal: %v", err)
+	}
+	c := Config{}
+	driverName, err := p.configVarResolver.GetConfigVarStringValue(rawConfig.Driver)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get baremetal provider's driver name: %v", err)
+	}
+	c.driver = plugins.Driver(driverName)
+
+	// TODO(MQ): add the right driver spec based on the used driver.
+	c.driverSpec = rawConfig.DriverSpec
+	return &c, &pconfig, &rawConfig, err
+}
+
+func (p provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec, error) {
+	return spec, nil
+}
+
+func (p provider) Validate(machinespec v1alpha1.MachineSpec) error {
+	return nil
+}
+
+func (p provider) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+	panic("implement me")
+}
+
+func (p provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, name string, err error) {
+	return "", "", nil
+}
+
+func (p provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+	panic("implement me")
+}
+
+func (p provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
+	panic("implement me")
+}
+
+func (p provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]string, error) {
+	return nil, nil
+}
+
+func (p provider) MigrateUID(machine *v1alpha1.Machine, new types.UID) error {
+	return nil
+}
+
+func (p provider) SetMetricsForMachines(machines v1alpha1.MachineList) error {
+	return nil
+}

--- a/pkg/cloudprovider/provider/baremetal/types/types.go
+++ b/pkg/cloudprovider/provider/baremetal/types/types.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type RawConfig struct {
+	Driver     providerconfigtypes.ConfigVarString `json:"driver"`
+	DriverSpec runtime.RawExtension                `json:"driverSpec"`
+}

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -57,6 +57,7 @@ const (
 	CloudProviderAlibaba      CloudProvider = "alibaba"
 	CloudProviderAnexia       CloudProvider = "anexia"
 	CloudProviderScaleway     CloudProvider = "scaleway"
+	CloudProviderBaremetal    CloudProvider = "baremetal"
 )
 
 var (
@@ -87,6 +88,7 @@ var (
 		CloudProviderAlibaba,
 		CloudProviderAnexia,
 		CloudProviderScaleway,
+		CloudProviderBaremetal,
 	}
 )
 

--- a/test/e2e/provisioning/testdata/machinedeployment-baremetal.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-baremetal.yaml
@@ -1,0 +1,34 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: << MACHINE_NAME >>
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: << MACHINE_NAME >>
+  template:
+    metadata:
+      labels:
+        name: << MACHINE_NAME >>
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProvider: "baremetal"
+          cloudProviderSpec:
+            driver: << DRIVER_NAME >>
+            driverSpec: << DRIVER_SPEC >>
+          operatingSystem: "<< OS_NAME >>"
+          operatingSystemSpec:
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+      versions:
+        kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new structure to provision machines(worker nodes) on a baremetal environments(onPrem). It represents the scheme of how baremetal providers/provisioners are added and used  by the machine controller.


**Special notes for your reviewer**:
This is only a draft/initial-structure for the baremetal providers. At the moment there is no real implementation/logic has been added, however the upcoming PRs would address the implementation of a potential provisioner/driver. 
     
**Optional Release Note**:
```release-note
Baremetal Clusters Provisioning 
```
