### PR TITLE
Omit null value from marshalled JSON for ConfigVarBool

### DIFF
--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -250,7 +250,7 @@ func (configVarBool ConfigVarBool) MarshalJSON() ([]byte, error) {
 		if err != nil {
 			return []byte{}, err
 		}
-		return []byte(fmt.Sprintf("%v", string(jsonVal))), nil
+		return jsonVal, nil
 	}
 
 	buffer := bytes.NewBufferString("{")
@@ -274,12 +274,16 @@ func (configVarBool ConfigVarBool) MarshalJSON() ([]byte, error) {
 		buffer.WriteString(fmt.Sprintf(`%s"configMapKeyRef":%s`, leadingComma, jsonVal))
 	}
 
-	jsonVal, err := json.Marshal(configVarBool.Value)
-	if err != nil {
-		return []byte{}, err
+	if configVarBool.Value != nil {
+		jsonVal, err := json.Marshal(configVarBool.Value)
+		if err != nil {
+			return []byte{}, err
+		}
+
+		buffer.WriteString(fmt.Sprintf(`,"value":%v`, string(jsonVal)))
 	}
 
-	buffer.WriteString(fmt.Sprintf(`,"value":%v}`, string(jsonVal)))
+	buffer.WriteString("}")
 
 	return buffer.Bytes(), nil
 }

--- a/pkg/providerconfig/types/types_test.go
+++ b/pkg/providerconfig/types/types_test.go
@@ -46,21 +46,50 @@ func TestConfigVarStringUnmarshalling(t *testing.T) {
 }
 
 func TestConfigVarBoolUnmarshalling(t *testing.T) {
-	jsonBool := []byte("true")
-	jsonMapBool := []byte(`{"value":true}`)
-
-	expectedResult := ConfigVarBool{Value: pointer.Bool(true)}
-
-	var jsonBoolTarget ConfigVarBool
-	var jsonMapBoolTarget ConfigVarBool
-
-	err := json.Unmarshal(jsonBool, &jsonBoolTarget)
-	if err != nil || !reflect.DeepEqual(expectedResult, jsonBoolTarget) {
-		t.Fatalf("Decoding raw bool into configVarBool failed! Error: '%v'", err)
+	testCases := []struct {
+		jsonString string
+		expected   ConfigVarBool
+	}{
+		{
+			jsonString: "true",
+			expected:   ConfigVarBool{Value: pointer.Bool(true)},
+		},
+		{
+			jsonString: `{"value":true}`,
+			expected:   ConfigVarBool{Value: pointer.Bool(true)},
+		},
+		{
+			jsonString: "null",
+			expected:   ConfigVarBool{},
+		},
+		{
+			jsonString: `{"value":null}`,
+			expected:   ConfigVarBool{},
+		},
+		{
+			jsonString: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"}}`,
+			expected:   ConfigVarBool{Value: nil, SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		},
+		{
+			jsonString: `{"value": null, "secretKeyRef":{"namespace":"ns","name":"name","key":"key"}}`,
+			expected:   ConfigVarBool{Value: nil, SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		},
+		{
+			jsonString: `{"value":false, "secretKeyRef":{"namespace":"ns","name":"name","key":"key"}}`,
+			expected:   ConfigVarBool{Value: pointer.Bool(false), SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		},
+		{
+			jsonString: `{"value":true, "secretKeyRef":{"namespace":"ns","name":"name","key":"key"}}`,
+			expected:   ConfigVarBool{Value: pointer.Bool(true), SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
+		},
 	}
-	err = json.Unmarshal(jsonMapBool, &jsonMapBoolTarget)
-	if err != nil || !reflect.DeepEqual(expectedResult, jsonMapBoolTarget) {
-		t.Fatalf("Decoding map bool into configVarBool failed! Error: '%v'", err)
+
+	for _, testCase := range testCases {
+		var cvb ConfigVarBool
+		err := json.Unmarshal([]byte(testCase.jsonString), &cvb)
+		if err != nil || !reflect.DeepEqual(testCase.expected, cvb) {
+			t.Fatalf("Decoding '%s' into configVarBool failed! Error: '%v'", testCase.jsonString, err)
+		}
 	}
 }
 
@@ -98,12 +127,24 @@ func TestConfigVarBoolMarshalling(t *testing.T) {
 		expected string
 	}{
 		{
+			cvb:      ConfigVarBool{},
+			expected: `null`,
+		},
+		{
 			cvb:      ConfigVarBool{Value: pointer.Bool(true)},
 			expected: `true`,
 		},
 		{
 			cvb:      ConfigVarBool{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
-			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"},"value":null}`,
+			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"}}`,
+		},
+		{
+			cvb:      ConfigVarBool{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}, Value: pointer.Bool(true)},
+			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"},"value":true}`,
+		},
+		{
+			cvb:      ConfigVarBool{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}, Value: pointer.Bool(false)},
+			expected: `{"secretKeyRef":{"namespace":"ns","name":"name","key":"key"},"value":false}`,
 		},
 	}
 
@@ -156,6 +197,8 @@ func TestConfigVarStringMarshallingAndUnmarshalling(t *testing.T) {
 func TestConfigVarBoolMarshallingAndUnmarshalling(t *testing.T) {
 
 	testCases := []ConfigVarBool{
+		{},
+		{Value: pointer.Bool(false)},
 		{Value: pointer.Bool(true)},
 		{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
 		{Value: pointer.Bool(true), SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},


### PR DESCRIPTION
**What this PR does / why we need it**:
Small refinement for the initial PR #1154 that changed `ConfigVarBool`. This slims down the JSON generated by `MarshalJSON` if the value is unset.

Also adds more tests to make sure my changes are capable of handling various input.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
