### PR TITLE
Default flatcar provisionUtility on AWS to cloud-init

### DIFF
--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -124,7 +124,11 @@ func (ad *admissionData) defaultAndValidateMachineSpec(spec *clusterv1alpha1.Mac
 		return fmt.Errorf("Invalid public keys specified: %v", err)
 	}
 
-	defaultedOperatingSystemSpec, err := providerconfig.DefaultOperatingSystemSpec(providerConfig.OperatingSystem, providerConfig.OperatingSystemSpec)
+	defaultedOperatingSystemSpec, err := providerconfig.DefaultOperatingSystemSpec(
+		providerConfig.OperatingSystem,
+		providerConfig.CloudProvider,
+		providerConfig.OperatingSystemSpec,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -156,14 +156,19 @@ func NewConfigVarResolver(ctx context.Context, client ctrlruntimeclient.Client) 
 	}
 }
 
-func DefaultOperatingSystemSpec(osys providerconfigtypes.OperatingSystem, operatingSystemSpec runtime.RawExtension) (runtime.RawExtension, error) {
+func DefaultOperatingSystemSpec(
+	osys providerconfigtypes.OperatingSystem,
+	cloudProvider providerconfigtypes.CloudProvider,
+	operatingSystemSpec runtime.RawExtension,
+) (runtime.RawExtension, error) {
+
 	switch osys {
 	case providerconfigtypes.OperatingSystemAmazonLinux2:
 		return amzn2.DefaultConfig(operatingSystemSpec), nil
 	case providerconfigtypes.OperatingSystemCentOS:
 		return centos.DefaultConfig(operatingSystemSpec), nil
 	case providerconfigtypes.OperatingSystemFlatcar:
-		return flatcar.DefaultConfig(operatingSystemSpec), nil
+		return flatcar.DefaultConfigForCloud(operatingSystemSpec, cloudProvider), nil
 	case providerconfigtypes.OperatingSystemRHEL:
 		return rhel.DefaultConfig(operatingSystemSpec), nil
 	case providerconfigtypes.OperatingSystemSLES:

--- a/pkg/providerconfig/types_test.go
+++ b/pkg/providerconfig/types_test.go
@@ -30,7 +30,7 @@ func TestDefaultOperatingSystemSpec(t *testing.T) {
 	for _, osys := range providerconfigtypes.AllOperatingSystems {
 		osys := osys
 		t.Run(string(osys), func(t *testing.T) {
-			operatingSystemSpec, err := DefaultOperatingSystemSpec(osys, runtime.RawExtension{})
+			operatingSystemSpec, err := DefaultOperatingSystemSpec(osys, "", runtime.RawExtension{})
 
 			if err != nil {
 				t.Error("no error expected")

--- a/pkg/userdata/flatcar/flatcar.go
+++ b/pkg/userdata/flatcar/flatcar.go
@@ -19,6 +19,8 @@ package flatcar
 import (
 	"encoding/json"
 
+	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -42,8 +44,17 @@ type Config struct {
 }
 
 func DefaultConfig(operatingSystemSpec runtime.RawExtension) runtime.RawExtension {
+	return DefaultConfigForCloud(operatingSystemSpec, "")
+}
+
+func DefaultConfigForCloud(operatingSystemSpec runtime.RawExtension, cloudProvider types.CloudProvider) runtime.RawExtension {
+	osSpec := Config{}
+	if cloudProvider == types.CloudProviderAWS {
+		osSpec.ProvisioningUtility = CloudInit
+	}
+
 	if operatingSystemSpec.Raw == nil {
-		operatingSystemSpec.Raw, _ = json.Marshal(Config{})
+		operatingSystemSpec.Raw, _ = json.Marshal(osSpec)
 	}
 
 	return operatingSystemSpec


### PR DESCRIPTION
**What this PR does / why we need it**:
Because AWS has very low user-data limit and ignition exceeding it preventing new flatcar instances to be created.

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default flatcar provisionUtility on AWS to cloud-init
```
