### PR TITLE
Add support for gp3 disk type in AWS

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,4 +35,4 @@ issues:
   - 'eviction\.go:221:4: the surrounding loop is unconditionally terminated'
   - 'cyclomatic complexity 31 of func `verifyMigrateUID` is high'
   - 'cyclomatic complexity 31 of func `main` is high'
-  - 'cyclomatic complexity 34 of func `(*provider).getConfig` is high'
+  - 'cyclomatic complexity 34 of func `\(\*provider\)\.getConfig` is high'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,3 +35,4 @@ issues:
   - 'eviction\.go:221:4: the surrounding loop is unconditionally terminated'
   - 'cyclomatic complexity 31 of func `verifyMigrateUID` is high'
   - 'cyclomatic complexity 31 of func `main` is high'
+  - 'cyclomatic complexity 34 of func `(*provider).getConfig` is high'

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -426,7 +426,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 			}
 		} else if c.DiskType == ec2.VolumeTypeGp3 {
 			if iops < 3000 || iops > 64000 {
-				return nil, nil, nil, errors.New("Invalid value for `diskIops` (min: 100, max: 64000)")
+				return nil, nil, nil, errors.New("Invalid value for `diskIops` (min: 3000, max: 64000)")
 			}
 		}
 

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -92,6 +92,7 @@ var (
 		ec2.VolumeTypeStandard,
 		ec2.VolumeTypeIo1,
 		ec2.VolumeTypeGp2,
+		ec2.VolumeTypeGp3,
 		ec2.VolumeTypeSc1,
 		ec2.VolumeTypeSt1,
 	)
@@ -419,8 +420,14 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		}
 		iops := *rawConfig.DiskIops
 
-		if iops < 100 || iops > 64000 {
-			return nil, nil, nil, errors.New("Invalid value for `diskIops` (min: 100, max: 64000)")
+		if c.DiskType == ec2.VolumeTypeIo1 {
+			if iops < 100 || iops > 64000 {
+				return nil, nil, nil, errors.New("Invalid value for `diskIops` (min: 100, max: 64000)")
+			}
+		} else if c.DiskType == ec2.VolumeTypeGp3 {
+			if iops < 3000 || iops > 64000 {
+				return nil, nil, nil, errors.New("Invalid value for `diskIops` (min: 100, max: 64000)")
+			}
 		}
 
 		c.DiskIops = rawConfig.DiskIops


### PR DESCRIPTION
**What this PR does / why we need it**:
Keeping up with AWS, this adds support for the `gp3` disk type. The difference to `gp2` is that you can define the IOPS for the disk to not depend on disk size for guaranteed IOPS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1123

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for gp3 disk type in AWS
```
Signed-off-by: Marvin Beckers <marvin@kubermatic.com>