### PR TITLE
Gitignore updated with .run directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.run
 /machine-controller*
 .terraform
 terraform.tfstate


### PR DESCRIPTION
**What this PR does / why we need it**:

The `.run` directory is commonly used to store running/debugging configurations for Jetbrains IDEs. This PR adds this directory to the `.gitignore`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Gitignore updated with .run directory
```
