### PR TITLE
Support Nautobot client in machine controller

### DIFF
--- a/pkg/nautobot/client.go
+++ b/pkg/nautobot/client.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nautobot
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type deviceClient struct {
+	token          string
+	dcTag          string
+	nautobotServer string
+	useHTTP        bool
+	client         *http.Client
+}
+
+func NewDeviceClient(token, dcTag, nautobotServer string) (*deviceClient, error) {
+	if token == "" || dcTag == "" || nautobotServer == "" {
+		return nil, errors.New("nautobot token, server address or site name cannot be empty")
+	}
+
+	client := http.DefaultClient
+	client.Timeout = 30 * time.Second
+	return &deviceClient{
+		client:         client,
+		dcTag:          dcTag,
+		token:          token,
+		nautobotServer: nautobotServer,
+	}, nil
+}
+
+func (dc *deviceClient) RequestActiveDevice() (*NetworkDevice, error) {
+	var scheme = "https"
+	if dc.useHTTP {
+		scheme = "http"
+	}
+
+	deviceUrl := url.URL{
+		Host:     dc.nautobotServer,
+		Path:     "api/dcim/devices/",
+		RawQuery: fmt.Sprintf("tag=%s&status=%s&limit=1&offset=0", dc.dcTag, Active),
+		Scheme:   scheme,
+	}
+	deviceRequest, err := http.NewRequest(http.MethodGet, deviceUrl.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fetch device request: %v", err)
+	}
+
+	deviceRequest.Header.Set("Authorization", fmt.Sprintf("Token %s", dc.token))
+	deviceRequest.Header.Set("Content-Type", "application/json")
+
+	res, err := dc.client.Do(deviceRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch device: %v", err)
+	}
+
+	device := &NetworkDevice{}
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read device response: %v", err)
+	}
+
+	if err := json.Unmarshal(data, device); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal device data: %v", err)
+	}
+
+	return device, nil
+}
+
+func (dc *deviceClient) GetActiveInterface(deviceId string) (*InterfaceInfo, error) {
+	var scheme = "https"
+	if dc.useHTTP {
+		scheme = "http"
+	}
+
+	deviceUrl := url.URL{
+		Host:     dc.nautobotServer,
+		Path:     "api/dcim/interfaces/",
+		RawQuery: fmt.Sprintf("mgmt_only=false&device_id=%s", deviceId),
+		Scheme:   scheme,
+	}
+	deviceRequest, err := http.NewRequest(http.MethodGet, deviceUrl.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fetch interface request: %v", err)
+	}
+
+	deviceRequest.Header.Set("Authorization", fmt.Sprintf("Token %s", dc.token))
+	deviceRequest.Header.Set("Content-Type", "application/json")
+
+	res, err := dc.client.Do(deviceRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch device interface: %v", err)
+	}
+
+	interfaces := &Interface{}
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read device interface response: %v", err)
+	}
+
+	if err := json.Unmarshal(data, interfaces); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal interface data: %v", err)
+	}
+
+	for _, i := range interfaces.Results {
+		if i.ConnectedEndpointReachable {
+			return &i, nil
+		}
+	}
+
+	return nil, errors.New("no active reachable interfaces found")
+}
+
+func (dc *deviceClient) GetIP(interfaceID string) (*IPInfo, error) {
+	var scheme = "https"
+	if dc.useHTTP {
+		scheme = "http"
+	}
+
+	ipURL := url.URL{
+		Host:     dc.nautobotServer,
+		Path:     "api/ipam/ip-addresses/",
+		RawQuery: fmt.Sprintf("interface_id=%s", interfaceID),
+		Scheme:   scheme,
+	}
+	deviceRequest, err := http.NewRequest(http.MethodGet, ipURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fetch ip request: %v", err)
+	}
+
+	deviceRequest.Header.Set("Authorization", fmt.Sprintf("Token %s", dc.token))
+	deviceRequest.Header.Set("Content-Type", "application/json")
+
+	res, err := dc.client.Do(deviceRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch ip: %v", err)
+	}
+
+	return extractIPFromBody(res.Body)
+}
+
+func (dc *deviceClient) GetPrefix(ipAddress, vrfID string, maskLength int) (*PrefixInfo, error) {
+	var scheme = "https"
+	if dc.useHTTP {
+		scheme = "http"
+	}
+
+	ipURL := url.URL{
+		Host:     dc.nautobotServer,
+		Path:     "api/ipam/prefixes/",
+		RawQuery: fmt.Sprintf("contains=%s&mask_length=%v&vrf_id=%s", ipAddress, maskLength, vrfID),
+		Scheme:   scheme,
+	}
+	deviceRequest, err := http.NewRequest(http.MethodGet, ipURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fetch prefix ip request: %v", err)
+	}
+
+	deviceRequest.Header.Set("Authorization", fmt.Sprintf("Token %s", dc.token))
+	deviceRequest.Header.Set("Content-Type", "application/json")
+
+	res, err := dc.client.Do(deviceRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch prefix ip: %v", err)
+	}
+
+	prefix := &Prefix{}
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ip response: %v", err)
+	}
+
+	if err := json.Unmarshal(data, prefix); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ip data: %v", err)
+	}
+
+	for _, i := range prefix.Results {
+		return &i, nil
+	}
+
+	return nil, errors.New("no prefix found")
+}
+
+func (dc *deviceClient) GetGatewayIP(parent, tag string) (*IPInfo, error) {
+	var scheme = "https"
+	if dc.useHTTP {
+		scheme = "http"
+	}
+
+	ipURL := url.URL{
+		Host:     dc.nautobotServer,
+		Path:     "api/ipam/ip-addresses/",
+		RawQuery: "parent=" + parent + "%2F30&tag=" + tag,
+		Scheme:   scheme,
+	}
+	deviceRequest, err := http.NewRequest(http.MethodGet, ipURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create fetch gateway ip request: %v", err)
+	}
+
+	deviceRequest.Header.Set("Authorization", fmt.Sprintf("Token %s", dc.token))
+	deviceRequest.Header.Set("Content-Type", "application/json")
+
+	res, err := dc.client.Do(deviceRequest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch gateway ip: %v", err)
+	}
+
+	return extractIPFromBody(res.Body)
+}

