### PR TITLE
Make anexia provider more resilient against errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/aliyun/alibaba-cloud-sdk-go v1.61.751
-	github.com/anexia-it/go-anxcloud v0.3.8
+	github.com/anexia-it/go-anxcloud v0.3.26
 	github.com/aws/aws-sdk-go v1.36.2
 	github.com/coreos/container-linux-config-transpiler v0.9.0
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,9 @@ github.com/aliyun/alibaba-cloud-sdk-go v1.61.751 h1:PX0jCn9kBBgaybsFltpmQ8F7O74h
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.751/go.mod h1:pUKYbK5JQ+1Dfxk80P0qxGqe5dkxDoabbZS7zOcouyA=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andygrunwald/go-gerrit v0.0.0-20190120104749-174420ebee6c/go.mod h1:0iuRQp6WJ44ts+iihy5E/WlPqfg5RNeQxOmzRkxCdtk=
-github.com/anexia-it/go-anxcloud v0.3.8 h1:+ZOVqUHwINTm9Q68GPVh+Q/c794Fe+2GahIVagNLjDg=
 github.com/anexia-it/go-anxcloud v0.3.8/go.mod h1:cevqezsbOJ4GBlAWaztfLKl9w4VzxJBt4ipgHORi3gw=
+github.com/anexia-it/go-anxcloud v0.3.26 h1:uStosj8srS6OA1OsPsMJBFqd4Znzl6fEhUv8b3+G8FU=
+github.com/anexia-it/go-anxcloud v0.3.26/go.mod h1:fiEBxEtBXx78/OWBJvL7+2o4TESrnEcrDYjLeonGkDw=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -319,6 +320,7 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -1004,6 +1006,7 @@ github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
+github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
 github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
@@ -1181,7 +1184,6 @@ github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -1606,7 +1608,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1987,7 +1988,6 @@ k8s.io/api v0.19.2/go.mod h1:IQpK0zFQ1xc5iNIQPqzgoOwuFugaYHK4iCknlAQP9nI=
 k8s.io/api v0.19.4/go.mod h1:SbtJ2aHCItirzdJ36YslycFNzWADYH3tgOhvBEFtZAk=
 k8s.io/api v0.20.1/go.mod h1:KqwcCVogGxQY3nBlRpwt+wpAMF/KjaCc7RpywacvqUo=
 k8s.io/api v0.20.2/go.mod h1:d7n6Ehyzx+S+cE3VhTGfVNNqtGc/oL9DCdYYahlurV8=
-k8s.io/api v0.20.2/go.mod h1:d7n6Ehyzx+S+cE3VhTGfVNNqtGc/oL9DCdYYahlurV8=
 k8s.io/api v0.22.2 h1:M8ZzAD0V6725Fjg53fKeTJxGsJvRbk4TEm/fexHMtfw=
 k8s.io/api v0.22.2/go.mod h1:y3ydYpLJAaDI+BbSe2xmGcqxiWHmWjkEeIbiwHvnPR8=
 k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783/go.mod h1:xvae1SZB3E17UpV59AWc271W/Ph25N+bjPyR63X6tPY=
@@ -2025,7 +2025,6 @@ k8s.io/apimachinery v0.19.0/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlm
 k8s.io/apimachinery v0.19.2/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
 k8s.io/apimachinery v0.19.4/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
 k8s.io/apimachinery v0.20.1/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
-k8s.io/apimachinery v0.20.2/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
 k8s.io/apimachinery v0.20.2/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
 k8s.io/apimachinery v0.22.2 h1:ejz6y/zNma8clPVfNDLnPbleBo6MpoFy/HBiBqCouVk=
 k8s.io/apimachinery v0.22.2/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
@@ -2112,8 +2111,6 @@ k8s.io/klog/v2 v2.9.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/kube-aggregator v0.19.0/go.mod h1:1Ln45PQggFAG8xOqWPIYMxUq8WNtpPnYsbUJ39DpF/A=
 k8s.io/kube-aggregator v0.19.4/go.mod h1:cTkvun110194d797AuThyydBBlgm+cKIFUeS2uzGJfU=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd h1:sOHNzJIkytDF6qadMNKhhDRpc6ODik8lVC6nOur7B2c=
