### PR TITLE
Use CentOS 7 images issued by CentOS CPE team

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -96,14 +96,18 @@ var (
 	)
 
 	amiFilters = map[providerconfigtypes.OperatingSystem]map[awstypes.CPUArchitecture]amiFilter{
+		// Source: https://wiki.centos.org/Cloud/AWS
 		providerconfigtypes.OperatingSystemCentOS: {
 			awstypes.CPUArchitectureX86_64: {
-				description: "CentOS Linux 7 x86_64 HVM EBS*",
-				// The AWS marketplace ID from AWS
-				owner:       "679593333241",
-				productCode: "aw0evgkw8e5c1q413zgy5pjce",
+				description: "CentOS 7* x86_64",
+				// The AWS marketplace ID from CentOS Community Platform Engineering (CPE)
+				owner: "125523088429",
 			},
-			// 2021-10-14 - No CentOS 7 ARM64 image available under legacy product code
+			awstypes.CPUArchitectureARM64: {
+				description: "CentOS 7* aarch64",
+				// The AWS marketplace ID from CentOS Community Platform Engineering (CPE)
+				owner: "125523088429",
+			},
 		},
 		providerconfigtypes.OperatingSystemAmazonLinux2: {
 			awstypes.CPUArchitectureX86_64: {


### PR DESCRIPTION
**What this PR does / why we need it**:
The current image filter for AMIs in AWS targets a legacy account for CentOS 7 images. CentOS (via their Community Platform Engineering team) started publishing their own images as per https://wiki.centos.org/Cloud/AWS. We should use those images instead.

The new location also has an ARM64 image.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1069

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use new source of CentOS 7 images (issued by CentOS CPE) in AWS when no AMI is set
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>