### PR TITLE
Disable systemd-resolved stub server

### DIFF
--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -184,6 +184,10 @@ write_files:
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
 
+{{- /* Disable systemd-resolved to give place to local DNS cache  */}}
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
+
 {{- /* As we added some modules and don't want to reboot, restart the service */}}
     systemctl restart systemd-modules-load.service
     sysctl --system

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -180,6 +180,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -176,6 +176,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/containerd.yaml
+++ b/pkg/userdata/ubuntu/testdata/containerd.yaml
@@ -52,6 +52,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -59,6 +65,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/containerd.yaml
+++ b/pkg/userdata/ubuntu/testdata/containerd.yaml
@@ -56,6 +56,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -52,6 +52,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -59,6 +65,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -56,6 +56,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -50,6 +50,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -57,6 +63,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -54,6 +54,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -50,6 +50,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -57,6 +63,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -54,6 +54,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -52,6 +52,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -59,6 +65,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -56,6 +56,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -50,6 +50,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -57,6 +63,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -54,6 +54,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -50,6 +50,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -57,6 +63,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -54,6 +54,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/version-1.17.16.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.17.16.yaml
@@ -50,6 +50,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -57,6 +63,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/version-1.17.16.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.17.16.yaml
@@ -54,6 +54,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/version-1.18.14.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.18.14.yaml
@@ -50,6 +50,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -57,6 +63,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/version-1.18.14.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.18.14.yaml
@@ -54,6 +54,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/version-1.19.4.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.19.4.yaml
@@ -50,6 +50,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -57,6 +63,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/version-1.19.4.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.19.4.yaml
@@ -54,6 +54,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/version-1.20.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.20.1.yaml
@@ -50,6 +50,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -57,6 +63,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/version-1.20.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.20.1.yaml
@@ -54,6 +54,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -63,6 +63,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -59,6 +59,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -66,6 +72,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -63,6 +63,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -59,6 +59,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -66,6 +72,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -50,6 +50,12 @@ write_files:
     # Enable cgroups memory and swap accounting
     GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
+- path: "/etc/systemd/resolved.conf"
+  content: |
+    # Updated by kubermatic machine-controller
+    # Disables systemd-resolved listener.
+    DNSStubListener=no
+
 - path: "/opt/bin/setup"
   permissions: "0755"
   content: |
@@ -57,6 +63,8 @@ write_files:
     set -xeuo pipefail
     if systemctl is-active ufw; then systemctl stop ufw; fi
     systemctl mask ufw
+    systemctl stop systemd-resolved
+    ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
     systemctl restart systemd-modules-load.service
     sysctl --system
     sed -i.orig '/.*swap.*/d' /etc/fstab

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -54,6 +54,7 @@ write_files:
   content: |
     # Updated by kubermatic machine-controller
     # Disables systemd-resolved listener.
+    [Resolve]
     DNSStubListener=no
 
 - path: "/opt/bin/setup"


### PR DESCRIPTION
**What this PR does / why we need it**:

This Pull Request disables `systemd-resolved` stub server from running on a Ubuntu node. The stub server running on nodes blocks `node-local-dns` to be started with a forwarder configuration.

### Current behaviour:
```yaml
# dns-config.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: coredns-extra-configs
  namespace: kube-system
data:
  Corefile: |
    example.com {
      forward . 10.11.10.54 10.11.10.40
    }
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: node-local-dns-extra-configs
  namespace: kube-system
data:
  Corefile: |
    example.com {
      forward . 10.11.10.54:53 10.11.10.40:53
    }
```

```bash
kubectl apply -f dns-config.yaml
kubectl rollout restart dameonset node-local-dns -n kube-system
```
```bash
kubectl get po -n kube-system -l app.kubernetes.io/name=node-local-dns
```
Output:
```
NAME                   READY   STATUS             RESTARTS   AGE
node-local-dns-7lg9m   0/1     Error              0          6m9s
node-local-dns-mj7bp   0/1     Error              0          6m3s
```

```bash
kubectl logs -n kube-system node-local-dns-7lg9m
```

Output: 
```
2021/07/16 15:48:24 [INFO] Starting node-cache image: 1.17.0
2021/07/16 15:48:24 [INFO] Using Corefile /etc/coredns/Corefile
2021/07/16 15:48:25 [ERROR] Failed to read node-cache coreFile /etc/coredns/Corefile.base - open /etc/coredns/Corefile.base: no such file or directory
2021/07/16 15:48:25 [INFO] Skipping kube-dns configmap sync as no directory was specified
Listen: listen tcp :53: bind: address already in use
```
### Expected behavior
Node-local-dns dameonset pods running with the forwarder configuration.
 
**Special notes for your reviewer**:
### How to Review:
1 - Check if systemd-resolved stub server is running on machine:
```
lsof -i :53 | grep systemd
```
2 - Create an **Ubuntu** machine deployment using this version of the machine-controller and check if machine join k8s cluster.
3- Check if  the stub-server is **not** running (the command shown above should return nothing, but a pure `lsof -i :53` show show the node-local-dns-cache)
4 - Reboot the machine and check again.
5 - Restart node-local-dns with pods running after applying forwarder extra configuration. Pods should be running.

```release-note
Disable systemd-resolved DNS cache to allow node-localdns-cache to run without conflicts.
```