### PR TITLE
Cluster-id addition in vsphere cloud-config api

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -546,6 +546,7 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 			Password:     c.Password,
 			InsecureFlag: c.AllowInsecure,
 			VCenterPort:  u.Port(),
+			ClusterID:    c.Cluster,
 		},
 		Disk: vspheretypes.DiskOpts{
 			SCSIControllerType: "pvscsi",

--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -78,6 +78,7 @@ type GlobalOpts struct {
 	Datacenter       string `gcfg:"datacenter"`
 	DefaultDatastore string `gcfg:"datastore"`
 	VCenterIP        string `gcfg:"server"`
+	ClusterID        string `gcfg:"cluster-id"`
 }
 
 type VirtualCenterConfig struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
The external CSI controller requires cluster-id to be set to correctly provision volumes in vSphere. This PR aims at solving this issue, adding such field in the vSphere cloud-config API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
