### PR TITLE
use a directory to make gocache separation easier to deal with

### DIFF
--- a/hack/ci-download-gocache.sh
+++ b/hack/ci-download-gocache.sh
@@ -55,8 +55,8 @@ if [ -z "${PULL_NUMBER:-}" ]; then
   CACHE_VERSION="$(git rev-parse ${CACHE_VERSION}~1)"
 fi
 
-ARCHIVE_NAME="machine-controller-${CACHE_VERSION}-${GO_VERSION}.tar"
-URL="${GOCACHE_MINIO_ADDRESS}/${ARCHIVE_NAME}"
+ARCHIVE_NAME="${CACHE_VERSION}-${GO_VERSION}.tar"
+URL="${GOCACHE_MINIO_ADDRESS}/machine-controller/${ARCHIVE_NAME}"
 
 # Do not go through the retry loop when there is nothing
 if ! curl --head --silent --fail "${URL}" > /dev/null; then

--- a/hack/ci-upload-gocache.sh
+++ b/hack/ci-upload-gocache.sh
@@ -53,6 +53,6 @@ curl \
   --fail \
   --upload-file "${ARCHIVE_FILE}" \
   --header "Content-Type: application/octet-stream" \
-  "${GOCACHE_MINIO_ADDRESS}/machine-controller-${GIT_HEAD_HASH}-${GO_VERSION}.tar"
+  "${GOCACHE_MINIO_ADDRESS}/machine-controller/${GIT_HEAD_HASH}-${GO_VERSION}.tar"
 
 echo "Upload complete."

--- a/hack/ci-upload-gocache.sh
+++ b/hack/ci-upload-gocache.sh
@@ -35,6 +35,13 @@ GOCACHE_DIR="$(mktemp -d)"
 export GOCACHE="${GOCACHE_DIR}"
 export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
 
+# PULL_BASE_REF is the name of the current branch in case of a post-submit
+# or the name of the base branch in case of a PR.
+GIT_BRANCH="${PULL_BASE_REF:-master}"
+
+# normalize branch name to prevent accidental directories being created
+GIT_BRANCH="$(echo "$GIT_BRANCH" | sed 's#/#-#g')"
+
 echo "Creating cache for revision ${GIT_HEAD_HASH} / Go ${GO_VERSION} ..."
 
 echo "Building binaries"
@@ -53,6 +60,6 @@ curl \
   --fail \
   --upload-file "${ARCHIVE_FILE}" \
   --header "Content-Type: application/octet-stream" \
-  "${GOCACHE_MINIO_ADDRESS}/machine-controller/${GIT_HEAD_HASH}-${GO_VERSION}.tar"
+  "${GOCACHE_MINIO_ADDRESS}/machine-controller/${GIT_BRANCH}/${GIT_HEAD_HASH}-${GO_VERSION}.tar"
 
 echo "Upload complete."


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the sister PR to https://github.com/kubermatic/kubermatic/pull/7780

**Optional Release Note**:
```release-note
NONE
```
