### PR TITLE
add aws-node-termination-handler label for node selector

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -389,6 +389,12 @@ func (p *provider) AddDefaults(spec v1alpha1.MachineSpec) (v1alpha1.MachineSpec,
 	if rawConfig.AssignPublicIP == nil {
 		rawConfig.AssignPublicIP = aws.Bool(true)
 	}
+	if rawConfig.IsSpotInstance != nil && *rawConfig.IsSpotInstance {
+		if spec.Labels == nil {
+			spec.Labels = map[string]string{}
+		}
+		spec.Labels["k8c.io/aws-spot"] = "aws-node-termination-handler"
+	}
 	spec.ProviderSpec.Value, err = setProviderSpec(*rawConfig, spec.ProviderSpec)
 	return spec, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Label machines and nodes with aws-node-termination-handler for aws spot instances draining.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes kubermatic/kubermatic#6723

**Special notes for your reviewer**:
Please have a look on this PR as well:
https://github.com/kubermatic/kubermatic/compare/master...moadqassem:supports-aws-node-termination-handler?expand=1

**Optional Release Note**:
```release-note
AWS Spot instances support
```
