### PR TITLE
Include optional subscription attachment in RHEL MachineDeployment 

### DIFF
--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -363,7 +363,7 @@ rh_subscription:
 {{- else }}
     username: "{{.OSConfig.RHELSubscriptionManagerUser}}"
     password: "{{.OSConfig.RHELSubscriptionManagerPassword}}"
-    auto-attach: "{{.OSConfig.AttachSubscription}}"
+    auto-attach: {{.OSConfig.AttachSubscription}}
 {{- end }}
 
 runcmd:

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -363,7 +363,7 @@ rh_subscription:
 {{- else }}
     username: "{{.OSConfig.RHELSubscriptionManagerUser}}"
     password: "{{.OSConfig.RHELSubscriptionManagerPassword}}"
-    auto-attach: true
+    auto-attach: "{{.OSConfig.AttachSubscription}}"
 {{- end }}
 
 runcmd:

--- a/pkg/userdata/rhel/rhel.go
+++ b/pkg/userdata/rhel/rhel.go
@@ -28,6 +28,7 @@ type Config struct {
 	RHELSubscriptionManagerUser     string `json:"rhelSubscriptionManagerUser,omitempty"`
 	RHELSubscriptionManagerPassword string `json:"rhelSubscriptionManagerPassword,omitempty"`
 	RHSMOfflineToken                string `json:"rhsmOfflineToken,omitempty"`
+	AttachSubscription              bool   `json:"attachSubscription"`
 	RHELUseSatelliteServer          bool   `json:"rhelUseSatelliteServer"`
 	RHELSatelliteServer             string `json:"rhelSatelliteServer"`
 	RHELOrganizationName            string `json:"rhelOrganizationName"`

--- a/pkg/userdata/rhel/testdata/kubelet-containerd-v1.19-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-containerd-v1.19-aws.yaml
@@ -460,7 +460,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: "false"
+    auto-attach: false
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-containerd-v1.19-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-containerd-v1.19-aws.yaml
@@ -460,7 +460,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: true
+    auto-attach: "false"
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.19-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.19-aws.yaml
@@ -444,7 +444,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: "false"
+    auto-attach: false
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.19-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.19-aws.yaml
@@ -444,7 +444,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: true
+    auto-attach: "false"
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
@@ -444,7 +444,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: "false"
+    auto-attach: false
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
@@ -444,7 +444,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: true
+    auto-attach: "false"
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -444,7 +444,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: "false"
+    auto-attach: false
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -444,7 +444,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: true
+    auto-attach: "false"
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws-external.yaml
@@ -460,7 +460,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: "false"
+    auto-attach: false
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws-external.yaml
@@ -460,7 +460,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: true
+    auto-attach: "false"
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -460,7 +460,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: "false"
+    auto-attach: false
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -460,7 +460,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: true
+    auto-attach: "false"
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere-mirrors.yaml
@@ -478,7 +478,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: true
+    auto-attach: "false"
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere-mirrors.yaml
@@ -478,7 +478,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: "false"
+    auto-attach: false
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere-proxy.yaml
@@ -482,7 +482,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: true
+    auto-attach: "false"
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere-proxy.yaml
@@ -482,7 +482,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: "false"
+    auto-attach: false
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere.yaml
@@ -469,7 +469,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: true
+    auto-attach: "false"
 
 runcmd:
 - systemctl start setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-vsphere.yaml
@@ -469,7 +469,7 @@ write_files:
 rh_subscription:
     username: ""
     password: ""
-    auto-attach: "false"
+    auto-attach: false
 
 runcmd:
 - systemctl start setup.service

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
@@ -41,6 +41,7 @@ spec:
           operatingSystemSpec:
             distUpgradeOnBoot: false
             disableAutoUpdate: true
+            attachSubscription: false
             # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
             rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -40,6 +40,7 @@ spec:
           operatingSystemSpec:
             distUpgradeOnBoot: false
             disableAutoUpdate: true
+            attachSubscription: false
             # 'rhelSubscriptionManagerUser' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_USER`
             rhelSubscriptionManagerUser: "<< RHEL_SUBSCRIPTION_MANAGER_USER >>"
             # 'rhelSubscriptionManagerPassword' is only used for rhel os and can be set via env var `RHEL_SUBSCRIPTION_MANAGER_PASSWORD`


### PR DESCRIPTION
**What this PR does / why we need it**:
Once a rhel machine is created and provisioned using machine controller, if we are using the username and password to register this machine we attach a subscription to it automatically. This is however doesn't give the option for the users to choose whether they would like to attach a subscription to the provisioned machine or not. Also this imposes a limitation for RHEL SCA which is not optimal. This PR gives the user the possibility to choose whether they would like to attach a subscription to the provisioned machine or not.  
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Optional RHEL subscription attachment 
```
