### PR TITLE
Add Conditions for Anexia Provider

### DIFF
--- a/pkg/cloudprovider/provider/anexia/helper_test.go
+++ b/pkg/cloudprovider/provider/anexia/helper_test.go
@@ -1,0 +1,74 @@
+package anexia
+
+import (
+	"encoding/json"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/search"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"k8s.io/apimachinery/pkg/runtime"
+	"net/http"
+	"testing"
+)
+
+type ConfigTestCase struct {
+	Config anxtypes.RawConfig
+	Error  error
+}
+
+type ValidateCallTestCase struct {
+	Spec          v1alpha1.MachineSpec
+	ExpectedError error
+}
+
+func getSpecsForValidationTest(t *testing.T, configCases []ConfigTestCase) []ValidateCallTestCase {
+
+	var testCases []ValidateCallTestCase
+
+	for _, configCase := range configCases {
+		jsonConfig, err := json.Marshal(configCase.Config)
+		testhelper.AssertNoErr(t, err)
+		jsonProviderConfig, err := json.Marshal(types.Config{
+			CloudProviderSpec:   runtime.RawExtension{Raw: jsonConfig},
+			OperatingSystemSpec: runtime.RawExtension{Raw: []byte("{}")},
+		})
+		testhelper.AssertNoErr(t, err)
+		testCases = append(testCases, ValidateCallTestCase{
+			Spec: v1alpha1.MachineSpec{
+				ProviderSpec: v1alpha1.ProviderSpec{
+					Value: &runtime.RawExtension{Raw: jsonProviderConfig},
+				},
+			},
+			ExpectedError: configCase.Error,
+		})
+	}
+	return testCases
+}
+
+func createSearchHandler(t *testing.T, iterations int) http.HandlerFunc {
+	counter := 0
+	return func(writer http.ResponseWriter, request *http.Request) {
+		test := request.URL.Query().Get("name")
+		testhelper.AssertEquals(t, "%-TestMachine", test)
+		testhelper.TestMethod(t, request, http.MethodGet)
+		if iterations == counter {
+			encoder := json.NewEncoder(writer)
+			testhelper.AssertNoErr(t, encoder.Encode(map[string]interface{}{
+				"data": []search.VM{
+					{
+						Name:       "543053-TestMachine",
+						Identifier: TestIdentifier,
+					},
+				},
+			}))
+		}
+		counter++
+	}
+}
+
+func newConfigVarString(str string) types.ConfigVarString {
+	return types.ConfigVarString{
+		Value: str,
+	}
+}

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -1,0 +1,289 @@
+package anexia
+
+import (
+	"encoding/json"
+	"errors"
+	anxclient "github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/anexia-it/go-anxcloud/pkg/ipam/address"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/progress"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/vm"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/utils"
+	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const TestIdentifier = "TestIdent"
+
+func TestAnexiaProvider(t *testing.T) {
+	testhelper.SetupHTTP()
+	client, server := anxclient.NewTestClient(nil, testhelper.Mux)
+	t.Cleanup(func() {
+		testhelper.TeardownHTTP()
+		server.Close()
+	})
+
+	t.Run("Test waiting for VM", func(t *testing.T) {
+		t.Parallel()
+
+		waitUntilVMIsFound := 2
+		testhelper.Mux.HandleFunc("/api/vsphere/v1/search/by_name.json", createSearchHandler(t, waitUntilVMIsFound))
+
+		providerStatus := anxtypes.ProviderStatus{}
+		ctx := utils.CreateReconcileContext(utils.ReconcileContext{
+			Machine: &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
+			},
+			Status:   &providerStatus,
+			UserData: "",
+			Config:   &anxtypes.Config{},
+
+			ProviderData: &cloudprovidertypes.ProviderData{},
+		})
+
+		err := waitForVM(ctx, client)
+		if err != nil {
+			t.Fatal("No error was expected", err)
+
+		}
+
+		if providerStatus.InstanceID != TestIdentifier {
+			t.Errorf("Excpected InstanceID to be set")
+		}
+	})
+
+	t.Run("Test provision VM", func(t *testing.T) {
+		t.Parallel()
+		testhelper.Mux.HandleFunc("/api/ipam/v1/address/reserve/ip/count.json", func(writer http.ResponseWriter, request *http.Request) {
+			err := json.NewEncoder(writer).Encode(address.ReserveRandomSummary{
+				Data: []address.ReservedIP{
+					{
+						ID:      "IP-ID",
+						Address: "8.8.8.8",
+					},
+				},
+			})
+			testhelper.AssertNoErr(t, err)
+		})
+
+		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/vm.json/LOCATION-ID/templates/TEMPLATE-ID", func(writer http.ResponseWriter, request *http.Request) {
+			testhelper.TestMethod(t, request, http.MethodPost)
+			type jsonObject = map[string]interface{}
+			expectedJSON := map[string]interface{}{
+				"cpu_performance_type": "performance",
+				"hostname":             "TestMachine",
+				"memory_mb":            json.Number("5"),
+				"network": []jsonObject{
+					{
+						"vlan":     "VLAN-ID",
+						"nic_type": "vmxnet3",
+						"ips":      []interface{}{"8.8.8.8"},
+					},
+				},
+			}
+			var jsonBody jsonObject
+			decoder := json.NewDecoder(request.Body)
+			decoder.UseNumber()
+			testhelper.AssertNoErr(t, decoder.Decode(&jsonBody))
+			testhelper.AssertEquals(t, expectedJSON["cpu_performance_type"], jsonBody["cpu_performance_type"])
+			testhelper.AssertEquals(t, expectedJSON["hostname"], jsonBody["hostname"])
+			testhelper.AssertEquals(t, expectedJSON["memory_mb"], jsonBody["memory_mb"])
+			testhelper.AssertEquals(t, expectedJSON["count"], jsonBody["count"])
+
+			expectedNetwork := expectedJSON["network"].([]jsonObject)[0]
+			bodyNetwork := jsonBody["network"].([]interface{})[0].(jsonObject)
+			testhelper.AssertEquals(t, expectedNetwork["vlan"], bodyNetwork["vlan"])
+			testhelper.AssertEquals(t, expectedNetwork["nic_type"], bodyNetwork["nic_type"])
+			testhelper.AssertEquals(t, expectedNetwork["ips"].([]interface{})[0], bodyNetwork["ips"].([]interface{})[0])
+
+			err := json.NewEncoder(writer).Encode(vm.ProvisioningResponse{
+				Progress:   100,
+				Errors:     nil,
+				Identifier: "TEST-IDENTIFIER",
+				Queued:     false,
+			})
+			testhelper.AssertNoErr(t, err)
+		})
+
+		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/progress.json/TEST-IDENTIFIER", func(writer http.ResponseWriter, request *http.Request) {
+			testhelper.TestMethod(t, request, http.MethodGet)
+
+			err := json.NewEncoder(writer).Encode(progress.Progress{
+				TaskIdentifier: "TEST-IDENTIFIER",
+				Queued:         false,
+				Progress:       100,
+				VMIdentifier:   "VM-IDENTIFIER",
+				Errors:         nil,
+			})
+			testhelper.AssertNoErr(t, err)
+		})
+
+		providerStatus := anxtypes.ProviderStatus{}
+		ctx := utils.CreateReconcileContext(utils.ReconcileContext{
+			Machine: &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
+			},
+			Status:   &providerStatus,
+			UserData: "",
+			Config: &anxtypes.Config{
+				VlanID:     "VLAN-ID",
+				LocationID: "LOCATION-ID",
+				TemplateID: "TEMPLATE-ID",
+				CPUs:       5,
+				Memory:     5,
+				DiskSize:   5,
+			},
+			ProviderData: &cloudprovidertypes.ProviderData{},
+		})
+
+		err := provisionVM(ctx, client)
+		testhelper.AssertNoErr(t, err)
+	})
+
+	t.Run("Test is VM Provisioning", func(t *testing.T) {
+		t.Parallel()
+		providerStatus := anxtypes.ProviderStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   ProvisionedType,
+					Reason: "InProvisioning",
+					Status: metav1.ConditionFalse,
+				},
+			},
+		}
+		ctx := utils.CreateReconcileContext(utils.ReconcileContext{
+			Status:       &providerStatus,
+			UserData:     "",
+			Config:       nil,
+			ProviderData: nil,
+		})
+
+		condition := meta.FindStatusCondition(providerStatus.Conditions, ProvisionedType)
+		condition.LastTransitionTime = metav1.Time{Time: time.Now().Add(-1 * time.Minute)}
+		testhelper.AssertEquals(t, true, isAlreadyProvisioning(ctx))
+
+		condition.Reason = "Provisioned"
+		condition.Status = metav1.ConditionTrue
+		testhelper.AssertEquals(t, false, isAlreadyProvisioning(ctx))
+
+		condition.Reason = "InProvisioning"
+		condition.Status = metav1.ConditionFalse
+		condition.LastTransitionTime = metav1.Time{Time: time.Now().Add(-10 * time.Minute)}
+		testhelper.AssertEquals(t, false, isAlreadyProvisioning(ctx))
+		testhelper.AssertEquals(t, condition.Reason, "ReInitialising")
+	})
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	var configCases []ConfigTestCase
+	configCases = append(configCases,
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{},
+			Error:  errors.New("token is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN")},
+			Error:  errors.New("cpu count is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1},
+			Error:  errors.New("disk size is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5},
+			Error:  errors.New("memory size is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5},
+			Error:  errors.New("location id is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5,
+				LocationID: newConfigVarString("TLID")},
+			Error: errors.New("template id is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5,
+				LocationID: newConfigVarString("LID"), TemplateID: newConfigVarString("TID")},
+			Error: errors.New("vlan id is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5,
+				LocationID: newConfigVarString("LID"), TemplateID: newConfigVarString("TID"), VlanID: newConfigVarString("VLAN")},
+			Error: nil,
+		},
+	)
+
+	provider := New(nil)
+	for _, testCase := range getSpecsForValidationTest(t, configCases) {
+		err := provider.Validate(testCase.Spec)
+		if testCase.ExpectedError != nil {
+			testhelper.AssertEquals(t, testCase.ExpectedError.Error(), err.Error())
+		} else {
+			testhelper.AssertEquals(t, testCase.ExpectedError, err)
+		}
+	}
+}
+
+func TestEnsureConditions(t *testing.T) {
+	t.Parallel()
+	status := anxtypes.ProviderStatus{}
+
+	ensureConditions(&status)
+
+	condition := meta.FindStatusCondition(status.Conditions, ProvisionedType)
+	if condition == nil {
+		t.Fatal("condition should not be nil")
+	}
+	testhelper.AssertEquals(t, metav1.ConditionUnknown, condition.Status)
+	testhelper.AssertEquals(t, "Initialising", condition.Reason)
+}
+
+func TestGetProviderStatus(t *testing.T) {
+	t.Parallel()
+
+	machine := &v1alpha1.Machine{}
+	providerStatus := anxtypes.ProviderStatus{
+		InstanceID: "InstanceID",
+	}
+	providerStatusJSON, err := json.Marshal(providerStatus)
+	testhelper.AssertNoErr(t, err)
+	machine.Status.ProviderStatus = &runtime.RawExtension{Raw: providerStatusJSON}
+
+	returnedStatus := getProviderStatus(machine)
+
+	testhelper.AssertEquals(t, "InstanceID", returnedStatus.InstanceID)
+
+}
+
+func TestUpdateStatus(t *testing.T) {
+	t.Parallel()
+	machine := &v1alpha1.Machine{}
+	providerStatus := anxtypes.ProviderStatus{
+		InstanceID: "InstanceID",
+	}
+	providerStatusJSON, err := json.Marshal(providerStatus)
+	testhelper.AssertNoErr(t, err)
+	machine.Status.ProviderStatus = &runtime.RawExtension{Raw: providerStatusJSON}
+
+	called := false
+	err = updateMachineStatus(machine, providerStatus, func(paramMachine *v1alpha1.Machine, modifier ...cloudprovidertypes.MachineModifier) error {
+		called = true
+		testhelper.AssertEquals(t, machine, paramMachine)
+		status := getProviderStatus(machine)
+		testhelper.AssertEquals(t, status.InstanceID, providerStatus.InstanceID)
+		return nil
+	})
+
+	testhelper.AssertEquals(t, true, called)
+	testhelper.AssertNoErr(t, err)
+}

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -179,6 +179,24 @@ func TestAnexiaProvider(t *testing.T) {
 		testhelper.AssertEquals(t, false, isAlreadyProvisioning(ctx))
 		testhelper.AssertEquals(t, condition.Reason, "ReInitialising")
 	})
