### PR TITLE
add bootstrap kubeconfig to the osm bootstraping

### DIFF
--- a/pkg/controller/machine/bootstrap.go
+++ b/pkg/controller/machine/bootstrap.go
@@ -31,6 +31,7 @@ import (
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"github.com/kubermatic/machine-controller/pkg/userdata/convert"
 	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
+	"github.com/kubermatic/machine-controller/pkg/userdata/helper"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -55,14 +56,14 @@ func getOSMBootstrapUserdata(ctx context.Context, client ctrlruntimeclient.Clien
 
 	// Ignition configuration is used for flatcar
 	if useIgnition(pconfig) {
-		return getOSMBootstrapUserDataForIgnition(ctx, req, pconfig.SSHPublicKeys, token, secretName, clusterName)
+		return getOSMBootstrapUserDataForIgnition(req, pconfig.SSHPublicKeys, token, secretName, clusterName)
 	}
 	// cloud-init is used for all other operating systems
-	return getOSMBootstrapUserDataForCloudInit(ctx, req, pconfig, token, secretName, clusterName)
+	return getOSMBootstrapUserDataForCloudInit(req, pconfig, token, secretName, clusterName)
 }
 
 // getOSMBootstrapUserDataForIgnition returns the userdata for the ignition bootstrap config
-func getOSMBootstrapUserDataForIgnition(ctx context.Context, req plugin.UserDataRequest, sshPublicKeys []string, token, secretName, clusterName string) (string, error) {
+func getOSMBootstrapUserDataForIgnition(req plugin.UserDataRequest, sshPublicKeys []string, token, secretName, clusterName string) (string, error) {
 	data := struct {
 		Token      string
 		SecretName string
@@ -106,7 +107,7 @@ func getOSMBootstrapUserDataForIgnition(ctx context.Context, req plugin.UserData
 }
 
 // getOSMBootstrapUserDataForCloudInit returns the userdata for the cloud-init bootstrap script
-func getOSMBootstrapUserDataForCloudInit(ctx context.Context, req plugin.UserDataRequest, pconfig *providerconfigtypes.Config, token, secretName, clusterName string) (string, error) {
+func getOSMBootstrapUserDataForCloudInit(req plugin.UserDataRequest, pconfig *providerconfigtypes.Config, token, secretName, clusterName string) (string, error) {
 	data := struct {
 		Token           string
 		SecretName      string
@@ -166,17 +167,24 @@ func getOSMBootstrapUserDataForCloudInit(ctx context.Context, req plugin.UserDat
 		return "", fmt.Errorf("failed to parse download-binaries template: %v", err)
 	}
 
+	bootstrapKubeconfig, err := helper.StringifyKubeconfig(req.Kubeconfig)
+	if err != nil {
+		return "", fmt.Errorf("failed to format bootstrap kubeconfig: %v", err)
+	}
+
 	cloudInit := &bytes.Buffer{}
 	err = bsCloudInit.Execute(cloudInit, struct {
 		Script  string
 		Service string
 		plugin.UserDataRequest
-		ProviderSpec *providerconfigtypes.Config
+		ProviderSpec        *providerconfigtypes.Config
+		BootstrapKubeconfig string
 	}{
-		Script:          base64.StdEncoding.EncodeToString(script.Bytes()),
-		Service:         base64.StdEncoding.EncodeToString([]byte(bootstrapServiceContentTemplate)),
-		UserDataRequest: req,
-		ProviderSpec:    pconfig,
+		Script:              base64.StdEncoding.EncodeToString(script.Bytes()),
+		Service:             base64.StdEncoding.EncodeToString([]byte(bootstrapServiceContentTemplate)),
+		UserDataRequest:     req,
+		ProviderSpec:        pconfig,
+		BootstrapKubeconfig: base64.StdEncoding.EncodeToString([]byte(bootstrapKubeconfig)),
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to execute cloudInitTemplate template: %v", err)
@@ -293,6 +301,11 @@ write_files:
   encoding: b64
   content: |
     {{ .Script }}
+- path: /etc/kubernetes/bootstrap-kubelet.conf
+  permissions: '0600'
+  encoding: b64
+  content: | 
+    {{ .BootstrapKubeconfig }}
 - path: /etc/systemd/system/bootstrap.service
   permissions: '0644'
   encoding: b64
@@ -331,6 +344,12 @@ reboot
 {{- end }}
 storage:
   files:
+  - path: /etc/kubernetes/bootstrap-kubelet.conf
+    mode: 0600
+    filesystem: root
+    contents:
+      inline: |
+      {{ .BootstrapKubeconfig }}
   - path: /opt/bin/bootstrap
     mode: 0755
     filesystem: root


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubelet bootstrap kubeconfig is generated per machine, thus it is bounded to the machine resource not to the machine deployment resource. OSM handles requests per machine deployment, thus we need to move the bootstrap kubeconfig to the machine controller at this point. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
