### PR TITLE
Use cloud-init for Flatcar machines on AWS unconditionally

### DIFF
--- a/pkg/userdata/flatcar/flatcar.go
+++ b/pkg/userdata/flatcar/flatcar.go
@@ -39,7 +39,7 @@ type Config struct {
 	DisableUpdateEngine bool `json:"disableUpdateEngine"`
 
 	// ProvisioningUtility specifies the type of provisioning utility, allowed values are cloud-init and ignition.
-	// Defaults to ignition.
+	// Defaults to cloud-init for AWS, and ignition for other providers.
 	ProvisioningUtility `json:"provisioningUtility,omitempty"`
 }
 
@@ -49,13 +49,15 @@ func DefaultConfig(operatingSystemSpec runtime.RawExtension) runtime.RawExtensio
 
 func DefaultConfigForCloud(operatingSystemSpec runtime.RawExtension, cloudProvider types.CloudProvider) runtime.RawExtension {
 	osSpec := Config{}
+
+	if operatingSystemSpec.Raw != nil {
+		_ = json.Unmarshal(operatingSystemSpec.Raw, &osSpec)
+	}
 	if cloudProvider == types.CloudProviderAWS {
 		osSpec.ProvisioningUtility = CloudInit
 	}
 
-	if operatingSystemSpec.Raw == nil {
-		operatingSystemSpec.Raw, _ = json.Marshal(osSpec)
-	}
+	operatingSystemSpec.Raw, _ = json.Marshal(osSpec)
 
 	return operatingSystemSpec
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The current implementation (#1119) sets the provisioning utility for AWS Flatcar machines to cloud-init only if the OperatingSystemSpec is not provided. Users might set some of the OperatingSystemSpec fields, but don't set the provisioning utility, in which case the current implementation wouldn't default to cloud-init.

With the proposed implementation, AWS Flatcar machines would get the provisioning utility unconditionally defaulted to cloud-init.

**Optional Release Note**:
```release-note
Use cloud-init for Flatcar machines on AWS unconditionally
```

/assign @kron4eg @moadqassem 
/hold