### PR TITLE
osm-namespace flag

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -186,7 +186,7 @@ func main() {
 	}
 
 	if useOSM && len(osmNamespace) == 0 {
-		klog.Fatalf("-osm-namespace flag is mandatory when -use-osm is set: %v", err)
+		klog.Fatalf("-osm-namespace flag is mandatory when -use-osm is set")
 	}
 
 	var parsedJoinClusterTimeout *time.Duration

--- a/pkg/controller/machine/bootstrap.go
+++ b/pkg/controller/machine/bootstrap.go
@@ -177,7 +177,7 @@ const (
 	bootstrapBinContentTemplate = `#!/bin/bash
 set -xeuo pipefail
 apt update && apt install -y curl jq
-curl -s -k -v --header 'Authorization: Bearer {{ .Token }}'	{{ .ServerURL }}/api/v1/namespaces/{{ .OSMNamespace }}/secrets/{{ .SecretName }} | jq '.data["cloud-config"]' -r| base64 -d > /etc/cloud/cloud.cfg.d/{{ .SecretName }}.cfg
+curl -s -k -v --header 'Authorization: Bearer {{ .Token }}'	{{ .ServerURL }}/api/v1/namespaces/{{ .OSMNamespace }}/secrets/{{ .SecretName }} | jq '.data["cloud-init"]' -r| base64 -d > /etc/cloud/cloud.cfg.d/{{ .SecretName }}.cfg
 cloud-init clean
 cloud-init --file /etc/cloud/cloud.cfg.d/{{ .SecretName }}.cfg init
 systemctl daemon-reload

--- a/pkg/controller/machine/bootstrap.go
+++ b/pkg/controller/machine/bootstrap.go
@@ -67,12 +67,12 @@ func getOSMBootstrapUserDataForIgnition(ctx context.Context, req plugin.UserData
 		Token        string
 		SecretName   string
 		ServerURL    string
-		osmNamespace string
+		OSMNamespace string
 	}{
 		Token:        token,
 		SecretName:   secretName,
 		ServerURL:    req.Kubeconfig.Clusters[clusterName].Server,
-		osmNamespace: osmNamespace,
+		OSMNamespace: osmNamespace,
 	}
 	bsScript, err := template.New("bootstrap-script").Parse(ignitionBootstrapBinContentTemplate)
 	if err != nil {
@@ -112,13 +112,13 @@ func getOSMBootstrapUserDataForCloudInit(ctx context.Context, req plugin.UserDat
 		SecretName   string
 		ServerURL    string
 		MachineName  string
-		osmNamespace string
+		OSMNamespace string
 	}{
 		Token:        token,
 		SecretName:   secretName,
 		ServerURL:    req.Kubeconfig.Clusters[clusterName].Server,
 		MachineName:  req.MachineSpec.Name,
-		osmNamespace: osmNamespace,
+		OSMNamespace: osmNamespace,
 	}
 	bsScript, err := template.New("bootstrap-cloud-init").Parse(bootstrapBinContentTemplate)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
A new command-line flag has been introduced to make the OSM integration transparent to the namespace used by OSM.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1103 

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
