### PR TITLE
Consider CPU arch when selecting default AMIs in AWS

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -103,10 +103,16 @@ var (
 				owner:       "679593333241",
 				productCode: "aw0evgkw8e5c1q413zgy5pjce",
 			},
+			// 2021-10-14 - No CentOS 7 ARM64 image available under legacy product code
 		},
 		providerconfigtypes.OperatingSystemAmazonLinux2: {
 			awstypes.CPUArchitectureX86_64: {
 				description: "Amazon Linux 2 AMI * x86_64 HVM gp2",
+				// The AWS marketplace ID from Amazon
+				owner: "137112412989",
+			},
+			awstypes.CPUArchitectureARM64: {
+				description: "Amazon Linux 2 LTS Arm64 AMI * arm64 HVM gp2",
 				// The AWS marketplace ID from Amazon
 				owner: "137112412989",
 			},
@@ -118,9 +124,21 @@ var (
 				// The AWS marketplace ID from Canonical
 				owner: "099720109477",
 			},
+			awstypes.CPUArchitectureARM64: {
+				// Be as precise as possible - otherwise we might get a nightly dev build
+				description: "Canonical, Ubuntu, 20.04 LTS, arm64 focal image build on ????-??-??",
+				// The AWS marketplace ID from Canonical
+				owner: "099720109477",
+			},
 		},
 		providerconfigtypes.OperatingSystemSLES: {
 			awstypes.CPUArchitectureX86_64: {
+				// Be as precise as possible - otherwise we might get a nightly dev build
+				description: "SUSE Linux Enterprise Server 15 SP1 (HVM, 64-bit, SSD-Backed)",
+				// The AWS marketplace ID from SLES
+				owner: "013907871322",
+			},
+			awstypes.CPUArchitectureARM64: {
 				// Be as precise as possible - otherwise we might get a nightly dev build
 				description: "SUSE Linux Enterprise Server 15 SP1 (HVM, 64-bit, SSD-Backed)",
 				// The AWS marketplace ID from SLES
@@ -134,6 +152,12 @@ var (
 				// The AWS marketplace ID from RedHat
 				owner: "309956199498",
 			},
+			awstypes.CPUArchitectureARM64: {
+				// Be as precise as possible - otherwise we might get a nightly dev build
+				description: "Provided by Red Hat, Inc.",
+				// The AWS marketplace ID from RedHat
+				owner: "309956199498",
+			},
 		},
 		providerconfigtypes.OperatingSystemFlatcar: {
 			awstypes.CPUArchitectureX86_64: {
@@ -142,6 +166,7 @@ var (
 				// The AWS marketplace ID from AWS
 				owner: "075585003325",
 			},
+			// 2021-10-14 - Flatcar stable does not support ARM yet (only alpha channels supports it)
 		},
 	}
 

--- a/pkg/cloudprovider/provider/aws/types/types.go
+++ b/pkg/cloudprovider/provider/aws/types/types.go
@@ -48,3 +48,12 @@ type SpotInstanceConfig struct {
 	PersistentRequest    providerconfigtypes.ConfigVarBool   `json:"persistentRequest,omitempty"`
 	InterruptionBehavior providerconfigtypes.ConfigVarString `json:"interruptionBehavior,omitempty"`
 }
+
+// CPUArchitecture defines processor architectures returned by the AWS API
+type CPUArchitecture string
+
+const (
+	CPUArchitectureARM64  CPUArchitecture = "arm64"
+	CPUArchitectureX86_64 CPUArchitecture = "x86_64"
+	CPUArchitectureI386   CPUArchitecture = "i386"
+)


### PR DESCRIPTION
**What this PR does / why we need it**: The AWS provider implementation was not aware of the CPU architecture that is going to be deployed. In AWS, this is defined by the instance type. This adds the ability to read the CPU arch from the instance type before creating a new instance and apply different AMI filters based on CPU arch.

We need this because currently, selecting arm64 from the KKP UI and not defining a custom AMI results in a failed `MachineDeployment`, as machine-controller tries to deploy a x86_64 image.

Right now, Flatcar does not support arm64 in their stable branch, and the CentOS images we target don't have an arm64 equivalent either. Follow-up for that is #1069.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1054

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support default AMIs in AWS for arm64 instance types for Ubuntu, RHEL, SLES and Amazon Linux 2
```
