### PR TITLE
add loadBalancerSku to azure cloud

### DIFF
--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -78,6 +78,7 @@ type config struct {
 	VMSize            string
 	VNetName          string
 	SubnetName        string
+	LoadBalancerSku   string
 	RouteTableName    string
 	AvailabilitySet   string
 	SecurityGroupName string
@@ -260,6 +261,11 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*config, *providerconfigt
 	c.SubnetName, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.SubnetName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get the value of \"subnetName\" field, error = %v", err)
+	}
+
+	c.LoadBalancerSku, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.LoadBalancerSku)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get the value of \"loadBalancerSku\" field, error = %v", err)
 	}
 
 	c.RouteTableName, err = p.configVarResolver.GetConfigVarStringValue(rawCfg.RouteTableName)
@@ -821,6 +827,7 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 		Location:                   c.Location,
 		VNetName:                   c.VNetName,
 		SubnetName:                 c.SubnetName,
+		LoadBalancerSku:            c.LoadBalancerSku,
 		RouteTableName:             c.RouteTableName,
 		PrimaryAvailabilitySetName: c.AvailabilitySet,
 		SecurityGroupName:          c.SecurityGroupName,

--- a/pkg/cloudprovider/provider/azure/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/azure/types/cloudconfig.go
@@ -37,6 +37,7 @@ type CloudConfig struct {
 	PrimaryAvailabilitySetName string `json:"primaryAvailabilitySetName"`
 	VnetResourceGroup          string `json:"vnetResourceGroup"`
 	UseInstanceMetadata        bool   `json:"useInstanceMetadata"`
+	LoadBalancerSku            string `json:"loadBalancerSku"`
 }
 
 func CloudConfigToString(c *CloudConfig) (string, error) {

--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -33,6 +33,7 @@ type RawConfig struct {
 	VMSize            providerconfigtypes.ConfigVarString `json:"vmSize"`
 	VNetName          providerconfigtypes.ConfigVarString `json:"vnetName"`
 	SubnetName        providerconfigtypes.ConfigVarString `json:"subnetName"`
+	LoadBalancerSku   providerconfigtypes.ConfigVarString `json:"loadBalancerSku"`
 	RouteTableName    providerconfigtypes.ConfigVarString `json:"routeTableName"`
 	AvailabilitySet   providerconfigtypes.ConfigVarString `json:"availabilitySet"`
 	SecurityGroupName providerconfigtypes.ConfigVarString `json:"securityGroupName"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Add loadBalancerSku field in the azure cloud config file to have the possibility to change the LB type to Standard.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
