### PR TITLE
Force certificates/v1 to register

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/node"
 	"github.com/kubermatic/machine-controller/pkg/signals"
 
+	certificatesv1 "k8s.io/api/certificates/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -178,7 +179,10 @@ func main() {
 		klog.Fatalf("failed to add machinesv1alpha1 api to scheme: %v", err)
 	}
 	if err := apiextensionsv1.AddToScheme(scheme.Scheme); err != nil {
-		klog.Fatalf("failed to add apiextensionv1beta1 api to scheme: %v", err)
+		klog.Fatalf("failed to add apiextensionsv1 api to scheme: %v", err)
+	}
+	if err := certificatesv1.AddToScheme(scheme.Scheme); err != nil {
+		klog.Fatalf("failed to add certificatesv1 api to scheme: %v", err)
 	}
 	if err := clusterv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		klog.Fatalf("failed to add clusterv1alpha1 api to scheme: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes it fails with:
```
E0616 15:27:06.818753       1 main.go:304] failed to start kubebuilder manager: no matches for kind "CertificateSigningRequest" in version "certificates.k8s.io/v1"
```

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix: Force certificates/v1 to register
```
