### PR TITLE
increase InstanceReadyCheckTimeout for OpenStack from 10 seconds to 10 minutes

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -217,10 +217,10 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		}
 
 		if c.InstanceReadyCheckTimeout < 0 {
-			c.InstanceReadyCheckTimeout = 10 * time.Second
+			c.InstanceReadyCheckTimeout = 120 * time.Second
 		}
 	} else {
-		c.InstanceReadyCheckTimeout = 10 * time.Second
+		c.InstanceReadyCheckTimeout = 120 * time.Second
 	}
 
 	// We ignore errors here because the OS domain is only required when using Identity API V3

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -217,10 +217,10 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		}
 
 		if c.InstanceReadyCheckTimeout < 0 {
-			c.InstanceReadyCheckTimeout = 120 * time.Second
+			c.InstanceReadyCheckTimeout = 600 * time.Second
 		}
 	} else {
-		c.InstanceReadyCheckTimeout = 120 * time.Second
+		c.InstanceReadyCheckTimeout = 600 * time.Second
 	}
 
 	// We ignore errors here because the OS domain is only required when using Identity API V3


### PR DESCRIPTION
Signed-off-by: Hubert Ströbitzer <hubert@kubermatic.com>

**What this PR does / why we need it**:

Customers have the issue that the provided default (10 seconds) is to small for OpenStack to get a VM up and running. They can for sure override this value but having good defaults is a better approach IMO.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
```release-note
Increasing the default value for OpenStack instances to get ready from 10 seconds to 10 minutes.
```
