### PR TITLE
disable ssh pwauth

### DIFF
--- a/pkg/controller/machine/bootstrap.go
+++ b/pkg/controller/machine/bootstrap.go
@@ -227,7 +227,7 @@ ExecStart=/opt/bin/bootstrap
 hostname: {{ .MachineSpec.Name }}
 {{- /* Never set the hostname on AWS nodes. Kubernetes(kube-proxy) requires the hostname to be the private dns name */}}
 {{ end }}
-ssh_pwauth: no
+ssh_pwauth: false
 
 {{- if .ProviderSpec.SSHPublicKeys }}
 ssh_authorized_keys:


### PR DESCRIPTION
**What this PR does / why we need it**:
For centos `ssh_pwauth: no` doesn't work and we need to set it to false instead. 
**Which  issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
