### PR TITLE
prevent AWS metrics from growing over time

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -923,6 +923,8 @@ func setProviderSpec(rawConfig awstypes.RawConfig, s v1alpha1.ProviderSpec) (*ru
 }
 
 func (p *provider) SetMetricsForMachines(machines v1alpha1.MachineList) error {
+	metricInstancesForMachines.Reset()
+
 	if len(machines.Items) < 1 {
 		return nil
 	}
@@ -948,7 +950,6 @@ func (p *provider) SetMetricsForMachines(machines v1alpha1.MachineList) error {
 			secretAccessKey: config.SecretAccessKey,
 			region:          config.Region,
 		}
-
 	}
 
 	allReservations := []*ec2.Reservation{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Without resetting the metric, old label values will never get cleaned up, so the number of metrics will just grow without bounds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix machine_controller_aws_instances_for_machine metric growing with new machines, but never forgetting old, deleted machines.
```