-k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd h1:sOHNzJIkytDF6qadMNKhhDRpc6ODik8lVC6nOur7B2c=
-k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kubectl v0.19.0/go.mod h1:gPCjjsmE6unJzgaUNXIFGZGafiUp5jh0If3F/x7/rRg=
 k8s.io/kubectl v0.19.4/go.mod h1:XPmlu4DJEYgD83pvZFeKF8+MSvGnYGqunbFSrJsqHv0=
@@ -2185,7 +2182,6 @@ sigs.k8s.io/structured-merge-diff v1.0.1 h1:LOs1LZWMsz1xs77Phr/pkB4LFaavH7IVq/3+
 sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
-sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=

--- a/pkg/cloudprovider/provider/anexia/helper_test.go
+++ b/pkg/cloudprovider/provider/anexia/helper_test.go
@@ -1,0 +1,74 @@
+package anexia
+
+import (
+	"encoding/json"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/search"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"k8s.io/apimachinery/pkg/runtime"
+	"net/http"
+	"testing"
+)
+
+type ConfigTestCase struct {
+	Config anxtypes.RawConfig
+	Error  error
+}
+
+type ValidateCallTestCase struct {
+	Spec          v1alpha1.MachineSpec
+	ExpectedError error
+}
+
+func getSpecsForValidationTest(t *testing.T, configCases []ConfigTestCase) []ValidateCallTestCase {
+
+	var testCases []ValidateCallTestCase
+
+	for _, configCase := range configCases {
+		jsonConfig, err := json.Marshal(configCase.Config)
+		testhelper.AssertNoErr(t, err)
+		jsonProviderConfig, err := json.Marshal(types.Config{
+			CloudProviderSpec:   runtime.RawExtension{Raw: jsonConfig},
+			OperatingSystemSpec: runtime.RawExtension{Raw: []byte("{}")},
+		})
+		testhelper.AssertNoErr(t, err)
+		testCases = append(testCases, ValidateCallTestCase{
+			Spec: v1alpha1.MachineSpec{
+				ProviderSpec: v1alpha1.ProviderSpec{
+					Value: &runtime.RawExtension{Raw: jsonProviderConfig},
+				},
+			},
+			ExpectedError: configCase.Error,
+		})
+	}
+	return testCases
+}
+
+func createSearchHandler(t *testing.T, iterations int) http.HandlerFunc {
+	counter := 0
+	return func(writer http.ResponseWriter, request *http.Request) {
+		test := request.URL.Query().Get("name")
+		testhelper.AssertEquals(t, "%-TestMachine", test)
+		testhelper.TestMethod(t, request, http.MethodGet)
+		if iterations == counter {
+			encoder := json.NewEncoder(writer)
+			testhelper.AssertNoErr(t, encoder.Encode(map[string]interface{}{
+				"data": []search.VM{
+					{
+						Name:       "543053-TestMachine",
+						Identifier: TestIdentifier,
+					},
+				},
+			}))
+		}
+		counter++
+	}
+}
+
+func newConfigVarString(str string) types.ConfigVarString {
+	return types.ConfigVarString{
+		Value: str,
+	}
+}

