### PR TITLE
Use default scheme and pass request context to ConfigVarResolver

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -25,6 +25,7 @@ import (
 	userdatamanager "github.com/kubermatic/machine-controller/pkg/userdata/manager"
 	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
@@ -77,6 +78,11 @@ func main() {
 	}
 
 	scheme := runtime.NewScheme()
+
+	if err := corev1.AddToScheme(scheme); err != nil {
+		klog.Fatalf("failed to add corev1 api to scheme: %v", err)
+	}
+
 	if err := osmv1alpha1.AddToScheme(scheme); err != nil {
 		klog.Fatalf("failed to add osmv1alpha1 api to scheme: %v", err)
 	}

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -25,8 +25,7 @@ import (
 	userdatamanager "github.com/kubermatic/machine-controller/pkg/userdata/manager"
 	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,19 +76,11 @@ func main() {
 		klog.Fatalf("error building kubeconfig: %v", err)
 	}
 
-	scheme := runtime.NewScheme()
-
-	if err := corev1.AddToScheme(scheme); err != nil {
-		klog.Fatalf("failed to add corev1 api to scheme: %v", err)
-	}
-
-	if err := osmv1alpha1.AddToScheme(scheme); err != nil {
+	if err := osmv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		klog.Fatalf("failed to add osmv1alpha1 api to scheme: %v", err)
 	}
 
-	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{
-		Scheme: scheme,
-	})
+	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
 	if err != nil {
 		klog.Fatalf("failed to build client: %v", err)
 	}

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -41,7 +41,6 @@ import (
 )
 
 type admissionData struct {
-	ctx             context.Context
 	client          ctrlruntimeclient.Client
 	userDataManager *userdatamanager.Manager
 	nodeSettings    machinecontroller.NodeSettings
@@ -125,7 +124,7 @@ func createAdmissionResponse(original, mutated runtime.Object) (*admissionv1.Adm
 	return response, nil
 }
 
-type mutator func(admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error)
+type mutator func(context.Context, admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error)
 
 func handleFuncFactory(mutate mutator) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -143,7 +142,7 @@ func handleFuncFactory(mutate mutator) func(http.ResponseWriter, *http.Request) 
 		}
 
 		// run the mutation logic
-		response, err := mutate(*review.Request)
+		response, err := mutate(r.Context(), *review.Request)
 		if err != nil {
 			response = &admissionv1.AdmissionResponse{}
 			response.Result = &metav1.Status{Message: err.Error()}

--- a/pkg/admission/machinedeployments.go
+++ b/pkg/admission/machinedeployments.go
@@ -17,6 +17,7 @@ limitations under the License.
 package admission
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -27,7 +28,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
 
-func (ad *admissionData) mutateMachineDeployments(ar admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+func (ad *admissionData) mutateMachineDeployments(ctx context.Context, ar admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
 	machineDeployment := clusterv1alpha1.MachineDeployment{}
 	if err := json.Unmarshal(ar.Object.Raw, &machineDeployment); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal: %v", err)
@@ -64,7 +65,7 @@ func (ad *admissionData) mutateMachineDeployments(ar admissionv1.AdmissionReques
 	}
 
 	if machineSpecNeedsValidation {
-		if err := ad.defaultAndValidateMachineSpec(&machineDeployment.Spec.Template.Spec); err != nil {
+		if err := ad.defaultAndValidateMachineSpec(ctx, &machineDeployment.Spec.Template.Spec); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -17,6 +17,7 @@ limitations under the License.
 package admission
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -38,7 +39,7 @@ import (
 // the `providerConfig` field to `providerSpec`
 const BypassSpecNoModificationRequirementAnnotation = "kubermatic.io/bypass-no-spec-mutation-requirement"
 
-func (ad *admissionData) mutateMachines(ar admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
+func (ad *admissionData) mutateMachines(ctx context.Context, ar admissionv1.AdmissionRequest) (*admissionv1.AdmissionResponse, error) {
 	machine := clusterv1alpha1.Machine{}
 	if err := json.Unmarshal(ar.Object.Raw, &machine); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal: %v", err)
@@ -80,7 +81,7 @@ func (ad *admissionData) mutateMachines(ar admissionv1.AdmissionRequest) (*admis
 	// Default and verify .Spec on CREATE only, its expensive and not required to do it on UPDATE
 	// as we disallow .Spec changes anyways
 	if ar.Operation == admissionv1.Create {
-		if err := ad.defaultAndValidateMachineSpec(&machine.Spec); err != nil {
+		if err := ad.defaultAndValidateMachineSpec(ctx, &machine.Spec); err != nil {
 			return nil, err
 		}
 
@@ -98,7 +99,7 @@ func (ad *admissionData) mutateMachines(ar admissionv1.AdmissionRequest) (*admis
 	return createAdmissionResponse(machineOriginal, &machine)
 }
 
-func (ad *admissionData) defaultAndValidateMachineSpec(spec *clusterv1alpha1.MachineSpec) error {
+func (ad *admissionData) defaultAndValidateMachineSpec(ctx context.Context, spec *clusterv1alpha1.MachineSpec) error {
 	providerConfig, err := providerconfigtypes.GetConfig(spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to read machine.spec.providerSpec: %v", err)
@@ -112,7 +113,7 @@ func (ad *admissionData) defaultAndValidateMachineSpec(spec *clusterv1alpha1.Mac
 		}
 	}
 
-	skg := providerconfig.NewConfigVarResolver(ad.ctx, ad.client)
+	skg := providerconfig.NewConfigVarResolver(ctx, ad.client)
 	prov, err := cloudprovider.ForProvider(providerConfig.CloudProvider, skg)
 	if err != nil {
 		return fmt.Errorf("failed to get cloud provider %q: %v", providerConfig.CloudProvider, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes two problems:

1. #1136 introduced usage of an empty/fresh `Scheme` to generate a Kubernetes client for the webhook. Unfortunately, that broke reading machine spec values from secret or configmap references (#1142), as the client did not recognise `v1.Secret` or `v1.ConfigMap` resources anymore. We're using the default scheme now and only add OSM APIs to it.

Because https://github.com/kubermatic/machine-controller/blob/86b1621658bb2e4a38ce3ff3c7c8d0c621aff1b0/pkg/providerconfig/types.go#L109-L117 does not throw or log the error from `cvr.GetConfigVarStringValue`, I found this only by running a debugger and reading the `err` variable. We might want to adjust that as well, but this PR focuses on fixing the webhook.

2. The client request (which was broken as per above) needs a context. But the passed context was always `nil`, because it came from an `admissionData` struct, for which the `ctx` field was never set. I honestly have no idea how the webhook worked at all before #1136 broke it. But this PR passes the `http.Request`'s context down to the `ConfigVarResolver`, which means that canceling the HTTP request for the admission request that is being processed and is using `ConfigVarResolver` will cancel downstream Kubernetes client calls too.

This problem was only reported for the Hetzner token, but I expect it to impact other providers too, where an unexpected empty value did not necessarily fail validation but validated the spec in a different way than the controller would use it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1142

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix unexpected empty values when reading Secret or ConfigMap references in the webhook
```
