### PR TITLE
Enable SeccompDefault setting if kubelet feature gate is passed

### DIFF
--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -235,6 +235,10 @@ func kubeletConfiguration(clusterDomain string, clusterDNS []net.IP, featureGate
 		}
 	}
 
+	if enabled, ok := featureGates["SeccompDefault"]; ok && enabled {
+		cfg.SeccompDefault = pointer.Bool(true)
+	}
+
 	buf, err := kyaml.Marshal(cfg)
 	return string(buf), err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

[SeccompDefault](https://kubernetes.io/docs/tutorials/security/seccomp/#enable-the-use-of-runtimedefault-as-the-default-seccomp-profile-for-all-workloads) is a useful kubelet feature gate to isolate every container with seccomp by default. Since it's an alpha feature, it needs a kubelet feature gate _and_ a kubelet config value. This PR sets the config value if the feature gate is passed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable SeccompDefault setting if kubelet feature gate `SeccompDefault` is passed
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
