### PR TITLE
Move spot instance e2e test to different AZ in eu-central-1

### DIFF
--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -171,7 +171,7 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_USER >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< RHEL_SUBSCRIPTION_MANAGER_PASSWORD >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>=%s", ""))
-		scenarioParams = append(scenarioParams, fmt.Sprintf("<< MAX_PRICE >>=%s", "0.02"))
+		scenarioParams = append(scenarioParams, fmt.Sprintf("<< MAX_PRICE >>=%s", "0.03"))
 	}
 
 	// only used by assume role scenario, otherwise empty (disabled)

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
@@ -27,7 +27,7 @@ spec:
             accessKeyId: << AWS_ACCESS_KEY_ID >>
             secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
             region: "eu-central-1"
-            availabilityZone: "eu-central-1a"
+            availabilityZone: "eu-central-1b"
             vpcId: "vpc-819f62e9"
             instanceType: "t2.medium"
             instanceProfile: "kubernetes-v1"


### PR DESCRIPTION
**What this PR does / why we need it**:

Spot prices in eu-central-1 seem to be causing the AWS e2e tests for spot instances to fail. Bumping this up so CI succeeds again (blocks a couple of PRs right now).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
