### PR TITLE
Disable nm-cloud-setup on rhel

### DIFF
--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -132,7 +132,6 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 const userDataTemplate = `#cloud-config
 bootcmd:
 - modprobe ip_tables
-
 {{ if ne .CloudProviderName "aws" }}
 hostname: {{ .MachineSpec.Name }}
 fqdn: {{ .MachineSpec.Name }}

--- a/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -1,4 +1,6 @@
 #cloud-config
+bootcmd:
+- modprobe ip_tables
 
 
 ssh_pwauth: no
@@ -413,6 +415,34 @@ write_files:
     WantedBy=multi-user.target
 
 
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
 rh_subscription:
     username: ""
     password: ""
@@ -420,3 +450,4 @@ rh_subscription:
 
 runcmd:
 - systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.17-aws.yaml
@@ -1,4 +1,6 @@
 #cloud-config
+bootcmd:
+- modprobe ip_tables
 
 
 ssh_pwauth: no
@@ -397,6 +399,34 @@ write_files:
     WantedBy=multi-user.target
 
 
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
 rh_subscription:
     username: ""
     password: ""
@@ -404,3 +434,4 @@ rh_subscription:
 
 runcmd:
 - systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.18-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.18-aws.yaml
@@ -1,4 +1,6 @@
 #cloud-config
+bootcmd:
+- modprobe ip_tables
 
 
 ssh_pwauth: no
@@ -397,6 +399,34 @@ write_files:
     WantedBy=multi-user.target
 
 
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
 rh_subscription:
     username: ""
     password: ""
@@ -404,3 +434,4 @@ rh_subscription:
 
 runcmd:
 - systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.19-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.19-aws.yaml
@@ -1,4 +1,6 @@
 #cloud-config
+bootcmd:
+- modprobe ip_tables
 
 
 ssh_pwauth: no
@@ -397,6 +399,34 @@ write_files:
     WantedBy=multi-user.target
 
 
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
 rh_subscription:
     username: ""
     password: ""
@@ -404,3 +434,4 @@ rh_subscription:
 
 runcmd:
 - systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-aws-external.yaml
@@ -1,4 +1,6 @@
 #cloud-config
+bootcmd:
+- modprobe ip_tables
 
 
 ssh_pwauth: no
@@ -396,6 +398,34 @@ write_files:
     WantedBy=multi-user.target
 
 
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
 rh_subscription:
     username: ""
     password: ""
@@ -403,3 +433,4 @@ rh_subscription:
 
 runcmd:
 - systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
@@ -1,4 +1,6 @@
 #cloud-config
+bootcmd:
+- modprobe ip_tables
 
 
 ssh_pwauth: no
@@ -397,6 +399,34 @@ write_files:
     WantedBy=multi-user.target
 
 
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
 rh_subscription:
     username: ""
     password: ""
@@ -404,3 +434,4 @@ rh_subscription:
 
 runcmd:
 - systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere-mirrors.yaml
@@ -1,4 +1,6 @@
 #cloud-config
+bootcmd:
+- modprobe ip_tables
 
 hostname: node1
 fqdn: node1
@@ -415,6 +417,34 @@ write_files:
     WantedBy=multi-user.target
 
 
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
 rh_subscription:
     username: ""
     password: ""
@@ -422,3 +452,4 @@ rh_subscription:
 
 runcmd:
 - systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere-proxy.yaml
@@ -1,4 +1,6 @@
 #cloud-config
+bootcmd:
+- modprobe ip_tables
 
 hostname: node1
 fqdn: node1
@@ -415,6 +417,34 @@ write_files:
     WantedBy=multi-user.target
 
 
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
 rh_subscription:
     username: ""
     password: ""
@@ -422,3 +452,4 @@ rh_subscription:
 
 runcmd:
 - systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-vsphere.yaml
@@ -1,4 +1,6 @@
 #cloud-config
+bootcmd:
+- modprobe ip_tables
 
 hostname: node1
 fqdn: node1
@@ -406,6 +408,34 @@ write_files:
     WantedBy=multi-user.target
 
 
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
 rh_subscription:
     username: ""
     password: ""
@@ -413,3 +443,4 @@ rh_subscription:
 
 runcmd:
 - systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems that `nm-cloud-setup` runs on RHEL machines on some cloud providers(e.g: AWS). `nm-cloud-setup` introduces new ip routing table which will end up conflicting with calico. This routing table disturbs host and pod connectivity, thus we need to disable this tool, otherwise we can't run canal for RHEL 8.4 on aws. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
disable `nm-cloud-setup` networking tool on RHEL 
```