+
+	t.Run("Test getIPAddress", func(t *testing.T) {
+		t.Parallel()
+		providerStatus := &anxtypes.ProviderStatus{
+			ReservedIP: "",
+			IPState: "",
+		}
+		ctx := utils.CreateReconcileContext(utils.ReconcileContext{Status: providerStatus})
+
+		t.Run("with unbound reserved IP", func(t *testing.T) {
+			expectedIP := "8.8.8.8"
+			providerStatus.ReservedIP = expectedIP
+			providerStatus.IPState = anxtypes.IPStateUnbound
+			reservedIP, err := getIPAddress(ctx, client)
+			testhelper.AssertNoErr(t, err)
+			testhelper.AssertEquals(t, expectedIP, reservedIP)
+		})
+	})
 }
 
 func TestValidate(t *testing.T) {

--- a/pkg/cloudprovider/provider/anexia/types/errors.go
+++ b/pkg/cloudprovider/provider/anexia/types/errors.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MultiError represent multiple errors at the same time.
+type MultiError []error
+
+func (r MultiError) Error() string {
+	errString := make([]string, len(r))
+	for i, err := range r {
+		errString[i] = fmt.Sprintf("Error %d: %s", i, err)
+	}
+	return fmt.Sprintf("Multiple errors occoured:\n%s", strings.Join(errString, "\n"))
+}
+
+func NewMultiError(errs ...error) error {
+	var combinedErr []error
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		combinedErr = append(combinedErr, err)
+	}
+
+	if len(combinedErr) > 0 {
+		return MultiError(combinedErr)
+	}
+
+	return nil
+}

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -32,6 +32,9 @@ const (
 	GetRequestTimeout    = 1 * time.Minute
 	DeleteRequestTimeout = 1 * time.Minute
 
+	IPStateBound    = "Bound"
+	IPStateUnbound  = "Unbound"
+
 	VmxNet3NIC       = "vmxnet3"
 	MachinePoweredOn = "poweredOn"
 )
