### PR TITLE
fix postsubmit for the new Docker images we use

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -852,11 +852,11 @@ postsubmits:
           command:
             - /bin/bash
             - -c
-            - >-
-              set -euo pipefail &&
-              /usr/local/bin/entrypoint.sh &&
-              docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD &&
-              docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io &&
+            - |
+              set -euo pipefail
+              start-docker.sh
+              docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
+              docker login -u $QUAY_IO_USERNAME -p $QUAY_IO_PASSWORD quay.io
               make download-gocache docker-image-publish
           # docker-in-docker needs privileged mode
           securityContext:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.15.1
+ARG GO_VERSION=1.17.1
 FROM golang:${GO_VERSION} AS builder
 WORKDIR /go/src/github.com/kubermatic/machine-controller
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
The old images had the confusing entrypoint that needed to be run manually, which has since been fixed to just provide a clear `start-docker.sh` that containers run whenever they need to.

**Optional Release Note**:
```release-note
NONE
```
