### PR TITLE
Differentiate CloudProviderName and KubeletCloudProviderName in templates

### DIFF
--- a/pkg/apis/plugin/plugin.go
+++ b/pkg/apis/plugin/plugin.go
@@ -41,20 +41,21 @@ const (
 
 // UserDataRequest requests user data with the given arguments.
 type UserDataRequest struct {
-	MachineSpec           clusterv1alpha1.MachineSpec
-	Kubeconfig            *clientcmdapi.Config
-	CloudProviderName     string
-	CloudConfig           string
-	DNSIPs                []net.IP
-	ExternalCloudProvider bool
-	HTTPProxy             string
-	NoProxy               string
-	PauseImage            string
-	KubeletFeatureGates   map[string]bool
-	KubeletConfigs        map[string]string
-	ContainerRuntime      containerruntime.Config
-	PodCIDR               string
-	NodePortRange         string
+	MachineSpec              clusterv1alpha1.MachineSpec
+	Kubeconfig               *clientcmdapi.Config
+	CloudProviderName        string
+	CloudConfig              string
+	DNSIPs                   []net.IP
+	ExternalCloudProvider    bool
+	HTTPProxy                string
+	NoProxy                  string
+	PauseImage               string
+	KubeletCloudProviderName string
+	KubeletFeatureGates      map[string]bool
+	KubeletConfigs           map[string]string
+	ContainerRuntime         containerruntime.Config
+	PodCIDR                  string
+	NodePortRange            string
 }
 
 // UserDataResponse contains the responded user data.

--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -702,7 +702,7 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 				return nil, fmt.Errorf("failed to create bootstrap kubeconfig: %v", err)
 			}
 
-			cloudConfig, cloudProviderName, err := prov.GetCloudConfig(machine.Spec)
+			cloudConfig, kubeletCloudProviderName, err := prov.GetCloudConfig(machine.Spec)
 			if err != nil {
 				return nil, fmt.Errorf("failed to render cloud config: %v", err)
 			}
@@ -746,20 +746,21 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 			crRuntime.RegistryCredentials = registryCredentials
 
 			req := plugin.UserDataRequest{
-				MachineSpec:           machine.Spec,
-				Kubeconfig:            kubeconfig,
-				CloudConfig:           cloudConfig,
-				CloudProviderName:     cloudProviderName,
-				ExternalCloudProvider: externalCloudProvider,
-				DNSIPs:                r.nodeSettings.ClusterDNSIPs,
-				PauseImage:            r.nodeSettings.PauseImage,
-				KubeletFeatureGates:   kubeletFeatureGates,
-				KubeletConfigs:        KubeletConfigs,
-				NoProxy:               r.nodeSettings.NoProxy,
-				HTTPProxy:             r.nodeSettings.HTTPProxy,
-				ContainerRuntime:      crRuntime,
-				PodCIDR:               r.podCIDR,
-				NodePortRange:         r.nodePortRange,
+				MachineSpec:              machine.Spec,
+				Kubeconfig:               kubeconfig,
+				CloudConfig:              cloudConfig,
+				CloudProviderName:        string(providerConfig.CloudProvider),
+				ExternalCloudProvider:    externalCloudProvider,
+				DNSIPs:                   r.nodeSettings.ClusterDNSIPs,
+				PauseImage:               r.nodeSettings.PauseImage,
+				KubeletCloudProviderName: kubeletCloudProviderName,
+				KubeletFeatureGates:      kubeletFeatureGates,
+				KubeletConfigs:           KubeletConfigs,
+				NoProxy:                  r.nodeSettings.NoProxy,
+				HTTPProxy:                r.nodeSettings.HTTPProxy,
+				ContainerRuntime:         crRuntime,
+				PodCIDR:                  r.podCIDR,
+				NodePortRange:            r.nodePortRange,
 			}
 
 			// Here we do stuff!

--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -246,7 +246,7 @@ write_files:
 
 - path: "/etc/systemd/system/kubelet.service"
   content: |
