### PR TITLE
add application credentials for cloud config

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -798,13 +798,15 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 
 	cc := &openstacktypes.CloudConfig{
 		Global: openstacktypes.GlobalOpts{
-			AuthURL:    c.IdentityEndpoint,
-			Username:   c.Username,
-			Password:   c.Password,
-			DomainName: c.DomainName,
-			TenantName: c.TenantName,
-			TenantID:   c.TenantID,
-			Region:     c.Region,
+			AuthURL:                     c.IdentityEndpoint,
+			Username:                    c.Username,
+			Password:                    c.Password,
+			DomainName:                  c.DomainName,
+			TenantName:                  c.TenantName,
+			TenantID:                    c.TenantID,
+			Region:                      c.Region,
+			ApplicationCredentialSecret: c.ApplicationCredentialSecret,
+			ApplicationCredentialID:     c.ApplicationCredentialID,
 		},
 		LoadBalancer: openstacktypes.LoadBalancerOpts{
 			ManageSecurityGroups: true,


### PR DESCRIPTION
**What this PR does / why we need it**: add application credentials for cloud-config.
Passing only application credentials cause the failure  of openstack-cloud-controller-manager:
```
W0618 07:16:50.834250       1 openstack.go:303] New openstack client created failed with config: You must provide a password to authenticate
F0618 07:16:50.834306       1 controllermanager.go:131] Cloud provider could not be initialized: could not init cloud provider "openstack": You must provide a password to authenticate
```
I assume the application credential are not included in cloud config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

```release-note
NONE
```