--- a/pkg/cloudprovider/provider/anexia/helper_test.go
+++ b/pkg/cloudprovider/provider/anexia/helper_test.go
@@ -1,15 +1,32 @@
+/*
+Copyright 2022 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package anexia
 
 import (
 	"encoding/json"
+	"net/http"
+	"testing"
+
 	"github.com/anexia-it/go-anxcloud/pkg/vsphere/search"
 	"github.com/gophercloud/gophercloud/testhelper"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8s.io/apimachinery/pkg/runtime"
-	"net/http"
-	"testing"
 )
 
 type ConfigTestCase struct {

--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -133,8 +133,7 @@ func waitForVM(ctx context.Context, client anxclient.Client) error {
 	}
 
 	reconcileContext.Status.InstanceID = identifier
-	updateMachineStatus(reconcileContext.Machine, *reconcileContext.Status, reconcileContext.ProviderData.Update)
-	return nil
+	return updateMachineStatus(reconcileContext.Machine, *reconcileContext.Status, reconcileContext.ProviderData.Update)
 }
 
 func provisionVM(ctx context.Context, client anxclient.Client) error {
@@ -205,7 +204,7 @@ func provisionVM(ctx context.Context, client anxclient.Client) error {
 
 	instanceID, err := vmAPI.Provisioning().Progress().AwaitCompletion(ctx, status.ProvisioningID)
 	if err != nil {
-		klog.Error("failed to await machine completion '%s'", reconcileContext.Machine.Name)
+		klog.Errorf("failed to await machine completion '%s'", reconcileContext.Machine.Name)
 		// something went wrong remove provisioning ID, so we can start from scratch
 		status.ProvisioningID = ""
 		return newError(common.CreateMachineError, "instance provisioning failed: %v", err)

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -1,0 +1,307 @@
+package anexia
+
+import (
+	"encoding/json"
+	"errors"
+	anxclient "github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/anexia-it/go-anxcloud/pkg/ipam/address"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/progress"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/vm"
+	"github.com/gophercloud/gophercloud/testhelper"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/utils"
+	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"net/http"
+	"testing"
+	"time"
+)
+
+const TestIdentifier = "TestIdent"
+
+func TestAnexiaProvider(t *testing.T) {
+	testhelper.SetupHTTP()
+	client, server := anxclient.NewTestClient(nil, testhelper.Mux)
+	t.Cleanup(func() {
+		testhelper.TeardownHTTP()
+		server.Close()
+	})
+
+	t.Run("Test waiting for VM", func(t *testing.T) {
+		t.Parallel()
+
+		waitUntilVMIsFound := 2
+		testhelper.Mux.HandleFunc("/api/vsphere/v1/search/by_name.json", createSearchHandler(t, waitUntilVMIsFound))
+
+		providerStatus := anxtypes.ProviderStatus{}
+		ctx := utils.CreateReconcileContext(utils.ReconcileContext{
+			Machine: &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
+			},
+			Status:   &providerStatus,
+			UserData: "",
+			Config:   &anxtypes.Config{},
+
+			ProviderData: &cloudprovidertypes.ProviderData{},
+		})
+
+		err := waitForVM(ctx, client)
+		if err != nil {
+			t.Fatal("No error was expected", err)
+
+		}
+
+		if providerStatus.InstanceID != TestIdentifier {
+			t.Errorf("Excpected InstanceID to be set")
+		}
+	})
+
+	t.Run("Test provision VM", func(t *testing.T) {
+		t.Parallel()
+		testhelper.Mux.HandleFunc("/api/ipam/v1/address/reserve/ip/count.json", func(writer http.ResponseWriter, request *http.Request) {
+			err := json.NewEncoder(writer).Encode(address.ReserveRandomSummary{
+				Data: []address.ReservedIP{
+					{
+						ID:      "IP-ID",
+						Address: "8.8.8.8",
+					},
+				},
+			})
+			testhelper.AssertNoErr(t, err)
+		})
+
+		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/vm.json/LOCATION-ID/templates/TEMPLATE-ID", func(writer http.ResponseWriter, request *http.Request) {
+			testhelper.TestMethod(t, request, http.MethodPost)
+			type jsonObject = map[string]interface{}
+			expectedJSON := map[string]interface{}{
+				"cpu_performance_type": "performance",
+				"hostname":             "TestMachine",
+				"memory_mb":            json.Number("5"),
+				"network": []jsonObject{
+					{
+						"vlan":     "VLAN-ID",
+						"nic_type": "vmxnet3",
+						"ips":      []interface{}{"8.8.8.8"},
+					},
+				},
+			}
+			var jsonBody jsonObject
+			decoder := json.NewDecoder(request.Body)
+			decoder.UseNumber()
+			testhelper.AssertNoErr(t, decoder.Decode(&jsonBody))
+			testhelper.AssertEquals(t, expectedJSON["cpu_performance_type"], jsonBody["cpu_performance_type"])
+			testhelper.AssertEquals(t, expectedJSON["hostname"], jsonBody["hostname"])
+			testhelper.AssertEquals(t, expectedJSON["memory_mb"], jsonBody["memory_mb"])
+			testhelper.AssertEquals(t, expectedJSON["count"], jsonBody["count"])
+
+			expectedNetwork := expectedJSON["network"].([]jsonObject)[0]
+			bodyNetwork := jsonBody["network"].([]interface{})[0].(jsonObject)
+			testhelper.AssertEquals(t, expectedNetwork["vlan"], bodyNetwork["vlan"])
+			testhelper.AssertEquals(t, expectedNetwork["nic_type"], bodyNetwork["nic_type"])
+			testhelper.AssertEquals(t, expectedNetwork["ips"].([]interface{})[0], bodyNetwork["ips"].([]interface{})[0])
+
+			err := json.NewEncoder(writer).Encode(vm.ProvisioningResponse{
+				Progress:   100,
+				Errors:     nil,
+				Identifier: "TEST-IDENTIFIER",
+				Queued:     false,
+			})
+			testhelper.AssertNoErr(t, err)
+		})
+
+		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/progress.json/TEST-IDENTIFIER", func(writer http.ResponseWriter, request *http.Request) {
+			testhelper.TestMethod(t, request, http.MethodGet)
+
+			err := json.NewEncoder(writer).Encode(progress.Progress{
+				TaskIdentifier: "TEST-IDENTIFIER",
+				Queued:         false,
+				Progress:       100,
+				VMIdentifier:   "VM-IDENTIFIER",
+				Errors:         nil,
+			})
+			testhelper.AssertNoErr(t, err)
+		})
+
+		providerStatus := anxtypes.ProviderStatus{}
+		ctx := utils.CreateReconcileContext(utils.ReconcileContext{
+			Machine: &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
+			},
+			Status:   &providerStatus,
+			UserData: "",
+			Config: &anxtypes.Config{
+				VlanID:     "VLAN-ID",
+				LocationID: "LOCATION-ID",
+				TemplateID: "TEMPLATE-ID",
+				CPUs:       5,
+				Memory:     5,
+				DiskSize:   5,
+			},
+			ProviderData: &cloudprovidertypes.ProviderData{},
+		})
+
+		err := provisionVM(ctx, client)
+		testhelper.AssertNoErr(t, err)
+	})
+
+	t.Run("Test is VM Provisioning", func(t *testing.T) {
+		t.Parallel()
+		providerStatus := anxtypes.ProviderStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   ProvisionedType,
+					Reason: "InProvisioning",
+					Status: metav1.ConditionFalse,
+				},
+			},
+		}
+		ctx := utils.CreateReconcileContext(utils.ReconcileContext{
+			Status:       &providerStatus,
+			UserData:     "",
+			Config:       nil,
+			ProviderData: nil,
+		})
+
+		condition := meta.FindStatusCondition(providerStatus.Conditions, ProvisionedType)
+		condition.LastTransitionTime = metav1.Time{Time: time.Now().Add(-1 * time.Minute)}
+		testhelper.AssertEquals(t, true, isAlreadyProvisioning(ctx))
+
+		condition.Reason = "Provisioned"
+		condition.Status = metav1.ConditionTrue
+		testhelper.AssertEquals(t, false, isAlreadyProvisioning(ctx))
+
+		condition.Reason = "InProvisioning"
+		condition.Status = metav1.ConditionFalse
+		condition.LastTransitionTime = metav1.Time{Time: time.Now().Add(-10 * time.Minute)}
+		testhelper.AssertEquals(t, false, isAlreadyProvisioning(ctx))
+		testhelper.AssertEquals(t, condition.Reason, "ReInitialising")
+	})
+
+	t.Run("Test getIPAddress", func(t *testing.T) {
+		t.Parallel()
+		providerStatus := &anxtypes.ProviderStatus{
+			ReservedIP: "",
+			IPState: "",
+		}
+		ctx := utils.CreateReconcileContext(utils.ReconcileContext{Status: providerStatus})
+
+		t.Run("with unbound reserved IP", func(t *testing.T) {
+			expectedIP := "8.8.8.8"
+			providerStatus.ReservedIP = expectedIP
+			providerStatus.IPState = anxtypes.IPStateUnbound
+			reservedIP, err := getIPAddress(ctx, client)
+			testhelper.AssertNoErr(t, err)
+			testhelper.AssertEquals(t, expectedIP, reservedIP)
+		})
+	})
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	var configCases []ConfigTestCase
+	configCases = append(configCases,
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{},
+			Error:  errors.New("token is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN")},
+			Error:  errors.New("cpu count is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1},
+			Error:  errors.New("disk size is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5},
+			Error:  errors.New("memory size is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5},
+			Error:  errors.New("location id is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5,
+				LocationID: newConfigVarString("TLID")},
+			Error: errors.New("template id is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5,
+				LocationID: newConfigVarString("LID"), TemplateID: newConfigVarString("TID")},
+			Error: errors.New("vlan id is missing"),
+		},
+		ConfigTestCase{
+			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5,
+				LocationID: newConfigVarString("LID"), TemplateID: newConfigVarString("TID"), VlanID: newConfigVarString("VLAN")},
+			Error: nil,
+		},
+	)
+
+	provider := New(nil)
+	for _, testCase := range getSpecsForValidationTest(t, configCases) {
+		err := provider.Validate(testCase.Spec)
+		if testCase.ExpectedError != nil {
+			testhelper.AssertEquals(t, testCase.ExpectedError.Error(), err.Error())
+		} else {
+			testhelper.AssertEquals(t, testCase.ExpectedError, err)
+		}
+	}
+}
+
+func TestEnsureConditions(t *testing.T) {
+	t.Parallel()
+	status := anxtypes.ProviderStatus{}
+
+	ensureConditions(&status)
+
+	condition := meta.FindStatusCondition(status.Conditions, ProvisionedType)
+	if condition == nil {
+		t.Fatal("condition should not be nil")
+	}
+	testhelper.AssertEquals(t, metav1.ConditionUnknown, condition.Status)
+	testhelper.AssertEquals(t, "Initialising", condition.Reason)
+}
+
+func TestGetProviderStatus(t *testing.T) {
+	t.Parallel()
+
+	machine := &v1alpha1.Machine{}
+	providerStatus := anxtypes.ProviderStatus{
+		InstanceID: "InstanceID",
+	}
+	providerStatusJSON, err := json.Marshal(providerStatus)
+	testhelper.AssertNoErr(t, err)
+	machine.Status.ProviderStatus = &runtime.RawExtension{Raw: providerStatusJSON}
+
+	returnedStatus := getProviderStatus(machine)
+
+	testhelper.AssertEquals(t, "InstanceID", returnedStatus.InstanceID)
+
+}
+
+func TestUpdateStatus(t *testing.T) {
+	t.Parallel()
+	machine := &v1alpha1.Machine{}
+	providerStatus := anxtypes.ProviderStatus{
+		InstanceID: "InstanceID",
+	}
+	providerStatusJSON, err := json.Marshal(providerStatus)
+	testhelper.AssertNoErr(t, err)
+	machine.Status.ProviderStatus = &runtime.RawExtension{Raw: providerStatusJSON}
+
+	called := false
+	err = updateMachineStatus(machine, providerStatus, func(paramMachine *v1alpha1.Machine, modifier ...cloudprovidertypes.MachineModifier) error {
+		called = true
+		testhelper.AssertEquals(t, machine, paramMachine)
+		status := getProviderStatus(machine)
+		testhelper.AssertEquals(t, status.InstanceID, providerStatus.InstanceID)
+		return nil
+	})
+
+	testhelper.AssertEquals(t, true, called)
+	testhelper.AssertNoErr(t, err)
+}

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/vm"
 	"github.com/gophercloud/gophercloud/testhelper"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/utils"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
@@ -62,7 +63,11 @@ func TestAnexiaProvider(t *testing.T) {
 			UserData: "",
 			Config:   &anxtypes.Config{},
 
-			ProviderData: &cloudprovidertypes.ProviderData{},
+			ProviderData: &cloudprovidertypes.ProviderData{
+				Update: func(m *clusterv1alpha1.Machine, mod ...cloudprovidertypes.MachineModifier) error {
+					return nil
+				},
+			},
 		})
 
 		err := waitForVM(ctx, client)
@@ -157,7 +162,11 @@ func TestAnexiaProvider(t *testing.T) {
 				Memory:     5,
 				DiskSize:   5,
 			},
-			ProviderData: &cloudprovidertypes.ProviderData{},
+			ProviderData: &cloudprovidertypes.ProviderData{
+				Update: func(m *clusterv1alpha1.Machine, mods ...cloudprovidertypes.MachineModifier) error {
+					return nil
+				},
+			},
 		})
 
 		err := provisionVM(ctx, client)

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package anexia
 
 import (

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -3,6 +3,10 @@ package anexia
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"testing"
+	"time"
+
 	anxclient "github.com/anexia-it/go-anxcloud/pkg/client"
 	"github.com/anexia-it/go-anxcloud/pkg/ipam/address"
 	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/progress"
@@ -15,9 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"net/http"
-	"testing"
-	"time"
 )
 
 const TestIdentifier = "TestIdent"
@@ -184,7 +185,7 @@ func TestAnexiaProvider(t *testing.T) {
 		t.Parallel()
 		providerStatus := &anxtypes.ProviderStatus{
 			ReservedIP: "",
-			IPState: "",
+			IPState:    "",
 		}
 		ctx := utils.CreateReconcileContext(utils.ReconcileContext{Status: providerStatus})
 

--- a/pkg/cloudprovider/provider/anexia/types/errors.go
+++ b/pkg/cloudprovider/provider/anexia/types/errors.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MultiError represent multiple errors at the same time.
+type MultiError []error
+
+func (r MultiError) Error() string {
+	errString := make([]string, len(r))
+	for i, err := range r {
+		errString[i] = fmt.Sprintf("Error %d: %s", i, err)
+	}
+	return fmt.Sprintf("Multiple errors occoured:\n%s", strings.Join(errString, "\n"))
+}
+
+func NewMultiError(errs ...error) error {
+	var combinedErr []error
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		combinedErr = append(combinedErr, err)
+	}
+
+	if len(combinedErr) > 0 {
+		return MultiError(combinedErr)
+	}
+
+	return nil
+}

--- a/pkg/cloudprovider/provider/anexia/types/errors.go
+++ b/pkg/cloudprovider/provider/anexia/types/errors.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package types
 
 import (

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package types
 
 import (
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
+	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
 	"github.com/kubermatic/machine-controller/pkg/jsonutil"
@@ -30,9 +33,17 @@ const (
 	GetRequestTimeout    = 1 * time.Minute
 	DeleteRequestTimeout = 1 * time.Minute
 
+	IPStateBound   = "Bound"
+	IPStateUnbound = "Unbound"
+
 	VmxNet3NIC       = "vmxnet3"
 	MachinePoweredOn = "poweredOn"
 )
+
+var StatusUpdateFailed = cloudprovidererrors.TerminalError{
+	Reason:  common.UpdateMachineError,
+	Message: "Unable to update the machine status",
+}
 
 type RawConfig struct {
 	Token      providerconfigtypes.ConfigVarString `json:"token,omitempty"`
@@ -45,9 +56,22 @@ type RawConfig struct {
 }
 
 type ProviderStatus struct {
-	InstanceID     string `json:"instanceID"`
-	ProvisioningID string `json:"provisioningID"`
-	// TODO: add conditions to track progress on the provider side
+	InstanceID       string         `json:"instanceID"`
+	ProvisioningID   string         `json:"provisioningID"`
+	DeprovisioningID string         `json:"deprovisioningID"`
+	ReservedIP       string         `json:"reservedIP"`
+	IPState          string         `json:"ipState"`
+	Conditions       []v1.Condition `json:"conditions,omitempty"`
+}
+
+type Config struct {
+	Token      string
+	VlanID     string
+	LocationID string
+	TemplateID string
+	CPUs       int
+	Memory     int
+	DiskSize   int
 }
 
 func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {

--- a/pkg/cloudprovider/provider/anexia/utils/utils.go
+++ b/pkg/cloudprovider/provider/anexia/utils/utils.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"context"
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
+	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+)
+
+type contextKey byte
+
+const MachineReconcileContextKey contextKey = 0
+
+type ReconcileContext struct {
+	Machine      *v1alpha1.Machine
+	Status       *anxtypes.ProviderStatus
+	UserData     string
+	Config       *anxtypes.Config
+	ProviderData *cloudprovidertypes.ProviderData
+}
+
+func CreateReconcileContext(cc ReconcileContext) context.Context {
+	return context.WithValue(context.Background(), MachineReconcileContextKey, cc)
+}
+
+func GetReconcileContext(ctx context.Context) ReconcileContext {
+	rawContext := ctx.Value(MachineReconcileContextKey)
+	if recContext, ok := rawContext.(ReconcileContext); ok {
+		return recContext
+	}
+	return ReconcileContext{}
+}

--- a/pkg/cloudprovider/provider/anexia/utils/utils.go
+++ b/pkg/cloudprovider/provider/anexia/utils/utils.go
@@ -1,7 +1,24 @@
+/*
+Copyright 2022 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package utils
 
 import (
 	"context"
+
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"


### PR DESCRIPTION
Signed-off-by: kstiehl <kevin.stiehl@numericas.de>

**What this PR does / why we need it**:

The Anexia API can behave a little bit weird sometimes. 
* Requests to the API get a negative status code because of some internal engine timeouts but in the VM get's provisionend anyways. We are now tracking whether we already provisionend an IP, and stop provisioning more of them on error.
* During deletion we use the new deprovisioning tracking
* The machine controller remembers ongoing provisionings and reattaches to them now after an error

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anexia Provider is more resilient now and supports reattaching to ongoing provisionings after an error
```