-{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
+{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
 
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"

--- a/pkg/userdata/amzn2/provider_test.go
+++ b/pkg/userdata/amzn2/provider_test.go
@@ -241,16 +241,17 @@ func TestUserDataGeneration(t *testing.T) {
 			}
 
 			req := plugin.UserDataRequest{
-				MachineSpec:           test.spec,
-				Kubeconfig:            kubeconfig,
-				CloudConfig:           cloudConfig,
-				CloudProviderName:     cloudProviderName,
-				DNSIPs:                test.clusterDNSIPs,
-				ExternalCloudProvider: test.externalCloudProvider,
-				HTTPProxy:             test.httpProxy,
-				NoProxy:               test.noProxy,
-				PauseImage:            test.pauseImage,
-				KubeletFeatureGates:   kubeletFeatureGates,
+				MachineSpec:              test.spec,
+				Kubeconfig:               kubeconfig,
+				CloudConfig:              cloudConfig,
+				CloudProviderName:        cloudProviderName,
+				KubeletCloudProviderName: cloudProviderName,
+				DNSIPs:                   test.clusterDNSIPs,
+				ExternalCloudProvider:    test.externalCloudProvider,
+				HTTPProxy:                test.httpProxy,
+				NoProxy:                  test.noProxy,
+				PauseImage:               test.pauseImage,
+				KubeletFeatureGates:      kubeletFeatureGates,
 				ContainerRuntime: containerruntime.Get(
 					test.containerruntime,
 					containerruntime.WithInsecureRegistries(test.insecureRegistries),

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -246,7 +246,7 @@ write_files:
 
 - path: "/etc/systemd/system/kubelet.service"
   content: |
-{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
+{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
 
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"

--- a/pkg/userdata/centos/provider_test.go
+++ b/pkg/userdata/centos/provider_test.go
@@ -241,16 +241,17 @@ func TestUserDataGeneration(t *testing.T) {
 			}
 
 			req := plugin.UserDataRequest{
-				MachineSpec:           test.spec,
-				Kubeconfig:            kubeconfig,
-				CloudConfig:           cloudConfig,
-				CloudProviderName:     cloudProviderName,
-				DNSIPs:                test.clusterDNSIPs,
-				ExternalCloudProvider: test.externalCloudProvider,
-				HTTPProxy:             test.httpProxy,
-				NoProxy:               test.noProxy,
-				PauseImage:            test.pauseImage,
-				KubeletFeatureGates:   kubeletFeatureGates,
+				MachineSpec:              test.spec,
+				Kubeconfig:               kubeconfig,
+				CloudConfig:              cloudConfig,
+				CloudProviderName:        cloudProviderName,
+				KubeletCloudProviderName: cloudProviderName,
+				DNSIPs:                   test.clusterDNSIPs,
+				ExternalCloudProvider:    test.externalCloudProvider,
+				HTTPProxy:                test.httpProxy,
+				NoProxy:                  test.noProxy,
+				PauseImage:               test.pauseImage,
+				KubeletFeatureGates:      kubeletFeatureGates,
 				ContainerRuntime: containerruntime.Get(
 					test.containerruntime,
 					containerruntime.WithInsecureRegistries(test.insecureRegistries),

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -252,7 +252,7 @@ systemd:
           Requires=download-script.service
           After=download-script.service
       contents: |
-{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 8 }}
+{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 8 }}
 
 storage:
   files:
@@ -520,7 +520,7 @@ coreos:
         Requires=download-script.service
         After=download-script.service
     content: |
-{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 6 }}
+{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 6 }}
 
   - name: apply-sysctl-settings.service
     enable: true

--- a/pkg/userdata/flatcar/provider_test.go
+++ b/pkg/userdata/flatcar/provider_test.go
@@ -421,16 +421,17 @@ func TestUserDataGeneration(t *testing.T) {
 			}
 
 			req := plugin.UserDataRequest{
-				MachineSpec:           test.spec,
-				Kubeconfig:            kubeconfig,
-				CloudConfig:           cloudConfig,
-				CloudProviderName:     cloudProviderName,
-				DNSIPs:                test.DNSIPs,
-				ExternalCloudProvider: test.externalCloudProvider,
-				HTTPProxy:             test.httpProxy,
-				NoProxy:               test.noProxy,
-				PauseImage:            test.pauseImage,
-				KubeletFeatureGates:   kubeletFeatureGates,
+				MachineSpec:              test.spec,
+				Kubeconfig:               kubeconfig,
+				CloudConfig:              cloudConfig,
+				CloudProviderName:        cloudProviderName,
+				KubeletCloudProviderName: cloudProviderName,
+				DNSIPs:                   test.DNSIPs,
+				ExternalCloudProvider:    test.externalCloudProvider,
+				HTTPProxy:                test.httpProxy,
+				NoProxy:                  test.noProxy,
+				PauseImage:               test.pauseImage,
+				KubeletFeatureGates:      kubeletFeatureGates,
 				ContainerRuntime: containerruntime.Get(
 					test.containerruntime,
 					containerruntime.WithInsecureRegistries(test.insecureRegistries),

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -258,7 +258,7 @@ write_files:
 
 - path: "/etc/systemd/system/kubelet.service"
   content: |
-{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
+{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
 
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"

--- a/pkg/userdata/rhel/provider_test.go
+++ b/pkg/userdata/rhel/provider_test.go
@@ -241,16 +241,17 @@ func TestUserDataGeneration(t *testing.T) {
 			}
 
 			req := plugin.UserDataRequest{
-				MachineSpec:           test.spec,
-				Kubeconfig:            kubeconfig,
-				CloudConfig:           cloudConfig,
-				CloudProviderName:     cloudProviderName,
-				DNSIPs:                test.clusterDNSIPs,
-				ExternalCloudProvider: test.externalCloudProvider,
-				HTTPProxy:             test.httpProxy,
-				NoProxy:               test.noProxy,
-				PauseImage:            test.pauseImage,
-				KubeletFeatureGates:   kubeletFeatureGates,
+				MachineSpec:              test.spec,
+				Kubeconfig:               kubeconfig,
+				CloudConfig:              cloudConfig,
+				CloudProviderName:        cloudProviderName,
+				KubeletCloudProviderName: cloudProviderName,
+				DNSIPs:                   test.clusterDNSIPs,
+				ExternalCloudProvider:    test.externalCloudProvider,
+				HTTPProxy:                test.httpProxy,
+				NoProxy:                  test.noProxy,
+				PauseImage:               test.pauseImage,
+				KubeletFeatureGates:      kubeletFeatureGates,
 				ContainerRuntime: containerruntime.Get(
 					test.containerruntime,
 					containerruntime.WithInsecureRegistries(test.insecureRegistries),

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -202,7 +202,7 @@ write_files:
 
 - path: "/etc/systemd/system/kubelet.service"
   content: |
-{{ kubeletSystemdUnit .ContainerRuntime.String .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
+{{ kubeletSystemdUnit .ContainerRuntime.String .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
 
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |

--- a/pkg/userdata/sles/provider_test.go
+++ b/pkg/userdata/sles/provider_test.go
@@ -438,16 +438,17 @@ func TestUserDataGeneration(t *testing.T) {
 			}
 
 			req := plugin.UserDataRequest{
-				MachineSpec:           test.spec,
-				Kubeconfig:            kubeconfig,
-				CloudConfig:           cloudConfig,
-				CloudProviderName:     cloudProviderName,
-				DNSIPs:                test.DNSIPs,
-				ExternalCloudProvider: test.externalCloudProvider,
-				HTTPProxy:             test.httpProxy,
-				NoProxy:               test.noProxy,
-				PauseImage:            test.pauseImage,
-				KubeletFeatureGates:   kubeletFeatureGates,
+				MachineSpec:              test.spec,
+				Kubeconfig:               kubeconfig,
+				CloudConfig:              cloudConfig,
+				CloudProviderName:        cloudProviderName,
+				KubeletCloudProviderName: cloudProviderName,
+				DNSIPs:                   test.DNSIPs,
+				ExternalCloudProvider:    test.externalCloudProvider,
+				HTTPProxy:                test.httpProxy,
+				NoProxy:                  test.noProxy,
+				PauseImage:               test.pauseImage,
+				KubeletFeatureGates:      kubeletFeatureGates,
 				ContainerRuntime: containerruntime.Get(
 					test.containerruntime,
 					containerruntime.WithInsecureRegistries(test.insecureRegistries),

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -247,7 +247,7 @@ write_files:
 
 - path: "/etc/systemd/system/kubelet.service"
   content: |
-{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .CloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
+{{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .PauseImage .MachineSpec.Taints .ExtraKubeletFlags | indent 4 }}
 
 - path: "/etc/systemd/system/kubelet.service.d/extras.conf"
   content: |

--- a/pkg/userdata/ubuntu/provider_test.go
+++ b/pkg/userdata/ubuntu/provider_test.go
@@ -474,16 +474,17 @@ func TestUserDataGeneration(t *testing.T) {
 			}
 
 			req := plugin.UserDataRequest{
-				MachineSpec:           test.spec,
-				Kubeconfig:            kubeconfig,
-				CloudConfig:           cloudConfig,
-				CloudProviderName:     cloudProviderName,
-				DNSIPs:                test.DNSIPs,
-				ExternalCloudProvider: test.externalCloudProvider,
-				HTTPProxy:             test.httpProxy,
-				NoProxy:               test.noProxy,
-				PauseImage:            test.pauseImage,
-				KubeletFeatureGates:   kubeletFeatureGates,
+				MachineSpec:              test.spec,
+				Kubeconfig:               kubeconfig,
+				CloudConfig:              cloudConfig,
+				CloudProviderName:        cloudProviderName,
+				KubeletCloudProviderName: cloudProviderName,
+				DNSIPs:                   test.DNSIPs,
+				ExternalCloudProvider:    test.externalCloudProvider,
+				HTTPProxy:                test.httpProxy,
+				NoProxy:                  test.noProxy,
+				PauseImage:               test.pauseImage,
+				KubeletFeatureGates:      kubeletFeatureGates,
 				ContainerRuntime: containerruntime.Get(
 					test.containerruntime,
 					containerruntime.WithInsecureRegistries(test.insecureRegistries),


### PR DESCRIPTION
**What this PR does / why we need it**:

We currently use the `CloudProviderName` field in templates for:

* the `--cloud-provider` flag in the Kubelet service
* running commands only for some provider(s)

However, `CloudProviderName` contains the value returned by `GetCloudConfig` function. This function returns the cloud provider name used by Kubelet, and only if the provider has an in-tree cloud provider implementation (in-tree CCM). In other words, `CloudProviderName` will be empty on providers such as Nutanix, DigitalOcean, Hetzner, etc...

We encountered the issue when we tried to install some packages only on Nutanix machines in #1161. Because Nutanix doesn't have in-tree CCM, `.CloudProviderName` is empty, and the Nutanix-specific logic is not executed.  Therefore, this PR is a prerequisite for #1161.

This issue is fixed by differentiating `CloudProviderName` and `KubeletCloudProviderName`:

* `CloudProviderName` is `providerConfig.CloudProvider`. It's used in templates when we want to run cloud-provider-specific logic (e.g. install some packages only for one provider)
* `KubeletCloudProviderName` is from `GetCloudConfig). It's passed to Kubelet via `--cloud-provider` flag

**Optional Release Note**:
```release-note
Differentiate CloudProviderName and KubeletCloudProviderName in templates
```

/assign @embik @moadqassem @ahmedwaleedmalik 