### PR TITLE
Nutanix: Add support for proxy URL setting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/coreos/container-linux-config-transpiler v0.9.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/digitalocean/godo v1.54.0
-	github.com/embik/nutanix-client-go v0.0.0-20220103122158-dbb64d7901ab
+	github.com/embik/nutanix-client-go v0.0.0-20220106131900-50b8f27e5f60
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-test/deep v1.0.7
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -332,8 +332,8 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
-github.com/embik/nutanix-client-go v0.0.0-20220103122158-dbb64d7901ab h1:WrwH567h9IFvCcAFORWFl+jOZqfvQc47LfnxN0nQzIk=
-github.com/embik/nutanix-client-go v0.0.0-20220103122158-dbb64d7901ab/go.mod h1:gkKNSxfEt3QtYG3S/wKiN8OmrJ4fpU7JbTlbnrMDOL8=
+github.com/embik/nutanix-client-go v0.0.0-20220106131900-50b8f27e5f60 h1:0FVKOkpksULFs6F7Kfd8ClBXVTvtiIKl07uV3HinOHk=
+github.com/embik/nutanix-client-go v0.0.0-20220106131900-50b8f27e5f60/go.mod h1:gkKNSxfEt3QtYG3S/wKiN8OmrJ4fpU7JbTlbnrMDOL8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.10.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/pkg/cloudprovider/provider/nutanix/client.go
+++ b/pkg/cloudprovider/provider/nutanix/client.go
@@ -78,6 +78,10 @@ func GetClientSet(config *Config) (*ClientSet, error) {
 		Insecure: config.AllowInsecure,
 	}
 
+	if config.ProxyURL != "" {
+		credentials.ProxyURL = config.ProxyURL
+	}
+
 	clientV3, err := nutanixv3.NewV3Client(credentials)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -43,6 +43,7 @@ type Config struct {
 	Username      string
 	Password      string
 	AllowInsecure bool
+	ProxyURL      string
 
 	ClusterName string
 	ProjectName string
@@ -150,6 +151,11 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	}
 
 	c.AllowInsecure, err = p.configVarResolver.GetConfigVarBoolValueOrEnv(rawConfig.AllowInsecure, "NUTANIX_ALLOW_INSECURE")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	c.ProxyURL, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.ProxyURL, "NUTANIX_PROXY_URL")
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/cloudprovider/provider/nutanix/types/types.go
+++ b/pkg/cloudprovider/provider/nutanix/types/types.go
@@ -35,6 +35,7 @@ type RawConfig struct {
 	Username      providerconfigtypes.ConfigVarString `json:"username"`
 	Password      providerconfigtypes.ConfigVarString `json:"password"`
 	AllowInsecure providerconfigtypes.ConfigVarBool   `json:"allowInsecure"`
+	ProxyURL      providerconfigtypes.ConfigVarString `json:"proxyURL,omitempty"`
 
 	ClusterName providerconfigtypes.ConfigVarString  `json:"clusterName"`
 	ProjectName *providerconfigtypes.ConfigVarString `json:"projectName,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for setting a proxy URL for Nutanix via `NUTANIX_PROXY_URL` or a field in the spec. This will be helpful for our E2E testing, and it's nice to support this use case for users as well (although I'm unsure how frequent that will be).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
