### PR TITLE
Split clients into worker and seed(default) clients for webhooks

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -59,7 +59,7 @@ func main() {
 	flag.StringVar(&opt.admissionTLSKeyPath, "tls-key-path", "/tmp/cert/key.pem", "The path of the TLS key for the MutatingWebhook")
 	flag.StringVar(&opt.caBundleFile, "ca-bundle", "", "path to a file containing all PEM-encoded CA certificates (will be used instead of the host's certificates if set)")
 	flag.StringVar(&opt.namespace, "namespace", "kubermatic", "The namespace where the webhooks will run")
-	flag.StringVar(&opt.workerClusterKubeconfig, "worker-cluster-kubeconfig", "", "Path to kubeconfig of worker/user cluster where machines and machinedeployments exist")
+	flag.StringVar(&opt.workerClusterKubeconfig, "worker-cluster-kubeconfig", "", "Path to kubeconfig of worker/user cluster where machines and machinedeployments exist. If not specified, value from --kubeconfig or in-cluster config will be used")
 
 	// OSM specific flags
 	flag.BoolVar(&opt.useOSM, "use-osm", false, "osm controller is enabled for node bootstrap")
@@ -84,9 +84,7 @@ func main() {
 		klog.Fatalf("error building kubeconfig: %v", err)
 	}
 
-	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{
-		Scheme: scheme.Scheme,
-	})
+	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{})
 	if err != nil {
 		klog.Fatalf("failed to build client: %v", err)
 	}
@@ -103,9 +101,7 @@ func main() {
 		}
 
 		// Build dedicated client for worker cluster
-		workerClient, err = ctrlruntimeclient.New(workerClusterConfig, ctrlruntimeclient.Options{
-			Scheme: scheme.Scheme,
-		})
+		workerClient, err = ctrlruntimeclient.New(workerClusterConfig, ctrlruntimeclient.Options{})
 		if err != nil {
 			klog.Fatalf("failed to build worker client: %v", err)
 		}

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -42,6 +42,7 @@ import (
 
 type admissionData struct {
 	client          ctrlruntimeclient.Client
+	workerClient    ctrlruntimeclient.Client
 	userDataManager *userdatamanager.Manager
 	nodeSettings    machinecontroller.NodeSettings
 	useOSM          bool
@@ -53,6 +54,7 @@ var jsonPatch = admissionv1.PatchTypeJSONPatch
 func New(
 	listenAddress string,
 	client ctrlruntimeclient.Client,
+	workerClient ctrlruntimeclient.Client,
 	um *userdatamanager.Manager,
 	nodeFlags *node.Flags,
 	useOSM bool,
@@ -61,6 +63,7 @@ func New(
 	mux := http.NewServeMux()
 	ad := &admissionData{
 		client:          client,
+		workerClient:    workerClient,
 		userDataManager: um,
 		useOSM:          useOSM,
 		namespace:       namespace,

--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -113,7 +113,7 @@ func (ad *admissionData) defaultAndValidateMachineSpec(ctx context.Context, spec
 		}
 	}
 
-	skg := providerconfig.NewConfigVarResolver(ctx, ad.client)
+	skg := providerconfig.NewConfigVarResolver(ctx, ad.workerClient)
 	prov, err := cloudprovider.ForProvider(providerConfig.CloudProvider, skg)
 	if err != nil {
 		return fmt.Errorf("failed to get cloud provider %q: %v", providerConfig.CloudProvider, err)


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
In KKP, these webhooks are deployed in a seed/master and worker(user) cluster architecture. Beforehand we were assuming that the only k8s client it needs is for the worker cluster since there was no need to interact with seed/master cluster. 

Although, after the addition of validations for OSM. There is a need to access resources, specifically OperatingSystemProfile, from the seed/master cluster.

To facilitate that we are splitting clients into:
1. Client - For seed/master, can use the in-cluster config
2. Worker Client - For worker cluster, needs out-of-cluster config

In case, the flag `worker-cluster-kubeconfig` is not specified then we assume that our subject is a single cluster and we use the same client as worker client.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
