### PR TITLE
update machine controller openstack rhel image

### DIFF
--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -51,7 +51,7 @@ var (
 	openStackImages = map[string]string{
 		string(providerconfigtypes.OperatingSystemUbuntu):  "machine-controller-e2e-ubuntu-20-04",
 		string(providerconfigtypes.OperatingSystemCentOS):  "machine-controller-e2e-centos",
-		string(providerconfigtypes.OperatingSystemRHEL):    "machine-controller-e2e-rhel",
+		string(providerconfigtypes.OperatingSystemRHEL):    "machine-controller-e2e-rhel-8-5",
 		string(providerconfigtypes.OperatingSystemFlatcar): "machine-controller-e2e-flatcar-stable-2983",
 	}
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
The current RHEL image on Openstack is RHEL 8.0 which had few issues. This PR updates the RHEL 8 image to the latest(8.5)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
