### PR TITLE
run e2e test Openstack Project Auth Provisioning  for one version of k8S

### DIFF
--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -376,8 +376,14 @@ func TestOpenstackProjectAuthProvisioningE2E(t *testing.T) {
 		fmt.Sprintf("<< NETWORK_NAME >>=%s", osNetwork),
 	}
 
-	selector := OsSelector("ubuntu")
-	runScenarios(t, selector, params, OSManifestProjectAuth, fmt.Sprintf("os-%s", *testRunIdentifier))
+	scenario := scenario{
+		name:              "MachineDeploy with project auth vars",
+		osName:            "ubuntu",
+		containerRuntime:  "containerd",
+		kubernetesVersion: "1.21.2",
+		executor:          verifyCreateAndDelete,
+	}
+	testScenario(t, scenario, *testRunIdentifier, params, OSManifestProjectAuth, false)
 }
 
 // TestDigitalOceanProvisioning - a test suite that exercises digital ocean provider


### PR DESCRIPTION
**What this PR does / why we need it**:
the test does not need to be launched for every k8s version and UUID migration. So it will reduce the number of necessary jobs to pass CI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
