### PR TITLE
Upgrade default ubuntu version to 20.04 LTS

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -649,7 +649,7 @@ presubmits:
           command:
             - "./hack/ci-e2e-test.sh"
           args:
-            - "TestAWSProvisioningE2EWithEbsEncryptionEnabled"
+            - "TestAWSEbsEncryptionEnabledProvisioningE2E"
           resources:
             requests:
               memory: 1Gi

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -44,7 +44,7 @@ import (
 const (
 	machineUIDTag   = "machine_uid"
 	centosImageName = "CentOS  7.7 64 bit"
-	ubuntuImageName = "Ubuntu  18.04 64 bit"
+	ubuntuImageName = "Ubuntu  20.04 64 bit"
 
 	finalizerInstance = "kubermatic.io/cleanup-alibaba-instance"
 )

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -109,7 +109,7 @@ var (
 		},
 		providerconfigtypes.OperatingSystemUbuntu: {
 			// Be as precise as possible - otherwise we might get a nightly dev build
-			description: "Canonical, Ubuntu, 18.04 LTS, amd64 bionic image build on ????-??-??",
+			description: "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on ????-??-??",
 			// The AWS marketplace ID from Canonical
 			owner: "099720109477",
 		},

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -126,12 +126,9 @@ var imageReferences = map[providerconfigtypes.OperatingSystem]compute.ImageRefer
 	},
 	providerconfigtypes.OperatingSystemUbuntu: {
 		Publisher: to.StringPtr("Canonical"),
-		Offer:     to.StringPtr("UbuntuServer"),
-		// FIXME We'd like to use Ubuntu 18.04 eventually, but the docker's release
-		// deb repo for `bionic` is empty, and we use `$RELEASE` in userdata.
-		// Either Docker needs to fix their repo, or we need to hardcode `xenial`.
-		Sku:     to.StringPtr("18.04-LTS"),
-		Version: to.StringPtr("latest"),
+		Offer:     to.StringPtr("0001-com-ubuntu-server-focal"),
+		Sku:       to.StringPtr("20_04-lts"),
+		Version:   to.StringPtr("latest"),
 	},
 	providerconfigtypes.OperatingSystemRHEL: {
 		Publisher: to.StringPtr("RedHat"),

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -85,7 +85,7 @@ func (t *TokenSource) Token() (*oauth2.Token, error) {
 func getSlugForOS(os providerconfigtypes.OperatingSystem) (string, error) {
 	switch os {
 	case providerconfigtypes.OperatingSystemUbuntu:
-		return "ubuntu-18-04-x64", nil
+		return "ubuntu-20-04-x64", nil
 	case providerconfigtypes.OperatingSystemCentOS:
 		return "centos-7-x64", nil
 	}

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -48,7 +48,7 @@ var imageProjects = map[providerconfigtypes.OperatingSystem]string{
 
 // imageFamilies maps the OS to the Google Cloud image projects
 var imageFamilies = map[providerconfigtypes.OperatingSystem]string{
-	providerconfigtypes.OperatingSystemUbuntu: "ubuntu-1804-lts",
+	providerconfigtypes.OperatingSystemUbuntu: "ubuntu-2004-lts",
 }
 
 // diskTypes are the disk types of the Google Cloud. Map is used for

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -68,7 +68,7 @@ type Config struct {
 func getNameForOS(os providerconfigtypes.OperatingSystem) (string, error) {
 	switch os {
 	case providerconfigtypes.OperatingSystemUbuntu:
-		return "ubuntu-18.04", nil
+		return "ubuntu-20.04", nil
 	case providerconfigtypes.OperatingSystemCentOS:
 		return "centos-7", nil
 	}

--- a/pkg/cloudprovider/provider/packet/provider.go
+++ b/pkg/cloudprovider/provider/packet/provider.go
@@ -428,7 +428,7 @@ func getDeviceByTag(client *packngo.Client, projectID, tag string) (*packngo.Dev
 func getNameForOS(os providerconfigtypes.OperatingSystem) (string, error) {
 	switch os {
 	case providerconfigtypes.OperatingSystemUbuntu:
-		return "ubuntu_18_04", nil
+		return "ubuntu_20_04", nil
 	case providerconfigtypes.OperatingSystemCentOS:
 		return "centos_7", nil
 	case providerconfigtypes.OperatingSystemFlatcar:

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -540,8 +540,8 @@ func TestAWSEbsEncryptionEnabledProvisioningE2E(t *testing.T) {
 	scenario := scenario{
 		name:              "AWS with ebs encryption enabled",
 		osName:            "ubuntu",
-		containerRuntime:  "docker",
-		kubernetesVersion: "v1.15.6",
+		containerRuntime:  "containerd",
+		kubernetesVersion: "v1.20.1",
 		executor:          verifyCreateAndDelete,
 	}
 	testScenario(t, scenario, fmt.Sprintf("aws-%s", *testRunIdentifier), params, AWSEBSEncryptedManifest, false)
@@ -685,7 +685,7 @@ func TestPacketProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, PACKET_PROJECT_ID environment variable cannot be empty")
 	}
 
-	selector := Not(OsSelector("sles", "rhel"))
+	selector := Not(OsSelector("sles", "rhel", "amzn2"))
 
 	// act
 	params := []string{
@@ -892,7 +892,7 @@ func TestDeploymentControllerUpgradesMachineE2E(t *testing.T) {
 	scenario := scenario{
 		name:              "MachineDeployment upgrade",
 		osName:            "ubuntu",
-		containerRuntime:  "docker",
+		containerRuntime:  "containerd",
 		kubernetesVersion: "1.16.2",
 		executor:          verifyCreateUpdateAndDelete,
 	}

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -520,9 +520,9 @@ func TestAWSCentOS8ProvisioningE2E(t *testing.T) {
 	runScenarios(t, selector, params, AWSManifest, fmt.Sprintf("aws-%s", *testRunIdentifier))
 }
 
-// TestAWSProvisioningE2EWithEbsEncryptionEnabled - a test suite that exercises AWS provider with ebs encryption enabled
+// TestAWSEbsEncryptionEnabledProvisioningE2E - a test suite that exercises AWS provider with ebs encryption enabled
 // by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
-func TestAWSProvisioningE2EWithEbsEncryptionEnabled(t *testing.T) {
+func TestAWSEbsEncryptionEnabledProvisioningE2E(t *testing.T) {
 	t.Parallel()
 
 	// test data

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -892,8 +892,8 @@ func TestDeploymentControllerUpgradesMachineE2E(t *testing.T) {
 	scenario := scenario{
 		name:              "MachineDeployment upgrade",
 		osName:            "ubuntu",
-		containerRuntime:  "containerd",
-		kubernetesVersion: "1.16.2",
+		containerRuntime:  "docker",
+		kubernetesVersion: "1.19.1",
 		executor:          verifyCreateUpdateAndDelete,
 	}
 	testScenario(t, scenario, *testRunIdentifier, params, HZManifest, false)

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -49,7 +49,7 @@ var (
 	}
 
 	openStackImages = map[string]string{
-		string(providerconfigtypes.OperatingSystemUbuntu):  "machine-controller-e2e-ubuntu",
+		string(providerconfigtypes.OperatingSystemUbuntu):  "Ubuntu Focal 20.04 (2021-09-30)",
 		string(providerconfigtypes.OperatingSystemCentOS):  "machine-controller-e2e-centos",
 		string(providerconfigtypes.OperatingSystemRHEL):    "machine-controller-e2e-rhel",
 		string(providerconfigtypes.OperatingSystemFlatcar): "machine-controller-e2e-flatcar",

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -49,7 +49,7 @@ var (
 	}
 
 	openStackImages = map[string]string{
-		string(providerconfigtypes.OperatingSystemUbuntu):  "Ubuntu Focal 20.04 (2021-09-30)",
+		string(providerconfigtypes.OperatingSystemUbuntu):  "machine-controller-e2e-ubuntu-20-04",
 		string(providerconfigtypes.OperatingSystemCentOS):  "machine-controller-e2e-centos",
 		string(providerconfigtypes.OperatingSystemRHEL):    "machine-controller-e2e-rhel",
 		string(providerconfigtypes.OperatingSystemFlatcar): "machine-controller-e2e-flatcar",


### PR DESCRIPTION
**What this PR does / why we need it**:
So far the default Ubuntu version that we use to deploy Ubuntu OS is 18.04 LTS. This PR upgrade the default ubuntu image from 18.04 to 20.04. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
At the moment vSphere is blocked by the absence of vcenter.
**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade default ubuntu version to 20.04
```
