### PR TITLE
Fix node_csr_approver

### DIFF
--- a/pkg/controller/nodecsrapprover/node_csr_approver.go
+++ b/pkg/controller/nodecsrapprover/node_csr_approver.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
 	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -141,6 +142,7 @@ func (r *reconciler) reconcile(ctx context.Context, request reconcile.Request) e
 	approvalCondition := certificatesv1.CertificateSigningRequestCondition{
 		Type:   certificatesv1.CertificateApproved,
 		Reason: "machine-controller NodeCSRApprover controller approved node serving cert",
+		Status: corev1.ConditionTrue,
 	}
 	csr.Status.Conditions = append(csr.Status.Conditions, approvalCondition)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
After upgrading certificates API to v1, .status field became required.

```
E0614 12:50:17.169084       1 node_csr_approver.go:77] Reconciliation of request /csr-dfnrk failed: failed to approve CSR "csr-dfnrk": CertificateSigningRequest.certificates.k8s.io "csr-dfnrk" is invalid: status.conditions[0].status: Required value
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix node_csr_approver
```