@@ -54,6 +57,8 @@ type RawConfig struct {
 type ProviderStatus struct {
 	InstanceID     string         `json:"instanceID"`
 	ProvisioningID string         `json:"provisioningID"`
+	ReservedIP     string         `json:"reservedIP"`
+	IPState        string         `json:"ipState"`
 	Conditions     []v1.Condition `json:"conditions,omitempty"`
 }
 

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package types
 
 import (
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
+	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -33,6 +36,11 @@ const (
 	MachinePoweredOn = "poweredOn"
 )
 
+var StatusUpdateFailed = cloudprovidererrors.TerminalError{
+	Reason:  common.UpdateMachineError,
+	Message: "Unable to update the machine status",
+}
+
 type RawConfig struct {
 	Token      providerconfigtypes.ConfigVarString `json:"token,omitempty"`
 	VlanID     providerconfigtypes.ConfigVarString `json:"vlanID"`
@@ -44,7 +52,17 @@ type RawConfig struct {
 }
 
 type ProviderStatus struct {
-	InstanceID     string `json:"instanceID"`
-	ProvisioningID string `json:"provisioningID"`
-	// TODO: add conditions to track progress on the provider side
+	InstanceID     string         `json:"instanceID"`
+	ProvisioningID string         `json:"provisioningID"`
+	Conditions     []v1.Condition `json:"conditions,omitempty"`
+}
+
+type Config struct {
+	Token      string
+	VlanID     string
+	LocationID string
+	TemplateID string
+	CPUs       int
+	Memory     int
+	DiskSize   int
 }

--- a/pkg/cloudprovider/provider/anexia/utils/utils.go
+++ b/pkg/cloudprovider/provider/anexia/utils/utils.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"context"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
+	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+)
+
+type contextKey byte
+
+const MachineReconcileContextKey contextKey = 0
+
+type ReconcileContext struct {
+	Machine      *v1alpha1.Machine
+	Status       *anxtypes.ProviderStatus
+	UserData     string
+	Config       *anxtypes.Config
+	ProviderData *cloudprovidertypes.ProviderData
+}
+
+func CreateReconcileContext(cc ReconcileContext) context.Context {
+	return context.WithValue(context.Background(), MachineReconcileContextKey, cc)
+}
+
+func GetReconcileContext(ctx context.Context) ReconcileContext {
+	rawContext := ctx.Value(MachineReconcileContextKey)
+	if recContext, ok := rawContext.(ReconcileContext); ok {
+		return recContext
+	}
+	return ReconcileContext{}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometime the Anexia API returns an error and no Progress Identifier, even though an VM is being provisioned.
Now an ongoing provisioning is being remebered inside the provider status by the newly added conditions.
If the status states that there already is a VM provisioning ongoing we wait for a VM with the corresponding name to appear. 

Also added some tests for the anexia provider


```release-note
Add Conditions to Anexia Provider Status, which allows to detect potentially ongoing provisionings 
```
