### PR TITLE
use the rhel ga instead of custom image on azure

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -313,7 +313,7 @@ presubmits:
               cpu: 500m
 
   - name: pull-machine-controller-e2e-aws-arm
-    always_run: true
+    always_run: false
     decorate: true
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -133,9 +133,9 @@ var imageReferences = map[providerconfigtypes.OperatingSystem]compute.ImageRefer
 	},
 	providerconfigtypes.OperatingSystemRHEL: {
 		Publisher: to.StringPtr("RedHat"),
-		Offer:     to.StringPtr("RHEL"),
-		Sku:       to.StringPtr("7-RAW-CI"),
-		Version:   to.StringPtr("7.7.2019081601"),
+		Offer:     to.StringPtr("rhel-byos"),
+		Sku:       to.StringPtr("rhel-lvm83"),
+		Version:   to.StringPtr("8.3.20201109"),
 	},
 	providerconfigtypes.OperatingSystemFlatcar: {
 		Publisher: to.StringPtr("kinvolk"),
@@ -150,6 +150,11 @@ var osPlans = map[providerconfigtypes.OperatingSystem]*compute.Plan{
 		Name:      pointer.StringPtr("stable"),
 		Publisher: pointer.StringPtr("kinvolk"),
 		Product:   pointer.StringPtr("flatcar-container-linux"),
+	},
+	providerconfigtypes.OperatingSystemRHEL: {
+		Name:      pointer.StringPtr("rhel-lvm83"),
+		Publisher: pointer.StringPtr("redhat"),
+		Product:   pointer.StringPtr("rhel-byos"),
 	},
 }
 
@@ -282,7 +287,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*config, *providerconfigt
 	c.OSDiskSize = rawCfg.OSDiskSize
 	c.DataDiskSize = rawCfg.DataDiskSize
 
-	if rawCfg.ImagePlan != nil {
+	if rawCfg.ImagePlan != nil && rawCfg.ImagePlan.Name != "" {
 		c.ImagePlan = &compute.Plan{
 			Name:      pointer.StringPtr(rawCfg.ImagePlan.Name),
 			Publisher: pointer.StringPtr(rawCfg.ImagePlan.Publisher),

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -204,7 +204,9 @@ write_files:
 {{- /*  https://bugs.launchpad.net/cloud-init/+bug/1662542 */}}
     hostnamectl set-hostname {{ .MachineSpec.Name }}
     {{ end }}
-
+    {{ if eq .CloudProviderName "azure" }}
+    yum update -y --disablerepo='*' --enablerepo='*microsoft*'
+    {{ end }}
     yum install -y \
       device-mapper-persistent-data \
       lvm2 \

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -147,13 +147,6 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		rhelSubscriptionManagerUser := os.Getenv("RHEL_SUBSCRIPTION_MANAGER_USER")
 		rhelSubscriptionManagerPassword := os.Getenv("RHEL_SUBSCRIPTION_MANAGER_PASSWORD")
 		rhsmOfflineToken := os.Getenv("REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN")
-		if strings.Contains(cloudProvider, string(providerconfigtypes.CloudProviderAzure)) {
-			rhelImageID := os.Getenv("AZURE_RHEL_IMAGE_ID")
-			if rhelImageID == "" {
-				t.Fatalf("Unable to run e2e tests, AZURE_RHEL_IMAGE_ID must be set when rhel is used as an os in Azure")
-			}
-			scenarioParams = append(scenarioParams, fmt.Sprintf("<< IMAGE_ID >>=%s", rhelImageID))
-		}
 
 		if rhelSubscriptionManagerUser == "" || rhelSubscriptionManagerPassword == "" || rhsmOfflineToken == "" {
 			t.Fatalf("Unable to run e2e tests, RHEL_SUBSCRIPTION_MANAGER_USER, RHEL_SUBSCRIPTION_MANAGER_PASSWORD, and " +
@@ -172,9 +165,12 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< OS_DISK_SIZE >>=%v", 30))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DATA_DISK_SIZE >>=%v", 30))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", ""))
-		scenarioParams = append(scenarioParams, fmt.Sprintf("<< IMAGE_ID >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 25))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< CUSTOM-IMAGE >>=%v", ""))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_USER >>=%s", ""))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>=%s", ""))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", ""))
+
 	}
 
 	// only used by OpenStack scenarios

--- a/test/e2e/provisioning/testdata/machinedeployment-azure-custom-image-reference.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure-custom-image-reference.yaml
@@ -38,7 +38,6 @@ spec:
             vnetName: "machine-controller-e2e"
             subnetName: "machine-controller-e2e"
             routeTableName: "machine-controller-e2e"
-            imageID: "<< IMAGE_ID >>"
             imageReference:
               publisher: "Canonical"
               offer: "0001-com-ubuntu-server-focal"

--- a/test/e2e/provisioning/testdata/machinedeployment-azure-redhat-satellite.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure-redhat-satellite.yaml
@@ -39,10 +39,6 @@ spec:
             assignPublicIP: true
             zones:
               - "1"
-            imagePlan:
-              name: ""
-              publisher: ""
-              product: ""
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
@@ -38,7 +38,6 @@ spec:
             vnetName: "machine-controller-e2e"
             subnetName: "machine-controller-e2e"
             routeTableName: "machine-controller-e2e"
-            imageID: "<< IMAGE_ID >>"
             assignPublicIP: false
             zones:
               - "1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Using RHEL GA images instead of custom images. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #974

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
