### PR TITLE
Skip satellite subscription deletion when the subscription is not found

### DIFF
--- a/pkg/rhsm/satellite_subscription_manager.go
+++ b/pkg/rhsm/satellite_subscription_manager.go
@@ -104,10 +104,21 @@ func (s *DefaultSatelliteSubscriptionManager) executeDeleteRequest(machineName, 
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode != http.StatusOK {
+	if !validStatusCode(response.StatusCode) {
 		return fmt.Errorf("error while executing request with status code: %v", response.StatusCode)
 	}
 
 	klog.Infof("host %v has been deleted successfully", machineName)
 	return nil
+}
+
+func validStatusCode(status int) bool {
+	switch status {
+	case http.StatusOK:
+		return true
+	case http.StatusNotFound:
+		return true
+	}
+
+	return false
 }

--- a/pkg/rhsm/util.go
+++ b/pkg/rhsm/util.go
@@ -23,14 +23,14 @@ import (
 )
 
 const (
-	redhatSubscriptionFinalizer = "kubermatic.io/red-hat-subscription"
+	RedhatSubscriptionFinalizer = "kubermatic.io/red-hat-subscription"
 )
 
-// AddRHELSubscriptionFinalizer adds finalizer redhatSubscriptionFinalizer to the machine object on rhel machine creation.
+// AddRHELSubscriptionFinalizer adds finalizer RedhatSubscriptionFinalizer to the machine object on rhel machine creation.
 func AddRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.MachineUpdater) error {
-	if !kuberneteshelper.HasFinalizer(machine, redhatSubscriptionFinalizer) {
+	if !kuberneteshelper.HasFinalizer(machine, RedhatSubscriptionFinalizer) {
 		if err := update(machine, func(m *v1alpha1.Machine) {
-			machine.Finalizers = append(m.Finalizers, redhatSubscriptionFinalizer)
+			machine.Finalizers = append(m.Finalizers, RedhatSubscriptionFinalizer)
 		}); err != nil {
 			return err
 		}
@@ -39,11 +39,11 @@ func AddRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.Machin
 	return nil
 }
 
-// RemoveRHELSubscriptionFinalizer removes finalizer redhatSubscriptionFinalizer to the machine object on rhel machine deletion.
+// RemoveRHELSubscriptionFinalizer removes finalizer RedhatSubscriptionFinalizer to the machine object on rhel machine deletion.
 func RemoveRHELSubscriptionFinalizer(machine *v1alpha1.Machine, update types.MachineUpdater) error {
-	if kuberneteshelper.HasFinalizer(machine, redhatSubscriptionFinalizer) {
+	if kuberneteshelper.HasFinalizer(machine, RedhatSubscriptionFinalizer) {
 		if err := update(machine, func(m *v1alpha1.Machine) {
-			machine.Finalizers = kuberneteshelper.RemoveFinalizer(machine.Finalizers, redhatSubscriptionFinalizer)
+			machine.Finalizers = kuberneteshelper.RemoveFinalizer(machine.Finalizers, RedhatSubscriptionFinalizer)
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
When the satellite subscription has been deleted manually or wasn't registered correctly in the first place due to some custom setup, the deletion of the subscription should be avoid otherwise the machine will be stuck in deletion phase
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #980 

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
