### PR TITLE
fix vsphere TLS client config overwrite

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/client.go
+++ b/pkg/cloudprovider/provider/vsphere/client.go
@@ -18,7 +18,6 @@ package vsphere
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/url"
 
@@ -50,9 +49,7 @@ func NewSession(ctx context.Context, config *Config) (*Session, error) {
 	// creating the govmoni Client in roundabout way because we need to set the proper CA bundle: reference https://github.com/vmware/govmomi/issues/1200
 	soapClient := soap.NewClient(clientURL, config.AllowInsecure)
 	// set our CA bundle
-	soapClient.DefaultTransport().TLSClientConfig = &tls.Config{
-		RootCAs: util.CABundle,
-	}
+	soapClient.DefaultTransport().TLSClientConfig.RootCAs = util.CABundle
 
 	vim25Client, err := vim25.NewClient(ctx, soapClient)
 	if err != nil {


### PR DESCRIPTION
**Which issue(s) this PR fixes**
Possible Fix for #6859

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Breaking: require hetzner Machine to have network defined
```
