### PR TITLE
Add SIG osm for overseeing changes for userdata and cloudprovider

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -12,3 +12,9 @@ aliases:
     - xmudrii
     - xrstf
     - youssefazrak
+
+  # Temporary SIG to oversee changes in userdata and cloudprovider sub-directories
+  # This SIG is responsible for ensuring that OSM and machine-controller are in sync
+  sig-osm:
+    - ahmedwaleedmalik
+    - moadqassem

--- a/pkg/cloudprovider/provider/OWNERS
+++ b/pkg/cloudprovider/provider/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - sig-osm
 
 labels:
-  - sig/cluster-management
+  - sig/osm
 
 options:
   no_parent_owners: true

--- a/pkg/cloudprovider/provider/OWNERS
+++ b/pkg/cloudprovider/provider/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-osm
+
+reviewers:
+  - sig-osm
+
+labels:
+  - sig/cluster-management
+
+options:
+  no_parent_owners: true

--- a/pkg/userdata/OWNERS
+++ b/pkg/userdata/OWNERS
@@ -7,7 +7,7 @@ reviewers:
   - sig-osm
 
 labels:
-  - sig/cluster-management
+  - sig/osm
 
 options:
   no_parent_owners: true

--- a/pkg/userdata/OWNERS
+++ b/pkg/userdata/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-osm
+
+reviewers:
+  - sig-osm
+
+labels:
+  - sig/cluster-management
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
At the moment, machine-controller and OSM have duplications mainly for [cloudprovider](https://github.com/kubermatic/machine-controller/tree/master/pkg/cloudprovider) and [userdata](https://github.com/kubermatic/machine-controller/tree/master/pkg/userdata). In order to ensure that both of them are in-sync we have created this SIG that can take care of this synchronization.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
