### PR TITLE
set the machine_controller_workers metric to an actual value

### DIFF
--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -216,6 +216,8 @@ func Add(
 		return err
 	}
 
+	metrics.Workers.Set(float64(numWorkers))
+
 	return c.Watch(
 		&source.Kind{Type: &corev1.Node{}},
 		handler.EnqueueRequestsFromMapFunc(func(node client.Object) (result []reconcile.Request) {


### PR DESCRIPTION
**What this PR does / why we need it**:
We define a metric but have not set its value since refactoring the MC to use controller-runtime in #592. This PR restores setting the metric value.

**Optional Release Note**:
```release-note
Fix machine_controller_workers metric always being 0.
```
