### PR TITLE
Flatcar version in AWS fix

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -122,7 +122,7 @@ var (
 		},
 		providerconfigtypes.OperatingSystemFlatcar: {
 			// Be as precise as possible - otherwise we might get a nightly dev build
-			description: "Flatcar Container Linux stable 2345.3.1 (HVM)",
+			description: "Flatcar Container Linux stable *",
 			// The AWS marketplace ID from AWS
 			owner: "075585003325",
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an hardcoding in the AWS provider when using flatcar.
The flatcar version has been replaced by a wildcard to fetch the
latest os version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Flatcar version in AWS fix
```
