### PR TITLE
[release/v1.27] fix vSphere client not using the provided custom CA bundle (#969)

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/client.go
+++ b/pkg/cloudprovider/provider/vsphere/client.go
@@ -22,13 +22,16 @@ import (
 	"fmt"
 	"net/url"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
-	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
-
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 type Session struct {
@@ -43,16 +46,26 @@ func NewSession(ctx context.Context, config *Config) (*Session, error) {
 	if err != nil {
 		return nil, err
 	}
-	clientURL.User = url.UserPassword(config.Username, config.Password)
 
-	client, err := govmomi.NewClient(ctx, clientURL, config.AllowInsecure)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build client: %v", err)
+	// creating the govmoni Client in roundabout way because we need to set the proper CA bundle: reference https://github.com/vmware/govmomi/issues/1200
+	soapClient := soap.NewClient(clientURL, config.AllowInsecure)
+	// set our CA bundle
+	soapClient.DefaultTransport().TLSClientConfig = &tls.Config{
+		RootCAs: util.CABundle,
 	}
 
-	// inject our global set of CA certificates
-	client.DefaultTransport().TLSClientConfig = &tls.Config{
-		RootCAs: util.CABundle,
+	vim25Client, err := vim25.NewClient(ctx, soapClient)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &govmomi.Client{
+		Client:         vim25Client,
+		SessionManager: session.NewManager(vim25Client),
+	}
+
+	if err = client.Login(ctx, url.UserPassword(config.Username, config.Password)); err != nil {
+		return nil, fmt.Errorf("failed vsphere login: %v", err)
 	}
 
 	finder := find.NewFinder(client.Client, true)


### PR DESCRIPTION
**What this PR does / why we need it**:
Backport of original #969 

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed vSphere client not using the provided custom CA bundle (#969)
```
