### PR TITLE
Rename NUTANIX_ALLOW_INSECURE to NUTANIX_INSECURE

### DIFF
--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -150,7 +150,7 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		return nil, nil, nil, err
 	}
 
-	c.AllowInsecure, err = p.configVarResolver.GetConfigVarBoolValueOrEnv(rawConfig.AllowInsecure, "NUTANIX_ALLOW_INSECURE")
+	c.AllowInsecure, err = p.configVarResolver.GetConfigVarBoolValueOrEnv(rawConfig.AllowInsecure, "NUTANIX_INSECURE")
 	if err != nil {
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR renames the `NUTANIX_ALLOW_INSECURE` environment variable to `NUTANIX_INSECURE`. [Terraform is using `NUTANIX_INSECURE`](https://registry.terraform.io/providers/nutanix/nutanix/latest/docs#argument-reference), so I think it would be nice to try to match environment variables used by Terraform. That would also make integration with KubeOne easier.

**Optional Release Note**:
```release-note
Rename NUTANIX_ALLOW_INSECURE environment variable to NUTANIX_INSECURE
```

/assign @embik 
/hold
to discuss