### PR TITLE
Add support for volume type openstack

### DIFF
--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -125,6 +125,8 @@ network: ""
 trustDevicePath: false
 # set root disk size
 rootDiskSizeGB: 50
+# set root disk volume type
+rootDiskVolumeType: ""
 # set node-volume-attach-limit flag for cloud-config
 nodeVolumeAttachLimit: 20
 # the list of tags you would like to attach to the instance

--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -119,7 +119,7 @@ spec:
             # Optional, if set, the rootDisk will be a volume. If not, the rootDisk
             # will be on ephemeral storage and its size will be derived from the flavor
             rootDiskSizeGB: 20
-            # Optional, only applied if rootDiskSizeGB is set. 
+            # Optional, only applied if rootDiskSizeGB is set.
             # Sets the volume type of the root disk.
             rootDiskVolumeType: ""
             # the list of metadata you would like to attach to the instance

--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -119,6 +119,9 @@ spec:
             # Optional, if set, the rootDisk will be a volume. If not, the rootDisk
             # will be on ephemeral storage and its size will be derived from the flavor
             rootDiskSizeGB: 20
+            # Optional, only applied if rootDiskSizeGB is set. 
+            # Sets the volume type of the root disk.
+            rootDiskVolumeType: ""
             # the list of metadata you would like to attach to the instance
             tags:
               tagKey: tagValue

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -101,6 +101,7 @@ type Config struct {
 	AvailabilityZone      string
 	TrustDevicePath       bool
 	RootDiskSizeGB        *int
+	RootDiskVolumeType    string
 	NodeVolumeAttachLimit *uint
 
 	InstanceReadyCheckPeriod  time.Duration
@@ -264,6 +265,10 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		return nil, nil, nil, err
 	}
 	c.RootDiskSizeGB = rawConfig.RootDiskSizeGB
