### PR TITLE
Actually read environment variable in GetConfigVarBoolValueOrEnv

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -475,7 +475,6 @@ presubmits:
 
   - name: pull-machine-controller-e2e-linode
     always_run: false
-    run_if_changed: pkg\/cloudprovider\/provider\/linode\/.*
     optional: true
     decorate: true
     error_on_eviction: true

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -436,7 +436,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		c.DiskIops = rawConfig.DiskIops
 	}
 
-	c.EBSVolumeEncrypted, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.EBSVolumeEncrypted)
+	c.EBSVolumeEncrypted, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.EBSVolumeEncrypted)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get ebsVolumeEncrypted value: %v", err)
 	}
@@ -450,7 +450,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		}
 		c.SpotMaxPrice = pointer.StringPtr(maxPrice)
 
-		persistentRequest, err := p.configVarResolver.GetConfigVarBoolValue(rawConfig.SpotInstanceConfig.PersistentRequest)
+		persistentRequest, _, err := p.configVarResolver.GetConfigVarBoolValue(rawConfig.SpotInstanceConfig.PersistentRequest)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -271,7 +271,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*config, *providerconfigt
 		return nil, nil, fmt.Errorf("failed to get the value of \"routeTableName\" field, error = %v", err)
 	}
 
-	c.AssignPublicIP, err = p.configVarResolver.GetConfigVarBoolValue(rawCfg.AssignPublicIP)
+	c.AssignPublicIP, _, err = p.configVarResolver.GetConfigVarBoolValue(rawCfg.AssignPublicIP)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get the value of \"assignPublicIP\" field, error = %v", err)
 	}

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -133,19 +133,19 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	if err != nil {
 		return nil, nil, err
 	}
-	c.Backups, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.Backups)
+	c.Backups, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.Backups)
 	if err != nil {
 		return nil, nil, err
 	}
-	c.IPv6, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.IPv6)
+	c.IPv6, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.IPv6)
 	if err != nil {
 		return nil, nil, err
 	}
-	c.PrivateNetworking, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.PrivateNetworking)
+	c.PrivateNetworking, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.PrivateNetworking)
 	if err != nil {
 		return nil, nil, err
 	}
-	c.Monitoring, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.Monitoring)
+	c.Monitoring, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.Monitoring)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -161,7 +161,7 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 		return nil, fmt.Errorf("cannot retrieve subnetwork: %v", err)
 	}
 
-	cfg.preemptible, err = resolver.GetConfigVarBoolValue(cpSpec.Preemptible)
+	cfg.preemptible, _, err = resolver.GetConfigVarBoolValue(cpSpec.Preemptible)
 	if err != nil {
 		return nil, fmt.Errorf("cannot retrieve preemptible: %v", err)
 	}
@@ -170,18 +170,18 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 	cfg.assignPublicIPAddress = true
 
 	if cpSpec.AssignPublicIPAddress != nil {
-		cfg.assignPublicIPAddress, err = resolver.GetConfigVarBoolValue(*cpSpec.AssignPublicIPAddress)
+		cfg.assignPublicIPAddress, _, err = resolver.GetConfigVarBoolValue(*cpSpec.AssignPublicIPAddress)
 		if err != nil {
 			return nil, fmt.Errorf("failed to retrieve assignPublicIPAddress: %v", err)
 		}
 	}
 
-	cfg.multizone, err = resolver.GetConfigVarBoolValue(cpSpec.MultiZone)
+	cfg.multizone, _, err = resolver.GetConfigVarBoolValue(cpSpec.MultiZone)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve multizone: %v", err)
 	}
 
-	cfg.regional, err = resolver.GetConfigVarBoolValue(cpSpec.Regional)
+	cfg.regional, _, err = resolver.GetConfigVarBoolValue(cpSpec.Regional)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve regional: %v", err)
 	}

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -140,11 +140,11 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	if err != nil {
 		return nil, nil, err
 	}
-	c.Backups, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.Backups)
+	c.Backups, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.Backups)
 	if err != nil {
 		return nil, nil, err
 	}
-	c.PrivateNetworking, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.PrivateNetworking)
+	c.PrivateNetworking, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.PrivateNetworking)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -255,7 +255,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	c.TrustDevicePath, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.TrustDevicePath)
+	c.TrustDevicePath, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.TrustDevicePath)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/cloudprovider/provider/scaleway/provider.go
+++ b/pkg/cloudprovider/provider/scaleway/provider.go
@@ -127,7 +127,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 	if err != nil {
 		return nil, nil, err
 	}
