### PR TITLE
Populate /etc/hostname during bootstrap for ignition

### DIFF
--- a/pkg/controller/machine/bootstrap.go
+++ b/pkg/controller/machine/bootstrap.go
@@ -282,12 +282,12 @@ storage:
       inline: |
 {{ .Script | indent 10}}
 {{ if ne .CloudProviderName "aws" }}
+{{- /* Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name */}}
   - path: /etc/hostname
     mode: 0600
     filesystem: root
     contents:
       inline: '{{ .MachineSpec.Name }}'
-{{- /* Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name */}}
 {{ end }}
 systemd:
   units:

--- a/pkg/controller/machine/bootstrap.go
+++ b/pkg/controller/machine/bootstrap.go
@@ -93,9 +93,9 @@ func getOSMBootstrapUserDataForIgnition(ctx context.Context, req plugin.UserData
 		SSHPublicKeys []string
 		plugin.UserDataRequest
 	}{
-		Script:        script.String(),
-		Service:       bootstrapServiceContentTemplate,
-		SSHPublicKeys: sshPublicKeys,
+		Script:          script.String(),
+		Service:         bootstrapServiceContentTemplate,
+		SSHPublicKeys:   sshPublicKeys,
 		UserDataRequest: req,
 	})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Write machine name to `/etc/hostname`, which is then later on consumed by kubelet to populate the flag `--hostname-override`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
