### PR TITLE
Allow-downgrades for dockerce and containerd

### DIFF
--- a/pkg/containerruntime/containerd.go
+++ b/pkg/containerruntime/containerd.go
@@ -144,7 +144,7 @@ Restart=always
 EnvironmentFile=-/etc/environment
 EOF
 
-apt-get install -y containerd.io={{ .ContainerdVersion }}*
+apt-get install -y --allow-downgrades containerd.io={{ .ContainerdVersion }}*
 apt-mark hold containerd.io
 
 systemctl daemon-reload

--- a/pkg/containerruntime/docker.go
+++ b/pkg/containerruntime/docker.go
@@ -151,7 +151,7 @@ Restart=always
 EnvironmentFile=-/etc/environment
 EOF
 
-apt-get install -y \
+apt-get install --allow-downgrades -y \
 {{- if .ContainerdVersion }}
     containerd.io={{ .ContainerdVersion }}* \
     docker-ce-cli=5:{{ .DockerVersion }}* \

--- a/pkg/userdata/ubuntu/testdata/containerd.yaml
+++ b/pkg/userdata/ubuntu/testdata/containerd.yaml
@@ -105,7 +105,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y containerd.io=1.4*
+    apt-get install -y --allow-downgrades containerd.io=1.4*
     apt-mark hold containerd.io
 
     systemctl daemon-reload

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -102,7 +102,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -100,7 +100,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -100,7 +100,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -102,7 +102,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -100,7 +100,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -100,7 +100,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/version-1.17.16.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.17.16.yaml
@@ -100,7 +100,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/version-1.18.14.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.18.14.yaml
@@ -100,7 +100,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/version-1.19.4.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.19.4.yaml
@@ -100,7 +100,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/version-1.20.1.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.20.1.yaml
@@ -100,7 +100,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -110,7 +110,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -110,7 +110,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -101,7 +101,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y \
+    apt-get install --allow-downgrades -y \
         containerd.io=1.4* \
         docker-ce-cli=5:19.03* \
         docker-ce=5:19.03*


### PR DESCRIPTION
**What this PR does / why we need it**:
If dockerce or/and containerd is/are already present on the machine, then the setup script will not install them and throw an error if the version installed is already higher than what we require, so I have added a --allow-downgrades flag to the installation script to downgrade them to the required version and complete the script execution without the error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1049 

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow-downgrades for docker-ce and containerd
```
