### PR TITLE
Fixed openstack client ca bundle handling

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -308,12 +308,16 @@ func getClient(c *Config) (*gophercloud.ProviderClient, error) {
 		ApplicationCredentialSecret: c.ApplicationCredentialSecret,
 	}
 
-	pc, err := goopenstack.AuthenticatedClient(opts)
+	pc, err := goopenstack.NewClient(c.IdentityEndpoint)
+	if err != nil {
+		return nil, err
+	}
 	if pc != nil {
 		// use the util's HTTP client to benefit, among other things, from its CA bundle
 		pc.HTTPClient = cloudproviderutil.HTTPClientConfig{LogPrefix: "[OpenStack API]"}.New()
 	}
 
+	err = goopenstack.Authenticate(pc, opts)
 	return pc, err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for openstack custom ca bundle handling. Client was trying to authenticate before setting the custom CA bundle which was causing errors.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #994 

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed using a custom CA Bundle for Openstack by authenticating after setting the custom CA bundle
```
