### PR TITLE
Enable vsphere e2e tests

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -545,7 +545,7 @@ presubmits:
               cpu: 500m
 
   - name: pull-machine-controller-e2e-vsphere
-    always_run: false
+    always_run: true
     decorate: true
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
@@ -790,7 +790,7 @@ presubmits:
               cpu: 500m
 
   - name: pull-machine-controller-e2e-vsphere-resource-pool
-    always_run: false
+    always_run: true
     decorate: true
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -766,7 +766,7 @@ func getVSphereTestParams(t *testing.T) []string {
 func TestVsphereProvisioningE2E(t *testing.T) {
 	t.Parallel()
 
-	selector := Not(OsSelector("sles", "rhel", "amzn2"))
+	selector := Not(OsSelector("sles", "amzn2"))
 	params := getVSphereTestParams(t)
 
 	runScenarios(t, selector, params, VSPhereManifest, fmt.Sprintf("vs-%s", *testRunIdentifier))


### PR DESCRIPTION
**What this PR does / why we need it**:
We managed to finish our vSphere setup in our new DC, thus we should enable vSphere tests again. Also this PR enables rhel(8.4) tests for vSphere. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