--- a/pkg/nautobot/common.go
+++ b/pkg/nautobot/common.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nautobot
+
+type Status struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+type Device struct {
+	ID          string `json:"id"`
+	URL         string `json:"url"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+}
+
+type Tags struct {
+	ID    string `json:"id"`
+	URL   string `json:"url"`
+	Name  string `json:"name"`
+	Slug  string `json:"slug"`
+	Color string `json:"color"`
+}
+
+type Tenant struct {
+	ID   string `json:"id"`
+	URL  string `json:"url"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+type Vrf struct {
+	ID          string `json:"id"`
+	URL         string `json:"url"`
+	Name        string `json:"name"`
+	Rd          string `json:"rd"`
+	DisplayName string `json:"display_name"`
+}
+
+type Family struct {
+	Value int    `json:"value"`
+	Label string `json:"label"`
+}
+
+type Site struct {
+	ID   string `json:"id"`
+	URL  string `json:"url"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}

--- a/pkg/nautobot/device.go
+++ b/pkg/nautobot/device.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nautobot
+
+import "time"
+
+type DeviceStatus string
+
+const (
+	Active  DeviceStatus = "active"
+	Planned DeviceStatus = "planned"
+	Staged  DeviceStatus = "staged"
+)
+
+type NetworkDevice struct {
+	Count   int          `json:"count"`
+	Results []DeviceInfo `json:"results"`
+}
+
+type DeviceInfo struct {
+	ID               string         `json:"id"`
+	URL              string         `json:"url"`
+	Name             string         `json:"name"`
+	DisplayName      string         `json:"display_name"`
+	DeviceType       *DeviceType    `json:"device_type"`
+	DeviceRole       *DeviceRole    `json:"device_role"`
+	Tenant           *Tenant        `json:"tenant"`
+	Platform         *Platform      `json:"platform"`
+	Serial           string         `json:"serial"`
+	AssetTag         interface{}    `json:"asset_tag"`
+	Site             *Site          `json:"site"`
+	Rack             *Rack          `json:"rack"`
+	Position         int            `json:"position"`
+	Face             *Face          `json:"face"`
+	ParentDevice     interface{}    `json:"parent_device"`
+	Status           *Status        `json:"status"`
+	PrimaryIP        *PrimaryIP     `json:"primary_ip"`
+	PrimaryIP4       *PrimaryIP4    `json:"primary_ip4"`
+	PrimaryIP6       interface{}    `json:"primary_ip6"`
+	Cluster          interface{}    `json:"cluster"`
+	VirtualChassis   interface{}    `json:"virtual_chassis"`
+	VcPosition       interface{}    `json:"vc_position"`
+	VcPriority       interface{}    `json:"vc_priority"`
+	Comments         string         `json:"comments"`
+	LocalContextData interface{}    `json:"local_context_data"`
+	Tags             []Tags         `json:"tags"`
+	ConfigContext    *ConfigContext `json:"config_context"`
+	Created          string         `json:"created"`
+	LastUpdated      time.Time      `json:"last_updated"`
+}
+
+type Manufacturer struct {
+	ID   string `json:"id"`
+	URL  string `json:"url"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+type DeviceType struct {
+	ID           string        `json:"id"`
+	URL          string        `json:"url"`
+	Manufacturer *Manufacturer `json:"manufacturer"`
+	Model        string        `json:"model"`
+	Slug         string        `json:"slug"`
+	DisplayName  string        `json:"display_name"`
+}
+
+type DeviceRole struct {
+	ID   string `json:"id"`
+	URL  string `json:"url"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+type Platform struct {
+	ID   string `json:"id"`
+	URL  string `json:"url"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+type Rack struct {
+	ID          string `json:"id"`
+	URL         string `json:"url"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+}
+
+type Face struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+type PrimaryIP struct {
+	ID      string `json:"id"`
+	URL     string `json:"url"`
+	Family  int    `json:"family"`
+	Address string `json:"address"`
+}
+
+type PrimaryIP4 struct {
+	ID      string `json:"id"`
+	URL     string `json:"url"`
+	Family  int    `json:"family"`
+	Address string `json:"address"`
+}
+
+type Ntp []struct {
+	IP     string `json:"ip"`
+	Prefer bool   `json:"prefer"`
+}
+
+type Host []struct {
+	IP        string `json:"ip"`
+	Version   string `json:"version"`
+	Community string `json:"community"`
+}
+
+type Community []struct {
+	Name string `json:"name"`
+	Role string `json:"role"`
+}
+
+type Snmp struct {
+	Host      Host      `json:"host"`
+	Contact   string    `json:"contact"`
+	Location  string    `json:"location"`
+	Community Community `json:"community"`
+}
+
+type Named struct {
+	PermitRoutes []string `json:"PERMIT_ROUTES"`
+}
+
+type Definitions struct {
+	Named *Named `json:"named"`
+}
+
+type ACL struct {
+	Definitions *Definitions `json:"definitions"`
+}
+
+type PermitConnRoutes struct {
+	Seq        int      `json:"seq"`
+	Type       string   `json:"type"`
+	Statements []string `json:"statements"`
+}
+
+type RouteMaps struct {
+	PermitConnRoutes *PermitConnRoutes `json:"PERMIT_CONN_ROUTES"`
+}
+
+type ConfigContext struct {
+	Cdp         bool      `json:"cdp"`
+	Ntp         Ntp       `json:"ntp"`
+	Lldp        bool      `json:"lldp"`
+	Snmp        *Snmp     `json:"snmp"`
+	AaaNewModel bool      `json:"aaa-new-model"`
+	ACL         *ACL      `json:"acl"`
+	RouteMaps   RouteMaps `json:"route-maps"`
+}

--- a/pkg/nautobot/interface.go
+++ b/pkg/nautobot/interface.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nautobot
+
+type Interface struct {
+	Count   int             `json:"count"`
+	Results []InterfaceInfo `json:"results"`
+}
+
+type InterfaceInfo struct {
+	ID                         string             `json:"id"`
+	URL                        string             `json:"url"`
+	Device                     *Device            `json:"device"`
+	Name                       string             `json:"name"`
+	Label                      string             `json:"label"`
+	Type                       *Type              `json:"type"`
+	Enabled                    bool               `json:"enabled"`
+	MacAddress                 string             `json:"mac_address"`
+	MgmtOnly                   bool               `json:"mgmt_only"`
+	Description                string             `json:"description"`
+	Cable                      *Cable             `json:"cable"`
+	CablePeer                  *CablePeer         `json:"cable_peer"`
+	CablePeerType              string             `json:"cable_peer_type"`
+	ConnectedEndpoint          *ConnectedEndpoint `json:"connected_endpoint"`
+	ConnectedEndpointType      string             `json:"connected_endpoint_type"`
+	ConnectedEndpointReachable bool               `json:"connected_endpoint_reachable"`
+	CountIpaddresses           int                `json:"count_ipaddresses"`
+}
+
+type Type struct {
+	Value string `json:"value"`
+	Label string `json:"label"`
+}
+
+type Cable struct {
+	ID    string `json:"id"`
+	URL   string `json:"url"`
+	Label string `json:"label"`
+}
+
+type CablePeer struct {
+	ID     string  `json:"id"`
+	URL    string  `json:"url"`
+	Device *Device `json:"device"`
+	Name   string  `json:"name"`
+	Cable  string  `json:"cable"`
+}
+
+type ConnectedEndpoint struct {
+	ID     string  `json:"id"`
+	URL    string  `json:"url"`
+	Device *Device `json:"device"`
+	Name   string  `json:"name"`
+	Cable  string  `json:"cable"`
+}

--- a/pkg/nautobot/ip.go
+++ b/pkg/nautobot/ip.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nautobot
+
+import "time"
+
+type IP struct {
+	Count   int      `json:"count"`
+	Results []IPInfo `json:"results"`
+}
+
+type IPInfo struct {
+	ID                 string          `json:"id"`
+	URL                string          `json:"url"`
+	Family             *Family         `json:"family"`
+	Address            string          `json:"address"`
+	Vrf                *Vrf            `json:"vrf"`
+	Tenant             *Tenant         `json:"tenant"`
+	Status             *Status         `json:"status"`
+	AssignedObjectType string          `json:"assigned_object_type"`
+	AssignedObjectID   string          `json:"assigned_object_id"`
+	AssignedObject     *AssignedObject `json:"assigned_object"`
+	DNSName            string          `json:"dns_name"`
+	Description        string          `json:"description"`
+	Created            string          `json:"created"`
+	LastUpdated        time.Time       `json:"last_updated"`
+}
+
+type AssignedObject struct {
+	ID     string  `json:"id"`
+	URL    string  `json:"url"`
+	Device *Device `json:"device"`
+	Name   string  `json:"name"`
+	Cable  string  `json:"cable"`
+}

--- a/pkg/nautobot/prefix.go
+++ b/pkg/nautobot/prefix.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nautobot
+
+import "time"
+
+type Prefix struct {
+	Count   int          `json:"count"`
+	Results []PrefixInfo `json:"results"`
+}
+
+type PrefixInfo struct {
+	ID          string    `json:"id"`
+	URL         string    `json:"url"`
+	Family      *Family   `json:"family"`
+	Prefix      string    `json:"prefix"`
+	Site        *Site     `json:"site"`
+	Vrf         *Vrf      `json:"vrf"`
+	Tenant      *Tenant   `json:"tenant"`
+	Status      *Status   `json:"status"`
+	IsPool      bool      `json:"is_pool"`
+	Description string    `json:"description"`
+	Tags        []Tags    `json:"tags"`
+	Created     string    `json:"created"`
+	LastUpdated time.Time `json:"last_updated"`
+}

--- a/pkg/nautobot/util.go
+++ b/pkg/nautobot/util.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nautobot
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+)
+
+func CidrToIPAndNetMask(ipv4 string) (string, string, int, error) {
+	ip, ipNet, err := net.ParseCIDR(ipv4)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to parse CIDR prefix: %v", err)
+	}
+
+	if len(ipNet.Mask) != 4 {
+		return "", "", 0, errors.New("inappropriate netmask length, netmask should be 4 bytes")
+	}
+	size, _ := ipNet.Mask.Size()
+
+	netmask := fmt.Sprintf("%d.%d.%d.%d", ipNet.Mask[0], ipNet.Mask[1], ipNet.Mask[2], ipNet.Mask[3])
+	return ip.String(), netmask, size, nil
+}
+
+func extractIPFromBody(resBody io.Reader) (*IPInfo, error) {
+	ip := &IP{}
+	data, err := ioutil.ReadAll(resBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read ip response: %v", err)
+	}
+
+	if err := json.Unmarshal(data, ip); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal ip data: %v", err)
+	}
+
+	for _, i := range ip.Results {
+		return &i, nil
+	}
+
+	return nil, errors.New("no ip address is found")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Support Nautobot minimal client which will be used to provision baremetal clusters
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The client is not being used in the baremetal provider. will be added once tested in a separate commit 
**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Nautobot client support
```
