### PR TITLE
Openstack support auth with projectName/ projectID

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -293,6 +293,29 @@ presubmits:
               memory: 1Gi
               cpu: 500m
 
+  - name: pull-machine-controller-e2e-openstack-project-auth
+    always_run: true
+    decorate: true
+    error_on_eviction: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    labels:
+      preset-openstack: "true"
+      preset-hetzner: "true"
+      preset-e2e-ssh: "true"
+      preset-rhel: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: golang:1.17.1
+          command:
+            - "./hack/ci-e2e-test.sh"
+          args:
+            - "TestOpenstackProjectAuthProvisioningE2E"
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 500m
+
   - name: pull-machine-controller-e2e-aws
     always_run: true
     decorate: true

--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/prometheus/client_golang/prometheus"
+	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1/migrations"
@@ -43,7 +44,6 @@ import (
 	machinesv1alpha1 "github.com/kubermatic/machine-controller/pkg/machines/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/node"
 	"github.com/kubermatic/machine-controller/pkg/signals"
-	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -101,8 +101,14 @@ username: ""
 password: ""
 # the openstack domain
 domainName: "default"
-# tenant name
-tenantName: ""
+# project name
+projectName: ""
+# project id
+projectID: ""
+# tenant name (deprecated, should use projectName)
+tenantName: "" 
+# tenant Id (deprecated, should use projectID)
+tenantID: ""
 # image to use (currently only ubuntu is supported)
 image: "Ubuntu 18.04 amd64"
 # instance flavor

--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -12,6 +12,9 @@ stringData:
   password: << OS_PASSWORD >>
   domainName: << OS_DOMAIN_NAME >>
   tenantName: << OS_TENANT_NAME >>
+  tenantID: << OS_TENANT_ID >>
+  projectName: << OS_PROJECT_NAME >>
+  projectID: << OS_PROJECT_ID >>
   region: << OS_REGION_NAME >>
   instanceReadyCheckPeriod: << INSTANCE_READY_CHECK_PERIOD >>
   instanceReadyCheckTimeout: << INSTANCE_READY_TIMEOUT >>
@@ -88,12 +91,34 @@ spec:
                 namespace: kube-system
                 name: machine-controller-openstack
                 key: domainName
+
+            # --- WARN: You should define either projectName or tenantName. if both are defined, tenantName is ignored ---
+            # If empty, can be set via OS_PROJECT_NAME env var
+            projectName:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: projectName
             # If empty, can be set via OS_TENANT_NAME env var
             tenantName:
               secretKeyRef:
                 namespace: kube-system
                 name: machine-controller-openstack
                 key: tenantName
+            # --- WARN: You should define either projectID or tenantID. if both are defined, tenantID is ignored ---
+            # If empty, can be set via OS_PROJECT_ID env var
+            projectID:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: projectID
+            # If empty, can be set via OS_TENANT_ID env var
+            tenantID:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-openstack
+                key: tenantID
+
             # Only required if there is more than one region to choose from
             region:
               secretKeyRef:

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -84,10 +84,10 @@ type Config struct {
 	ApplicationCredentialSecret string
 	Username                    string
 	Password                    string
-	DomainName                  string
-	TenantName                  string
-	TenantID                    string
-	TokenID                     string
+	DomainName  string
+	ProjectName string
+	ProjectID   string
+	TokenID     string
 	Region                      string
 	ComputeAPIVersion           string
 
@@ -140,11 +140,11 @@ func (p *provider) getConfigAuth(c *Config, rawConfig *openstacktypes.RawConfig)
 	if err != nil {
 		return fmt.Errorf("failed to get the value of \"password\" field, error = %v", err)
 	}
-	c.TenantName, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantName, "OS_TENANT_NAME")
+	c.ProjectName, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantName, "OS_TENANT_NAME")
 	if err != nil {
 		return fmt.Errorf("failed to get the value of \"tenantName\" field, error = %v", err)
 	}
