### PR TITLE
fix migrate uid test

### DIFF
--- a/test/e2e/provisioning/migrateuidscenario.go
+++ b/test/e2e/provisioning/migrateuidscenario.go
@@ -60,13 +60,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 	machine.Name = machineDeployment.Name
 	machine.Namespace = metav1.NamespaceSystem
 	machine.Spec.Name = machine.Name
-	fakeClient := fakectrlruntimeclient.NewFakeClient(
-		&v1alpha1.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      machineDeployment.Name,
-				Namespace: metav1.NamespaceSystem,
-			},
-		})
+	fakeClient := fakectrlruntimeclient.NewFakeClient(machine)
 
 	providerData := &cloudprovidertypes.ProviderData{
 		Update: cloudprovidertypes.GetMachineUpdater(context.Background(), fakeClient),


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a bug in the migrate machine uid tests. We use a fake client in order to run the migarate uid test. In the current code base, we populate the fake client with a machine object that has a name and a namespace value. There are some modifiers functions that we use, in order to update machine cr(e.g: adding finalizers). Since the machine cr that we populate the client with, only has a name and namespace, the cloud provider would simply fail to parse the cloud provider spec(since it nil) and thus the test will fail. 

This PR change this by populating the full object in the client, thus once the modifiers functions execute an update it will have the full copy of the machine not just the machine name and namespace. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
