### PR TITLE
Fix RHEL subscription deregistration on OpenStack

### DIFF
--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -132,6 +132,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 const userDataTemplate = `#cloud-config
 {{ if ne .CloudProviderName "aws" }}
 hostname: {{ .MachineSpec.Name }}
+fqdn: {{ .MachineSpec.Name }}
 {{- /* Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name */}}
 {{ end }}
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere-mirrors.yaml
@@ -1,6 +1,7 @@
 #cloud-config
 
 hostname: node1
+fqdn: node1
 
 
 ssh_pwauth: no

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere-proxy.yaml
@@ -1,6 +1,7 @@
 #cloud-config
 
 hostname: node1
+fqdn: node1
 
 
 ssh_pwauth: no

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere.yaml
@@ -1,6 +1,7 @@
 #cloud-config
 
 hostname: node1
+fqdn: node1
 
 
 ssh_pwauth: no


### PR DESCRIPTION
The deregistration of a RHEL subscription failed if the machines FQDN
did not match its node name. This happened for instance on OpenStack
clusters that add the .novalocal domain suffix.

This change sets the fqdn field in the cloud-init userdata to the hostname to
ensure that the machine name matches the registered name in the
RHSM or Satellite server.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix RHEL subscription deregistration on OpenStack
```