-	c.TenantID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantID, "OS_TENANT_ID")
+	c.ProjectID, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.TenantID, "OS_TENANT_ID")
 	if err != nil {
 		return fmt.Errorf("failed to get the value of \"tenantID\" field, error = %v", err)
 	}
@@ -283,8 +283,8 @@ func getClient(c *Config) (*gophercloud.ProviderClient, error) {
 		Username:                    c.Username,
 		Password:                    c.Password,
 		DomainName:                  c.DomainName,
-		TenantName:                  c.TenantName,
-		TenantID:                    c.TenantID,
+		TenantName:                  c.ProjectName,
+		TenantID:                    c.ProjectID,
 		TokenID:                     c.TokenID,
 		ApplicationCredentialID:     c.ApplicationCredentialID,
 		ApplicationCredentialSecret: c.ApplicationCredentialSecret,
@@ -408,7 +408,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 			return errors.New("password must be configured")
 		}
 
-		if c.TenantID == "" && c.TenantName == "" {
+		if c.ProjectID == "" && c.ProjectName == "" {
 			return errors.New("either tenantID or tenantName must be configured")
 		}
 	} else {
@@ -814,8 +814,8 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 			Username:                    c.Username,
 			Password:                    c.Password,
 			DomainName:                  c.DomainName,
-			TenantName:                  c.TenantName,
-			TenantID:                    c.TenantID,
+			ProjectName:                 c.ProjectName,
+			ProjectID:                   c.ProjectID,
 			Region:                      c.Region,
 			ApplicationCredentialSecret: c.ApplicationCredentialSecret,
 			ApplicationCredentialID:     c.ApplicationCredentialID,

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
 	"testing"
 	"text/template"
@@ -33,10 +31,12 @@ import (
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	cloudprovidertesting "github.com/kubermatic/machine-controller/pkg/cloudprovider/testing"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"net/http"
 	"testing"
 	"text/template"
@@ -145,6 +147,10 @@ type openstackProviderSpecConf struct {
 	RootDiskVolumeType          string
 	ApplicationCredentialID     string
 	ApplicationCredentialSecret string
+	ProjectName                 string
+	ProjectID                   string
+	TenantID                    string
+	TenantName                  string
 	ComputeAPIVersion           string
 }
 
@@ -185,8 +191,14 @@ func (o openstackProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 		"applicationCredentialID": "{{ .ApplicationCredentialID }}",
 		"applicationCredentialSecret": "{{ .ApplicationCredentialSecret }}",
 		{{- else }}
-		"tenantID": "",
-		"tenantName": "eu-de",
+		{{ if .ProjectID }}
+		"projectID": "{{ .ProjectID }}",
+		"projectName": "{{ .ProjectName }}",
+        {{- end }}
+        {{- if .TenantID }}
+		"tenantID": "{{ .TenantID }}",
+		"tenantName": "{{ .TenantName }}",
+        {{- end }}
 		"username": "dummy",
 		"password": "this_is_a_password",
 		{{- end }}
@@ -287,6 +299,54 @@ func TestCreateServer(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("provider.Create() or = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+		})
+	}
+}
+
+func TestProjectAuthVarsAreCorrectlyLoaded(t *testing.T) {
+	tests := []struct {
+		name         string
+		expectedName string
+		expectedID   string
+		specConf     openstackProviderSpecConf
+	}{
+		{
+			name:         "Project auth vars should be when tenant vars are not defined",
+			expectedID:   "the_project_id",
+			expectedName: "the_project_name",
+			specConf:     openstackProviderSpecConf{ProjectID: "the_project_id", ProjectName: "the_project_name"},
+		},
+		{
+			name:         "Project auth vars should be used even if tenant vars are defined",
+			expectedID:   "the_project_id",
+			expectedName: "the_project_name",
+			specConf:     openstackProviderSpecConf{ProjectID: "the_project_id", ProjectName: "the_project_name", TenantID: "the_tenant_id", TenantName: "the_tenant_name"},
+		},
+		{
+			name:         "Tenant auth vars should be used when project vars are not defined",
+			expectedID:   "the_tenant_id",
+			expectedName: "the_tenant_name",
+			specConf:     openstackProviderSpecConf{TenantID: "the_tenant_id", TenantName: "the_tenant_name"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &provider{
+				// Note that configVarResolver is not used in this test as the getConfigFunc is mocked.
+				configVarResolver: providerconfig.NewConfigVarResolver(context.Background(), fakeclient.NewFakeClient()),
+			}
+			conf, _, _, _ := p.getConfig(v1alpha1.ProviderSpec{
+				Value: &runtime.RawExtension{
+					Raw: tt.specConf.rawProviderSpec(t),
+				},
+			})
+
+			if conf.ProjectID != tt.expectedID {
+				t.Errorf("ProjectID = %v, wanted %v", conf.ProjectID, tt.expectedID)
+			}
+			if conf.ProjectName != tt.expectedName {
+				t.Errorf("ProjectName = %v, wanted %v", conf.ProjectName, tt.expectedName)
 			}
 		})
 	}

--- a/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/openstack/types/cloudconfig.go
@@ -39,8 +39,8 @@ application-credential-secret = {{ .Global.ApplicationCredentialSecret | iniEsca
 {{- else }}
 username    = {{ .Global.Username | iniEscape }}
 password    = {{ .Global.Password | iniEscape }}
-tenant-name = {{ .Global.TenantName | iniEscape }}
-tenant-id   = {{ .Global.TenantID | iniEscape }}
+tenant-name = {{ .Global.ProjectName | iniEscape }}
+tenant-id   = {{ .Global.ProjectID | iniEscape }}
 {{- end }}
 domain-name = {{ .Global.DomainName | iniEscape }}
 region      = {{ .Global.Region | iniEscape }}
@@ -104,10 +104,17 @@ type GlobalOpts struct {
 	Password                    string
 	ApplicationCredentialID     string `gcfg:"application-credential-id"`
 	ApplicationCredentialSecret string `gcfg:"application-credential-secret"`
-	TenantName                  string `gcfg:"tenant-name"`
-	TenantID                    string `gcfg:"tenant-id"`
-	DomainName                  string `gcfg:"domain-name"`
-	Region                      string
+
+	// project name formerly known as tenant name.
+	// it serialized as tenant-name because openstack CCM reads only tenant-name. In CCM, internally project and tenant
+	// are stored into tenant-name.
+	ProjectName string `gcfg:"tenant-name"`
+
+	// project id formerly known as tenant id.
+	// serialized as tenant-id for same reason as ProjectName
+	ProjectID  string `gcfg:"tenant-id"`
+	DomainName string `gcfg:"domain-name"`
+	Region     string
 }
 
 // CloudConfig is used to read and store information from the cloud configuration file

--- a/pkg/cloudprovider/provider/openstack/types/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/openstack/types/cloudconfig_test.go
@@ -40,12 +40,12 @@ func TestCloudConfigToString(t *testing.T) {
 			name: "simple-config",
 			config: &CloudConfig{
 				Global: GlobalOpts{
-					AuthURL:    "https://127.0.0.1:8443",
-					Username:   "admin",
-					Password:   "password",
-					DomainName: "Default",
-					TenantName: "Test",
-					Region:     "eu-central1",
+					AuthURL:     "https://127.0.0.1:8443",
+					Username:    "admin",
+					Password:    "password",
+					DomainName:  "Default",
+					ProjectName: "Test",
+					Region:      "eu-central1",
 				},
 				BlockStorage: BlockStorageOpts{
 					BSVersion:             "v2",
@@ -63,12 +63,12 @@ func TestCloudConfigToString(t *testing.T) {
 			name: "use-octavia-explicitly-enabled",
 			config: &CloudConfig{
 				Global: GlobalOpts{
-					AuthURL:    "https://127.0.0.1:8443",
-					Username:   "admin",
-					Password:   "password",
-					DomainName: "Default",
-					TenantName: "Test",
-					Region:     "eu-central1",
+					AuthURL:     "https://127.0.0.1:8443",
+					Username:    "admin",
+					Password:    "password",
+					DomainName:  "Default",
+					ProjectName: "Test",
+					Region:      "eu-central1",
 				},
 				BlockStorage: BlockStorageOpts{
 					BSVersion:             "v2",
@@ -87,12 +87,12 @@ func TestCloudConfigToString(t *testing.T) {
 			name: "use-octavia-explicitly-disabled",
 			config: &CloudConfig{
 				Global: GlobalOpts{
-					AuthURL:    "https://127.0.0.1:8443",
-					Username:   "admin",
-					Password:   "password",
-					DomainName: "Default",
-					TenantName: "Test",
-					Region:     "eu-central1",
+					AuthURL:     "https://127.0.0.1:8443",
+					Username:    "admin",
+					Password:    "password",
+					DomainName:  "Default",
+					ProjectName: "Test",
+					Region:      "eu-central1",
 				},
 				BlockStorage: BlockStorageOpts{
 					BSVersion:             "v2",
@@ -111,12 +111,12 @@ func TestCloudConfigToString(t *testing.T) {
 			name: "config-with-special-chars",
 			config: &CloudConfig{
 				Global: GlobalOpts{
-					AuthURL:    "https://127.0.0.1:8443",
-					Username:   "admin",
-					Password:   `.)\^x[tt0L@};p<KJ|f.VQ]7r9u;"ZF|`,
-					DomainName: "Default",
-					TenantName: "Test",
-					Region:     "eu-central1",
+					AuthURL:     "https://127.0.0.1:8443",
+					Username:    "admin",
+					Password:    `.)\^x[tt0L@};p<KJ|f.VQ]7r9u;"ZF|`,
+					DomainName:  "Default",
+					ProjectName: "Test",
+					Region:      "eu-central1",
 				},
 				BlockStorage: BlockStorageOpts{
 					BSVersion:             "v2",

--- a/pkg/cloudprovider/provider/openstack/types/types.go
+++ b/pkg/cloudprovider/provider/openstack/types/types.go
@@ -28,6 +28,8 @@ type RawConfig struct {
 	ApplicationCredentialID     providerconfigtypes.ConfigVarString `json:"applicationCredentialID,omitempty"`
 	ApplicationCredentialSecret providerconfigtypes.ConfigVarString `json:"applicationCredentialSecret,omitempty"`
 	DomainName                  providerconfigtypes.ConfigVarString `json:"domainName,omitempty"`
+	ProjectName                 providerconfigtypes.ConfigVarString `json:"projectName,omitempty"`
+	ProjectID                   providerconfigtypes.ConfigVarString `json:"projectID,omitempty"`
 	TenantName                  providerconfigtypes.ConfigVarString `json:"tenantName,omitempty"`
 	TenantID                    providerconfigtypes.ConfigVarString `json:"tenantID,omitempty"`
 	TokenID                     providerconfigtypes.ConfigVarString `json:"tokenId,omitempty"`

--- a/pkg/providerconfig/types_test.go
+++ b/pkg/providerconfig/types_test.go
@@ -19,9 +19,9 @@ package providerconfig
 import (
 	"testing"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestDefaultOperatingSystemSpec(t *testing.T) {

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -69,6 +69,7 @@ const (
 	ScalewayManifest                  = "./testdata/machinedeployment-scaleway.yaml"
 	OSMachineManifest                 = "./testdata/machine-openstack.yaml"
 	OSManifest                        = "./testdata/machinedeployment-openstack.yaml"
+	OSManifestProjectAuth             = "./testdata/machinedeployment-openstack-project-auth.yaml"
 	OSUpgradeManifest                 = "./testdata/machinedeployment-openstack-upgrade.yml"
 	invalidMachineManifest            = "./testdata/machine-invalid.yaml"
 	kubevirtManifest                  = "./testdata/machinedeployment-kubevirt.yaml"
@@ -346,6 +347,37 @@ func TestOpenstackProvisioningE2E(t *testing.T) {
 
 	selector := Not(OsSelector("sles", "rhel", "amzn2"))
 	runScenarios(t, selector, params, OSManifest, fmt.Sprintf("os-%s", *testRunIdentifier))
+}
+
+func TestOpenstackProjectAuthProvisioningE2E(t *testing.T) {
+	t.Parallel()
+
+	osAuthURL := os.Getenv("OS_AUTH_URL")
+	osDomain := os.Getenv("OS_DOMAIN")
+	osPassword := os.Getenv("OS_PASSWORD")
+	osRegion := os.Getenv("OS_REGION")
+	osUsername := os.Getenv("OS_USERNAME")
+
+	// not a mistake: openstack has deprecated OS_TENANT_NAME in favor of OS_PROJECT_NAME, but it contains same value.
+	osProject := os.Getenv("OS_TENANT_NAME")
+	osNetwork := os.Getenv("OS_NETWORK_NAME")
+
+	if osAuthURL == "" || osUsername == "" || osPassword == "" || osDomain == "" || osRegion == "" || osProject == "" {
+		t.Fatal("unable to run test suite, all of OS_AUTH_URL, OS_USERNAME, OS_PASSOWRD, OS_REGION, and OS_TENANT OS_DOMAIN must be set!")
+	}
+
+	params := []string{
+		fmt.Sprintf("<< IDENTITY_ENDPOINT >>=%s", osAuthURL),
+		fmt.Sprintf("<< USERNAME >>=%s", osUsername),
+		fmt.Sprintf("<< PASSWORD >>=%s", osPassword),
+		fmt.Sprintf("<< DOMAIN_NAME >>=%s", osDomain),
+		fmt.Sprintf("<< REGION >>=%s", osRegion),
+		fmt.Sprintf("<< PROJECT_NAME >>=%s", osProject),
+		fmt.Sprintf("<< NETWORK_NAME >>=%s", osNetwork),
+	}
+
+	selector := OsSelector("ubuntu")
+	runScenarios(t, selector, params, OSManifestProjectAuth, fmt.Sprintf("os-%s", *testRunIdentifier))
 }
 
 // TestDigitalOceanProvisioning - a test suite that exercises digital ocean provider

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack-project-auth.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack-project-auth.yaml
@@ -1,0 +1,49 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: << MACHINE_NAME >>
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: << MACHINE_NAME >>
+  template:
+    metadata:
+      labels:
+        name: << MACHINE_NAME >>
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProvider: "openstack"
+          cloudProviderSpec:
+            identityEndpoint: "<< IDENTITY_ENDPOINT >>"
+            username: "<< USERNAME >>"
+            password: "<< PASSWORD >>"
+            projectName: "<< PROJECT_NAME >>"
+            image: "<< OS_IMAGE >>"
+            flavor: "m1.tiny"
+            floatingIpPool: ""
+            domainName: "<< DOMAIN_NAME >>"
+            region: "<< REGION >>"
+            network: "<< NETWORK_NAME >>"
+            instanceReadyCheckPeriod: 5s
+            instanceReadyCheckTimeout: 2m
+          operatingSystem: "<< OS_NAME >>"
+          operatingSystemSpec:
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+            # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
+            rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
+            # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`
+            rhelSubscriptionManagerPassword: "<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>"
+            rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
+      versions:
+        kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
 OpenStack has deprecated `OS_TENANT_NAME / OS_TENANT_ID` in favor or `OS_PROJECT_NAME / OS_PROJECT_ID`, but these variables contain the same value.


ref kubermatic/kubermatic#6248

**Special notes for your reviewer**:
The cloudProviderSpec has been updated to add `projectName` and `projectID`. 
We first try to read `project` variables. If they are not defined, we fall back to tenant variables. Internally (ie `Config` struct), the values are stored under `project` variables, even if the user has specified it in `tenant` vars under `cloudProviderSpec`

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Openstack authentication with `project name` and  `project id`
```
