### PR TITLE
Apply band-aid to reanimate CentOS8 bootstraping

### DIFF
--- a/pkg/controller/machine/bootstrap.go
+++ b/pkg/controller/machine/bootstrap.go
@@ -230,6 +230,11 @@ systemctl restart kubelet-healthcheck.service
 
 	bootstrapYumBinContentTemplate = `#!/bin/bash
 set -xeuo pipefail
+source /etc/os-release
+if [ "$ID" == "centos" ] && [ "$VERSION_ID" == "8" ]; then
+  sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+  sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+fi
 {{- if .EnterpriseLinux }}
 yum install epel-release -y
 {{- end }}
@@ -241,7 +246,7 @@ systemctl daemon-reload
 systemctl restart setup.service
 systemctl restart kubelet.service
 systemctl restart kubelet-healthcheck.service
-  `
+	`
 
 	bootstrapZypperBinContentTemplate = `#!/bin/bash
 set -xeuo pipefail


### PR DESCRIPTION
**What this PR does / why we need it**:
As of Feb 1 2022 centos8 packages been moved to the archeology site vault.centos.org so we are following the lead.

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Make centos8 work again
```
