### PR TITLE
Add nil check for SpotInstanceConfig

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -354,7 +354,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	c.Tags = rawConfig.Tags
 	c.AssignPublicIP = rawConfig.AssignPublicIP
 	c.IsSpotInstance = rawConfig.IsSpotInstance
-	if c.IsSpotInstance != nil && *c.IsSpotInstance {
+	if rawConfig.SpotInstanceConfig != nil && c.IsSpotInstance != nil && *c.IsSpotInstance {
 		maxPrice, err := p.configVarResolver.GetConfigVarStringValue(rawConfig.SpotInstanceConfig.MaxPrice)
 		if err != nil {
 			return nil, nil, nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a `nil` check before trying to extract the SpotInstanceConfig. The machine-controller-webhook panics without this check if `IsSpotInstance` is set to true, but the config is not provided.

```
2021/06/29 17:39:38 http: panic serving 10.244.0.0:32995: runtime error: invalid memory address or nil pointer dereference
goroutine 231 [running]:
net/http.(*conn).serve.func1(0xc0005e1ae0)
	net/http/server.go:1801 +0x147
panic(0x2ced6e0, 0x52e3290)
	runtime/panic.go:975 +0x3e9
net/http.(*timeoutHandler).ServeHTTP(0xc000771b00, 0x38829c0, 0xc0007fa8c0, 0xc0008f9b00)
	net/http/server.go:3277 +0x988
net/http.serverHandler.ServeHTTP(0xc0007fa0e0, 0x38829c0, 0xc0007fa8c0, 0xc0008f9b00)
	net/http/server.go:2843 +0xa3
net/http.(*conn).serve(0xc0005e1ae0, 0x388dc40, 0xc00097e680)
	net/http/server.go:1925 +0x8ad
created by net/http.(*Server).Serve
	net/http/server.go:2969 +0x36c
```

**Optional Release Note**:
```release-note
Fix issue causing machine-controller-webhook to panic if IsSpotInstance is set to true, but SpotInstanceConfig isn't provided
```

/assign @moadqassem @kron4eg 