### PR TITLE
Add mutating logic to populate OSP annotation based on OS flavor

### DIFF
--- a/pkg/admission/machinedeployments.go
+++ b/pkg/admission/machinedeployments.go
@@ -36,7 +36,7 @@ func (ad *admissionData) mutateMachineDeployments(ar admissionv1.AdmissionReques
 
 	machineDeploymentDefaultingFunction(&machineDeployment)
 
-	if err := mutationsForMachineDeployment(&machineDeployment); err != nil {
+	if err := mutationsForMachineDeployment(&machineDeployment, ad.useOSM); err != nil {
 		return nil, fmt.Errorf("mutation failed: %v", err)
 	}
 

--- a/pkg/admission/machinedeployments_validation.go
+++ b/pkg/admission/machinedeployments_validation.go
@@ -161,6 +161,7 @@ func ensureOSPAnnotation(md *v1alpha1.MachineDeployment, providerConfig provider
 			md.Annotations[osmresources.MachineDeploymentOSPAnnotation] = fmt.Sprintf(ospNamePattern, providerConfig.OperatingSystem)
 			return nil
 		case providerconfigtypes.OperatingSystemAmazonLinux2:
+			// This is a special case where the OS name suffix in OSP is different then the actual OS name
 			md.Annotations[osmresources.MachineDeploymentOSPAnnotation] = fmt.Sprintf(ospNamePattern, "amazon-linux")
 			return nil
 		default:

--- a/pkg/admission/machinedeployments_validation.go
+++ b/pkg/admission/machinedeployments_validation.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	osmresources "k8c.io/operating-system-manager/pkg/controllers/osc/resources"
+
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -31,6 +33,8 @@ import (
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
+
+const ospNamePattern = "osp-%s"
 
 func validateMachineDeployment(md v1alpha1.MachineDeployment) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -114,10 +118,17 @@ func machineDeploymentDefaultingFunction(md *v1alpha1.MachineDeployment) {
 	v1alpha1.PopulateDefaultsMachineDeployment(md)
 }
 
-func mutationsForMachineDeployment(md *v1alpha1.MachineDeployment) error {
+func mutationsForMachineDeployment(md *v1alpha1.MachineDeployment, useOSM bool) error {
 	providerConfig, err := providerconfigtypes.GetConfig(md.Spec.Template.Spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to read MachineDeployment.Spec.Template.Spec.ProviderSpec: %v", err)
+	}
+
+	if useOSM {
+		err = ensureOSPAnnotation(md, *providerConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Packet has been renamed to Equinix Metal
@@ -134,5 +145,27 @@ func mutationsForMachineDeployment(md *v1alpha1.MachineDeployment) error {
 		return fmt.Errorf("failed to json marshal machine.spec.providerSpec: %v", err)
 	}
 
+	return nil
+}
+
+func ensureOSPAnnotation(md *v1alpha1.MachineDeployment, providerConfig providerconfigtypes.Config) error {
+	// Check for existing annotation
+	if _, ok := md.Annotations[osmresources.MachineDeploymentOSPAnnotation]; !ok {
+		if md.Annotations == nil {
+			md.Annotations = make(map[string]string)
+		}
+		// Annotation not specified, populate default OSP annotation
+		switch providerConfig.OperatingSystem {
+		case providerconfigtypes.OperatingSystemUbuntu, providerconfigtypes.OperatingSystemCentOS, providerconfigtypes.OperatingSystemFlatcar,
+			providerconfigtypes.OperatingSystemRHEL, providerconfigtypes.OperatingSystemSLES:
+			md.Annotations[osmresources.MachineDeploymentOSPAnnotation] = fmt.Sprintf(ospNamePattern, providerConfig.OperatingSystem)
+			return nil
+		case providerconfigtypes.OperatingSystemAmazonLinux2:
+			md.Annotations[osmresources.MachineDeploymentOSPAnnotation] = fmt.Sprintf(ospNamePattern, "amazon-linux")
+			return nil
+		default:
+			return fmt.Errorf("failed to populate OSP annotation for machinedeployment with unsupported Operating System %s", providerConfig.OperatingSystem)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
This PR provides us a way to populate default OSP annotation in case it's missing. This is a requirement since OSM will only watch and cater resources that have this particular annotation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Webhook is the best place to facilitate this mutation. Since in the future, we'll have an option to specify a custom value from the front-end/API but for defaulting webhook will be used.

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
