### PR TITLE
cluster-id addition in cloudConfig template

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -36,6 +36,7 @@ working-dir       = {{ .Global.WorkingDir | iniEscape }}
 datacenter        = {{ .Global.Datacenter | iniEscape }}
 datastore         = {{ .Global.DefaultDatastore | iniEscape }}
 server            = {{ .Global.VCenterIP | iniEscape }}
+cluster-id        = {{ .Global.ClusterID | iniEscape }}
 
 [Disk]
 scsicontrollertype = {{ .Disk.SCSIControllerType | iniEscape }}

--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -36,7 +36,6 @@ working-dir       = {{ .Global.WorkingDir | iniEscape }}
 datacenter        = {{ .Global.Datacenter | iniEscape }}
 datastore         = {{ .Global.DefaultDatastore | iniEscape }}
 server            = {{ .Global.VCenterIP | iniEscape }}
-cluster-id        = {{ .Global.ClusterID | iniEscape }}
 
 [Disk]
 scsicontrollertype = {{ .Disk.SCSIControllerType | iniEscape }}

--- a/pkg/cloudprovider/provider/vsphere/types/testdata/2-virtual-centers.golden
+++ b/pkg/cloudprovider/provider/vsphere/types/testdata/2-virtual-centers.golden
@@ -7,6 +7,7 @@ working-dir       = ""
 datacenter        = ""
 datastore         = ""
 server            = ""
+cluster-id        = ""
 
 [Disk]
 scsicontrollertype = "pvscsi"

--- a/pkg/cloudprovider/provider/vsphere/types/testdata/simple-config.golden
+++ b/pkg/cloudprovider/provider/vsphere/types/testdata/simple-config.golden
@@ -7,6 +7,7 @@ working-dir       = ""
 datacenter        = ""
 datastore         = ""
 server            = ""
+cluster-id        = ""
 
 [Disk]
 scsicontrollertype = "pvscsi"

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
@@ -31,7 +31,6 @@ spec:
             folder: '/dc-1/vm/e2e-tests'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            cluster: '<< VSPHERE_CLUSTER >>'
             datastoreCluster: 'dsc-1'
             cpus: 2
             MemoryMB: 2048

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
@@ -31,7 +31,6 @@ spec:
             folder: '/dc-1/vm/e2e-tests'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            cluster: '<< VSPHERE_CLUSTER >>'
             datastoreCluster: 'dsc-1'
             resourcePool: 'e2e-resource-pool'
             cpus: 2

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -31,7 +31,7 @@ spec:
             folder: '/Customer-A/vm/e2e-tests'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            cluster: '<< VSPHERE_CLUSTER >>'
+            cluster: 'cl-1'
             datastore: datastore1
             allowInsecure: true
             cpus: 2

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -31,7 +31,7 @@ spec:
             folder: '/dc-1/vm/e2e-tests'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            cluster: '<< VSPHERE_CLUSTER >>'
+            cluster: 'cl-1'
             datastore: exsi-nas
             cpus: 2
             MemoryMB: 2048


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the cluster-id field in the cloud-config template. Such field is needed by the CSI driver to properly provision volumes. [here](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/ab99988ea60db9589af949a643661e24fdc20105/docs/book/driver-deployment/installation.md#vsphere-configuration-file-for-block-volumes-) it's possible to find a reference to the value, while [here](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/84d76319b05552d617ab0493836ae92b861663f1/pkg/common/config/types.go#L27) there is the Config struct in the `vsphere-csi-driver` repo.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
