### PR TITLE
introduce insecure option for openstack cloud provider

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -805,6 +805,7 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 			AuthURL:    c.IdentityEndpoint,
 			Username:   c.Username,
 			Password:   c.Password,
+			Insecure:   c.Insecure,
 			DomainName: c.DomainName,
 			TenantName: c.TenantName,
 			TenantID:   c.TenantID,

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -17,14 +17,10 @@ limitations under the License.
 package openstack
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
-	"sync"
-	"time"
-	"crypto/tls"
-	"net/http"
 	"github.com/gophercloud/gophercloud"
 	goopenstack "github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
@@ -33,6 +29,10 @@ import (
 	osfloatingips "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
 	osnetworks "github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/pagination"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -86,7 +86,7 @@ type Config struct {
 	ApplicationCredentialSecret string
 	Username                    string
 	Password                    string
-	Insecure					bool
+	Insecure                    bool
 	DomainName                  string
 	TenantName                  string
 	TenantID                    string
@@ -314,7 +314,6 @@ func getClient(c *Config) (*gophercloud.ProviderClient, error) {
 		ApplicationCredentialSecret: c.ApplicationCredentialSecret,
 	}
 
-	
 	pc, err := goopenstack.AuthenticatedClient(opts)
 	if pc != nil {
 		// use the util's HTTP client to benefit, among other things, from its CA bundle
@@ -325,8 +324,8 @@ func getClient(c *Config) (*gophercloud.ProviderClient, error) {
 		pc.HTTPClient.Transport = &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
-				}, 
-			}
+			},
+		}
 	}
 
 	return pc, err

--- a/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
@@ -39,6 +39,9 @@ application-credential-secret = {{ .Global.ApplicationCredentialSecret | iniEsca
 {{- else }}
 username    = {{ .Global.Username | iniEscape }}
 password    = {{ .Global.Password | iniEscape }}
+{{- if .Global.Insecure }}
+insecure    = {{ .Global.Insecure  | boolPtr }}
+{{- end }}
 tenant-name = {{ .Global.TenantName | iniEscape }}
 tenant-id   = {{ .Global.TenantID | iniEscape }}
 {{- end }}
@@ -102,6 +105,7 @@ type GlobalOpts struct {
 	AuthURL                     string `gcfg:"auth-url"`
 	Username                    string
 	Password                    string
+	Insecure                    bool   `gcfg:"insecure"`
 	ApplicationCredentialID     string `gcfg:"application-credential-id"`
 	ApplicationCredentialSecret string `gcfg:"application-credential-secret"`
 	TenantName                  string `gcfg:"tenant-name"`

--- a/pkg/cloudprovider/provider/openstack/types/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/openstack/types/cloudconfig_test.go
@@ -60,6 +60,30 @@ func TestCloudConfigToString(t *testing.T) {
 			},
 		},
 		{
+			name: "simple-insecure-config",
+			config: &CloudConfig{
+				Global: GlobalOpts{
+					AuthURL:    "https://127.0.0.1:8443",
+					Username:   "admin",
+					Password:   "password",
+					Insecure:   true,
+					DomainName: "Default",
+					TenantName: "Test",
+					Region:     "eu-central1",
+				},
+				BlockStorage: BlockStorageOpts{
+					BSVersion:             "v2",
+					IgnoreVolumeAZ:        true,
+					TrustDevicePath:       true,
+					NodeVolumeAttachLimit: 25,
+				},
+				LoadBalancer: LoadBalancerOpts{
+					ManageSecurityGroups: true,
+				},
+				Version: "1.10.0",
+			},
+		},
+		{
 			name: "use-octavia-explicitly-enabled",
 			config: &CloudConfig{
 				Global: GlobalOpts{

--- a/pkg/cloudprovider/provider/openstack/types/testdata/simple-insecure-config.golden
+++ b/pkg/cloudprovider/provider/openstack/types/testdata/simple-insecure-config.golden
@@ -1,0 +1,22 @@
+[Global]
+auth-url    = "https://127.0.0.1:8443"
+username    = "admin"
+password    = "password"
+insecure    = true
+tenant-name = "Test"
+tenant-id   = ""
+domain-name = "Default"
+region      = "eu-central1"
+
+[LoadBalancer]
+lb-version = "v2"
+subnet-id = ""
+floating-network-id = ""
+lb-method = "ROUND_ROBIN"
+lb-provider = ""
+
+[BlockStorage]
+ignore-volume-az  = true
+trust-device-path = true
+bs-version        = "v2"
+node-volume-attach-limit = 25

--- a/pkg/cloudprovider/provider/openstack/types/types.go
+++ b/pkg/cloudprovider/provider/openstack/types/types.go
@@ -25,7 +25,7 @@ type RawConfig struct {
 	IdentityEndpoint            providerconfigtypes.ConfigVarString `json:"identityEndpoint,omitempty"`
 	Username                    providerconfigtypes.ConfigVarString `json:"username,omitempty"`
 	Password                    providerconfigtypes.ConfigVarString `json:"password,omitempty"`
-	Insecure					providerconfigtypes.ConfigVarBool   `json:"insecure,omitempty"`
+	Insecure                    providerconfigtypes.ConfigVarBool   `json:"insecure,omitempty"`
 	ApplicationCredentialID     providerconfigtypes.ConfigVarString `json:"applicationCredentialID,omitempty"`
 	ApplicationCredentialSecret providerconfigtypes.ConfigVarString `json:"applicationCredentialSecret,omitempty"`
 	DomainName                  providerconfigtypes.ConfigVarString `json:"domainName,omitempty"`

--- a/pkg/cloudprovider/provider/openstack/types/types.go
+++ b/pkg/cloudprovider/provider/openstack/types/types.go
@@ -25,6 +25,7 @@ type RawConfig struct {
 	IdentityEndpoint            providerconfigtypes.ConfigVarString `json:"identityEndpoint,omitempty"`
 	Username                    providerconfigtypes.ConfigVarString `json:"username,omitempty"`
 	Password                    providerconfigtypes.ConfigVarString `json:"password,omitempty"`
+	Insecure					providerconfigtypes.ConfigVarBool   `json:"insecure,omitempty"`
 	ApplicationCredentialID     providerconfigtypes.ConfigVarString `json:"applicationCredentialID,omitempty"`
 	ApplicationCredentialSecret providerconfigtypes.ConfigVarString `json:"applicationCredentialSecret,omitempty"`
 	DomainName                  providerconfigtypes.ConfigVarString `json:"domainName,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #970

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduces the `insecure` option which can be set via `OS_INSECURE` or `insecure=true` in the cloud provider config
```