-	c.IPv6, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.IPv6)
+	c.IPv6, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.IPv6)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -135,13 +135,16 @@ func (cvr *ConfigVarResolver) GetConfigVarBoolValueOrEnv(configVar providerconfi
 	if err != nil {
 		return false, err
 	}
-	if stringVal == "" {
+
+	// if stringVar is "false", it might have been not set and we can attempt to read from environment.
+	// if it is "true", we know it was configured via value or secret reference.
+	if stringVal == "" || stringVal == strconv.FormatBool(false) {
 		envVal, envValFound := os.LookupEnv(envVarName)
-		if !envValFound {
-			return false, fmt.Errorf("all mechanisms(value, secret, configMap) of getting the value failed, including reading from environment variable = %s which was not set", envVarName)
+		if envValFound {
+			stringVal = envVal
 		}
-		stringVal = envVal
 	}
+
 	boolVal, err := strconv.ParseBool(stringVal)
 	if err != nil {
 		return false, err

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -147,11 +147,11 @@ func (cvr *ConfigVarResolver) GetConfigVarBoolValue(configVar providerconfigtype
 		return false, false, fmt.Errorf("configmap '%s' in namespace '%s' has no key '%s'", configVar.ConfigMapKeyRef.Name, configVar.ConfigMapKeyRef.Namespace, configVar.ConfigMapKeyRef.Key)
 	}
 
-	if !configVar.Valid {
+	if configVar.Value == nil {
 		return false, false, nil
 	}
 
-	return configVar.Value, true, nil
+	return configVar.Value != nil && *configVar.Value, true, nil
 }
 
 func (cvr *ConfigVarResolver) GetConfigVarBoolValueOrEnv(configVar providerconfigtypes.ConfigVarBool, envVarName string) (bool, error) {

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -141,7 +141,7 @@ func (cvr *ConfigVarResolver) GetConfigVarBoolValue(configVar providerconfigtype
 			return false, false, fmt.Errorf("error retrieving configmap '%s' from namespace '%s': '%v'", configVar.ConfigMapKeyRef.Name, configVar.ConfigMapKeyRef.Namespace, err)
 		}
 		if val, ok := configMap.Data[configVar.ConfigMapKeyRef.Key]; ok {
-			boolVal, err := strconv.ParseBool(string(val))
+			boolVal, err := strconv.ParseBool(val)
 			return boolVal, (err == nil), err
 		}
 		return false, false, fmt.Errorf("configmap '%s' in namespace '%s' has no key '%s'", configVar.ConfigMapKeyRef.Name, configVar.ConfigMapKeyRef.Namespace, configVar.ConfigMapKeyRef.Key)

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -116,40 +116,60 @@ func (cvr *ConfigVarResolver) GetConfigVarStringValueOrEnv(configVar providercon
 	return envVal, nil
 }
 
-func (cvr *ConfigVarResolver) GetConfigVarBoolValue(configVar providerconfigtypes.ConfigVarBool) (bool, error) {
-	cvs := providerconfigtypes.ConfigVarString{Value: strconv.FormatBool(configVar.Value), SecretKeyRef: configVar.SecretKeyRef}
-	stringVal, err := cvr.GetConfigVarStringValue(cvs)
-	if err != nil {
-		return false, err
+// GetConfigVarBoolValue returns a boolean from a ConfigVarBool. If there is no valid source for the boolean,
+// the second bool returned will be false (to be able to differentiate between "false" and "unset")
+func (cvr *ConfigVarResolver) GetConfigVarBoolValue(configVar providerconfigtypes.ConfigVarBool) (bool, bool, error) {
+	// We need all three of these to fetch and use a secret
+	if configVar.SecretKeyRef.Name != "" && configVar.SecretKeyRef.Namespace != "" && configVar.SecretKeyRef.Key != "" {
+		secret := &corev1.Secret{}
+		name := types.NamespacedName{Namespace: configVar.SecretKeyRef.Namespace, Name: configVar.SecretKeyRef.Name}
+		if err := cvr.client.Get(cvr.ctx, name, secret); err != nil {
+			return false, false, fmt.Errorf("error retrieving secret '%s' from namespace '%s': '%v'", configVar.SecretKeyRef.Name, configVar.SecretKeyRef.Namespace, err)
+		}
+		if val, ok := secret.Data[configVar.SecretKeyRef.Key]; ok {
+			boolVal, err := strconv.ParseBool(string(val))
+			return boolVal, (err == nil), err
+		}
+		return false, false, fmt.Errorf("secret '%s' in namespace '%s' has no key '%s'", configVar.SecretKeyRef.Name, configVar.SecretKeyRef.Namespace, configVar.SecretKeyRef.Key)
 	}
-	boolVal, err := strconv.ParseBool(stringVal)
-	if err != nil {
-		return false, err
+
+	// We need all three of these to fetch and use a configmap
+	if configVar.ConfigMapKeyRef.Name != "" && configVar.ConfigMapKeyRef.Namespace != "" && configVar.ConfigMapKeyRef.Key != "" {
+		configMap := &corev1.ConfigMap{}
+		name := types.NamespacedName{Namespace: configVar.ConfigMapKeyRef.Namespace, Name: configVar.ConfigMapKeyRef.Name}
+		if err := cvr.client.Get(cvr.ctx, name, configMap); err != nil {
+			return false, false, fmt.Errorf("error retrieving configmap '%s' from namespace '%s': '%v'", configVar.ConfigMapKeyRef.Name, configVar.ConfigMapKeyRef.Namespace, err)
+		}
+		if val, ok := configMap.Data[configVar.ConfigMapKeyRef.Key]; ok {
+			boolVal, err := strconv.ParseBool(string(val))
+			return boolVal, (err == nil), err
+		}
+		return false, false, fmt.Errorf("configmap '%s' in namespace '%s' has no key '%s'", configVar.ConfigMapKeyRef.Name, configVar.ConfigMapKeyRef.Namespace, configVar.ConfigMapKeyRef.Key)
 	}
-	return boolVal, nil
+
+	if !configVar.Valid {
+		return false, false, nil
+	}
+
+	return configVar.Value, true, nil
 }
 
 func (cvr *ConfigVarResolver) GetConfigVarBoolValueOrEnv(configVar providerconfigtypes.ConfigVarBool, envVarName string) (bool, error) {
-	cvs := providerconfigtypes.ConfigVarString{Value: strconv.FormatBool(configVar.Value), SecretKeyRef: configVar.SecretKeyRef}
-	stringVal, err := cvr.GetConfigVarStringValue(cvs)
-	if err != nil {
-		return false, err
+	boolVal, valid, err := cvr.GetConfigVarBoolValue(configVar)
+	if valid && err == nil {
+		return boolVal, nil
 	}
 
-	// if stringVar is "false", it might have been not set and we can attempt to read from environment.
-	// if it is "true", we know it was configured via value or secret reference.
-	if stringVal == "" || stringVal == strconv.FormatBool(false) {
-		envVal, envValFound := os.LookupEnv(envVarName)
-		if envValFound {
-			stringVal = envVal
+	envVal, envValFound := os.LookupEnv(envVarName)
+	if envValFound {
+		envValBool, err := strconv.ParseBool(envVal)
+		if err != nil {
+			return false, err
 		}
+		return envValBool, nil
 	}
 
-	boolVal, err := strconv.ParseBool(stringVal)
-	if err != nil {
-		return false, err
-	}
-	return boolVal, nil
+	return false, nil
 }
 
 func NewConfigVarResolver(ctx context.Context, client ctrlruntimeclient.Client) *ConfigVarResolver {

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 
@@ -287,11 +286,12 @@ func (configVarBool ConfigVarBool) MarshalJSON() ([]byte, error) {
 
 func (configVarBool *ConfigVarBool) UnmarshalJSON(b []byte) error {
 	if !bytes.HasPrefix(b, []byte("{")) {
-		value, err := strconv.ParseBool(string(b))
-		if err != nil {
-			return fmt.Errorf("Error converting string to bool: '%v'", err)
+		var val *bool
+		if err := json.Unmarshal(b, &val); err != nil {
+			return fmt.Errorf("Error parsing value: '%v'", err)
 		}
-		configVarBool.Value = &value
+		configVarBool.Value = val
+
 		return nil
 	}
 

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -250,9 +250,9 @@ func (configVarBool ConfigVarBool) MarshalJSON() ([]byte, error) {
 	if secretKeyRefEmpty && configMapKeyRefEmpty {
 		if configVarBool.Valid {
 			return []byte(fmt.Sprintf("%v", configVarBool.Value)), nil
-		} else {
-			return []byte{}, nil
 		}
+
+		return []byte{}, nil
 	}
 
 	buffer := bytes.NewBufferString("{")
@@ -286,15 +286,15 @@ func (configVarBool *ConfigVarBool) UnmarshalJSON(b []byte) error {
 		if string(b) == "" {
 			configVarBool.Valid = false
 			return nil
-		} else {
-			value, err := strconv.ParseBool(string(b))
-			if err != nil {
-				return fmt.Errorf("Error converting string to bool: '%v'", err)
-			}
-			configVarBool.Value = value
-			configVarBool.Valid = true
-			return nil
 		}
+
+		value, err := strconv.ParseBool(string(b))
+		if err != nil {
+			return fmt.Errorf("Error converting string to bool: '%v'", err)
+		}
+		configVarBool.Value = value
+		configVarBool.Valid = true
+		return nil
 	}
 	var cvbDummy configVarBoolWithoutUnmarshaller
 	err := json.Unmarshal(b, &cvbDummy)

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -247,7 +247,10 @@ func (configVarBool ConfigVarBool) MarshalJSON() ([]byte, error) {
 	}
 
 	if secretKeyRefEmpty && configMapKeyRefEmpty {
-		jsonVal, _ := json.Marshal(configVarBool.Value)
+		jsonVal, err := json.Marshal(configVarBool.Value)
+		if err != nil {
+			return []byte{}, err
+		}
 		return []byte(fmt.Sprintf("%v", string(jsonVal))), nil
 	}
 
@@ -272,7 +275,11 @@ func (configVarBool ConfigVarBool) MarshalJSON() ([]byte, error) {
 		buffer.WriteString(fmt.Sprintf(`%s"configMapKeyRef":%s`, leadingComma, jsonVal))
 	}
 
-	jsonVal, _ := json.Marshal(configVarBool.Value)
+	jsonVal, err := json.Marshal(configVarBool.Value)
+	if err != nil {
+		return []byte{}, err
+	}
+
 	buffer.WriteString(fmt.Sprintf(`,"value":%v}`, string(jsonVal)))
 
 	return buffer.Bytes(), nil

--- a/pkg/providerconfig/types/types_test.go
+++ b/pkg/providerconfig/types/types_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
 )
 
 func TestConfigVarStringUnmarshalling(t *testing.T) {
@@ -48,7 +49,7 @@ func TestConfigVarBoolUnmarshalling(t *testing.T) {
 	jsonBool := []byte("true")
 	jsonMapBool := []byte(`{"value":true}`)
 
-	expectedResult := ConfigVarBool{Value: true}
+	expectedResult := ConfigVarBool{Value: pointer.Bool(true)}
 
 	var jsonBoolTarget ConfigVarBool
 	var jsonMapBoolTarget ConfigVarBool
@@ -97,12 +98,12 @@ func TestConfigVarBoolMarshalling(t *testing.T) {
 		expected string
 	}{
 		{
-			cvb:      ConfigVarBool{Value: true},
+			cvb:      ConfigVarBool{Value: pointer.Bool(true)},
 			expected: `true`,
 		},
 		{
 			cvb:      ConfigVarBool{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
-			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"},"value":false}`,
+			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"},"value":null}`,
 		},
 	}
 
@@ -155,17 +156,17 @@ func TestConfigVarStringMarshallingAndUnmarshalling(t *testing.T) {
 func TestConfigVarBoolMarshallingAndUnmarshalling(t *testing.T) {
 
 	testCases := []ConfigVarBool{
-		{Value: true},
+		{Value: pointer.Bool(true)},
 		{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
-		{Value: true, SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		{Value: pointer.Bool(true), SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
 		{ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
-		{Value: true, ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		{Value: pointer.Bool(true), ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
 		{
 			ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
 			SecretKeyRef:    GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
 		},
 		{
-			Value:           true,
+			Value:           pointer.Bool(true),
 			ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
 			SecretKeyRef:    GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
`GetConfigVarBoolValueOrEnv` never read the environment variable it was passed, as `stringVal` was always `"false"` when no value was passed (`configVar.Value` is a bool and defaults to `false` if not set), but the condition to read the env variable was `stringVal == ""`. This must be a pretty old bug as this code was introduced 4 years ago, but it was only ever used in `VSPHERE_ALLOW_INSECURE`, which is not in use in KKP for whatever reason.

This PR reworks the `ConfigVarBool` functions to make sure we can differentiate between an unset value and `false`.

This is needed as it also breaks `NUTANIX_ALLOW_INSECURE`, which is used in https://github.com/kubermatic/kubermatic/pull/8448.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix not reading bool configuration values from environment (VSPHERE_ALLOW_INSECURE and NUTANIX_INSECURE)
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
