### PR TITLE
Add support for AWS AssumeRole functionality

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -834,6 +834,28 @@ presubmits:
               memory: 1Gi
               cpu: 500m
 
+  - name: pull-machine-controller-e2e-aws-assume-role
+    always_run: false
+    decorate: true
+    error_on_eviction: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    labels:
+      preset-aws-assume-role: "true"
+      preset-hetzner: "true"
+      preset-e2e-ssh: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: golang:1.17.1
+          command:
+            - "./hack/ci-e2e-test.sh"
+          args:
+            - "TestAWSAssumeRoleProvisioningE2E"
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 500m
+
 postsubmits:
   - name: ci-push-machine-controller-image
     always_run: true

--- a/pkg/cloudprovider/provider/aws/types/types.go
+++ b/pkg/cloudprovider/provider/aws/types/types.go
@@ -24,6 +24,9 @@ type RawConfig struct {
 	AccessKeyID     providerconfigtypes.ConfigVarString `json:"accessKeyId,omitempty"`
 	SecretAccessKey providerconfigtypes.ConfigVarString `json:"secretAccessKey,omitempty"`
 
+	AssumeRoleARN        providerconfigtypes.ConfigVarString `json:"assumeRoleARN,omitempty"`
+	AssumeRoleExternalID providerconfigtypes.ConfigVarString `json:"assumeRoleExternalID,omitempty"`
+
 	Region             providerconfigtypes.ConfigVarString   `json:"region"`
 	AvailabilityZone   providerconfigtypes.ConfigVarString   `json:"availabilityZone,omitempty"`
 	VpcID              providerconfigtypes.ConfigVarString   `json:"vpcId"`

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -388,6 +388,36 @@ func TestAWSProvisioningE2E(t *testing.T) {
 	runScenarios(t, selector, params, AWSManifest, fmt.Sprintf("aws-%s", *testRunIdentifier))
 }
 
+// TestAWSAssumeRoleProvisioning - a test suite that exercises AWS provider
+// by requesting nodes using an assumed role.
+func TestAWSAssumeRoleProvisioningE2E(t *testing.T) {
+	t.Parallel()
+
+	// test data
+	awsKeyID := os.Getenv("AWS_E2E_TESTS_KEY_ID")
+	awsSecret := os.Getenv("AWS_E2E_TESTS_SECRET")
+	awsAssumeRoleARN := os.Getenv("AWS_ASSUME_ROLE_ARN")
+	awsAssumeRoleExternalID := os.Getenv("AWS_ASSUME_ROLE_EXTERNAL_ID")
+	if len(awsKeyID) == 0 || len(awsSecret) == 0 || len(awsAssumeRoleARN) == 0 || len(awsAssumeRoleExternalID) == 0 {
+		t.Fatal("unable to run the test suite, environment variables AWS_E2E_TESTS_KEY_ID, AWS_E2E_TESTS_SECRET, AWS_E2E_ASSUME_ROLE_ARN and AWS_E2E_ASSUME_ROLE_EXTERNAL_ID cannot be empty")
+	}
+
+	// act
+	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
+		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),
+		fmt.Sprintf("<< PROVISIONING_UTILITY >>=%s", flatcar.CloudInit),
+	}
+
+	scenario := scenario{
+		name:              "AWS with AssumeRole",
+		osName:            "ubuntu",
+		containerRuntime:  "docker",
+		kubernetesVersion: "1.19.9",
+		executor:          verifyCreateAndDelete,
+	}
+	testScenario(t, scenario, *testRunIdentifier, params, AWSManifest, false)
+}
+
 // TestAWSSpotInstanceProvisioning - a test suite that exercises AWS provider
 // by requesting spot nodes with different combination of container runtime type, container runtime version and the OS flavour.
 func TestAWSSpotInstanceProvisioningE2E(t *testing.T) {

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -174,6 +174,10 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< MAX_PRICE >>=%s", "0.02"))
 	}
 
+	// only used by assume role scenario, otherwise empty (disabled)
+	scenarioParams = append(scenarioParams, fmt.Sprintf("<< AWS_ASSUME_ROLE_ARN >>=%s", os.Getenv("AWS_ASSUME_ROLE_ARN")))
+	scenarioParams = append(scenarioParams, fmt.Sprintf("<< AWS_ASSUME_ROLE_EXTERNAL_ID >>=%s", os.Getenv("AWS_ASSUME_ROLE_EXTERNAL_ID")))
+
 	// only used by OpenStack scenarios
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< OS_IMAGE >>=%s", openStackImages[testCase.osName]))
 

--- a/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
@@ -26,6 +26,8 @@ spec:
           cloudProviderSpec:
             accessKeyId: << AWS_ACCESS_KEY_ID >>
             secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
+            assumeRoleARN: "<< AWS_ASSUME_ROLE_ARN >>"
+            assumeRoleExternalID: "<< AWS_ASSUME_ROLE_EXTERNAL_ID >>"
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
             vpcId: "vpc-819f62e9"


### PR DESCRIPTION
**What this PR does / why we need it**: Allows using the AWS AssumeRole calls to run user clusters in external AWS accounts.

**Which issue(s) this PR fixes**:
Fixes #1072 

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support AWS AssumeRole functionality to run user clusters in external accounts
```
