### PR TITLE
Fix disk size calculation in Nutanix spec validation

### DIFF
--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -231,7 +231,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 	}
 
 	if config.DiskSizeGB != nil && *config.DiskSizeGB*1024*1024*1024 < imageSizeBytes {
-		return fmt.Errorf("requested disk size (%d bytes) is smaller than image size (%d bytes)", *config.DiskSizeGB*1024*1024, *image.Status.Resources.SizeBytes)
+		return fmt.Errorf("requested disk size (%d bytes) is smaller than image size (%d bytes)", *config.DiskSizeGB*1024*1024*1024, *image.Status.Resources.SizeBytes)
 	}
 
 	return nil

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -230,7 +230,7 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to read image size for '%s'", config.ImageName)
 	}
 
-	if config.DiskSizeGB != nil && *config.DiskSizeGB*1024*1024 < imageSizeBytes {
+	if config.DiskSizeGB != nil && *config.DiskSizeGB*1024*1024*1024 < imageSizeBytes {
 		return fmt.Errorf("requested disk size (%d bytes) is smaller than image size (%d bytes)", *config.DiskSizeGB*1024*1024, *image.Status.Resources.SizeBytes)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor fix to the disk size calculation for disk size validation for Nutanix specs. It compares kilobytes to bytes before, which meant the disk size needed to be really large to pass the webhook.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