+	c.RootDiskVolumeType, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.RootDiskVolumeType)
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	c.NodeVolumeAttachLimit = rawConfig.NodeVolumeAttachLimit
 	c.Tags = rawConfig.Tags
 	if c.Tags == nil {
@@ -567,6 +572,7 @@ func (p *provider) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.Pr
 				SourceType:          bootfromvolume.SourceImage,
 				UUID:                image.ID,
 				VolumeSize:          *c.RootDiskSizeGB,
+				VolumeType:          c.RootDiskVolumeType,
 			},
 		}
 		createOpts := bootfromvolume.CreateOptsExt{

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -166,7 +166,7 @@ func (o openstackProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 		"rootDiskSizeGB": {{ .RootDiskSizeGB }},
 		{{- end }}
 		{{- if .RootDiskVolumeType }}
-		"rootDiskVolumeType": {{ .RootDiskVolumeType }}
+		"rootDiskVolumeType": "{{ .RootDiskVolumeType }}",
 		{{- end }}
 		"securityGroups": [
 			"kubernetes-xyz"

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -113,7 +113,7 @@ const expectedBlockDeviceBootVolumeTypeRequest = `{
 		  "source_type": "image",
 		  "uuid": "f3e4a95d-1f4f-4989-97ce-f3a1fb8c04d7",
 		  "volume_size": 10,
-		  "volume_type": "ssd"
+		  "volume_type": "ssd",
 		}
 	  ],
 	  "flavorRef": "1",

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -105,6 +105,7 @@ const expectedBlockDeviceBootRequest = `{
 type openstackProviderSpecConf struct {
 	IdentityEndpointURL         string
 	RootDiskSizeGB              *int32
+	RootDiskVolumeType          string
 	ApplicationCredentialID     string
 	ApplicationCredentialSecret string
 }
@@ -126,6 +127,9 @@ func (o openstackProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 		"instanceReadyCheckTimeout": "2m",
 		{{- if .RootDiskSizeGB }}
 		"rootDiskSizeGB": {{ .RootDiskSizeGB }},
+		{{- end }}
+		{{- if .RootDiskVolumeType }}
+		"rootDiskVolumeType": {{ .RootDiskVolumeType }}
 		{{- end }}
 		"securityGroups": [
 			"kubernetes-xyz"
@@ -184,6 +188,12 @@ func TestCreateServer(t *testing.T) {
 		{
 			name:          "Custom disk size",
 			specConf:      openstackProviderSpecConf{RootDiskSizeGB: pointer.Int32Ptr(10)},
+			userdata:      "fake-userdata",
+			wantServerReq: expectedBlockDeviceBootRequest,
+		},
+		{
+			name:          "Custom disk type",
+			specConf:      openstackProviderSpecConf{RootDiskVolumeType: "ssd"},
 			userdata:      "fake-userdata",
 			wantServerReq: expectedBlockDeviceBootRequest,
 		},

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -102,6 +102,43 @@ const expectedBlockDeviceBootRequest = `{
   }
 }`
 
+const expectedBlockDeviceBootVolumeTypeRequest = `{
+	"server": {
+	  "availability_zone": "eu-de-01",
+	  "block_device_mapping_v2": [
+		{
+		  "boot_index": 0,
+		  "delete_on_termination": true,
+		  "destination_type": "volume",
+		  "source_type": "image",
+		  "uuid": "f3e4a95d-1f4f-4989-97ce-f3a1fb8c04d7",
+		  "volume_size": 10,
+		  "volume_type": "ssd"
+		}
+	  ],
+	  "flavorRef": "1",
+	  "imageRef": "",
+	  "metadata": {
+		"kubernetes-cluster": "xyz",
+		"machine-uid": "",
+		"system-cluster": "zyx",
+		"system-project": "xxx"
+	  },
+	  "name": "test",
+	  "networks": [
+		{
+		  "uuid": "d32019d3-bc6e-4319-9c1d-6722fc136a22"
+		}
+	  ],
+	  "security_groups": [
+		{
+		  "name": "kubernetes-xyz"
+		}
+	  ],
+	  "user_data": "ZmFrZS11c2VyZGF0YQ=="
+	}
+  }`
+
 type openstackProviderSpecConf struct {
 	IdentityEndpointURL         string
 	RootDiskSizeGB              *int32
@@ -193,9 +230,9 @@ func TestCreateServer(t *testing.T) {
 		},
 		{
 			name:          "Custom disk type",
-			specConf:      openstackProviderSpecConf{RootDiskVolumeType: "ssd"},
+			specConf:      openstackProviderSpecConf{RootDiskSizeGB: pointer.Int32Ptr(10), RootDiskVolumeType: "ssd"},
 			userdata:      "fake-userdata",
-			wantServerReq: expectedBlockDeviceBootRequest,
+			wantServerReq: expectedBlockDeviceBootVolumeTypeRequest,
 		},
 		{
 			name:          "Application Credentials",

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -113,7 +113,7 @@ const expectedBlockDeviceBootVolumeTypeRequest = `{
 		  "source_type": "image",
 		  "uuid": "f3e4a95d-1f4f-4989-97ce-f3a1fb8c04d7",
 		  "volume_size": 10,
-		  "volume_type": "ssd",
+		  "volume_type": "ssd"
 		}
 	  ],
 	  "flavorRef": "1",

--- a/pkg/cloudprovider/provider/openstack/types/types.go
+++ b/pkg/cloudprovider/provider/openstack/types/types.go
@@ -45,6 +45,7 @@ type RawConfig struct {
 	AvailabilityZone      providerconfigtypes.ConfigVarString   `json:"availabilityZone,omitempty"`
 	TrustDevicePath       providerconfigtypes.ConfigVarBool     `json:"trustDevicePath"`
 	RootDiskSizeGB        *int                                  `json:"rootDiskSizeGB"`
+	RootDiskVolumeType    providerconfigtypes.ConfigVarString   `json:"rootDiskVolumeType,omitempty"`
 	NodeVolumeAttachLimit *uint                                 `json:"nodeVolumeAttachLimit"`
 	// This tag is related to server metadata, not compute server's tag
 	Tags map[string]string `json:"tags,omitempty"`


### PR DESCRIPTION
Signed-off-by: Happy2C0de <46957159+Happy2C0de@users.noreply.github.com>

**What this PR does / why we need it**:
Adds support to add a volume type to the machine deployments. This goes along with the setting `rootDiskSizeGB` and I added it such that it's only applied if and only if the `rootDiskSizeGB` is specified. I think that makes sense.
Exposes the VolumeType option in the underlying library, see:
https://pkg.go.dev/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume#BlockDevice

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support to specify the root disk volume type in Openstack if booted from volume.
```
