### PR TITLE
Remove cluster field from vSphere provider

### DIFF
--- a/examples/vsphere-datastore-cluster-machinedeployment.yaml
+++ b/examples/vsphere-datastore-cluster-machinedeployment.yaml
@@ -54,7 +54,6 @@ spec:
             vmNetName: network1
             # Optional
             folder: folder1
-            cluster: cluster1
             datastoreCluster: datastorecluster1
             # Can also be set via the env var 'VSPHERE_ALLOW_INSECURE' on the machine-controller
             allowInsecure: true

--- a/examples/vsphere-machinedeployment.yaml
+++ b/examples/vsphere-machinedeployment.yaml
@@ -54,7 +54,6 @@ spec:
             vmNetName: network1
             # Optional
             folder: folder1
-            cluster: cluster1
             datastore: datastore1
             # Can also be set via the env var 'VSPHERE_ALLOW_INSECURE' on the machine-controller
             allowInsecure: true

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -64,7 +64,6 @@ type Config struct {
 	Password         string
 	VSphereURL       string
 	Datacenter       string
-	Cluster          string
 	Folder           string
 	ResourcePool     string
 	Datastore        string
@@ -160,11 +159,6 @@ func (p *provider) getConfig(s v1alpha1.ProviderSpec) (*Config, *providerconfigt
 		return nil, nil, nil, err
 	}
 
-	c.Cluster, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Cluster)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	c.Folder, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Folder)
 	if err != nil {
 		return nil, nil, nil, err
@@ -223,10 +217,6 @@ func (p *provider) Validate(spec v1alpha1.MachineSpec) error {
 		}
 	} else {
 		return fmt.Errorf("one between datastore and datastore cluster should be specified: %v", err)
-	}
-
-	if _, err := session.Finder.ClusterComputeResource(ctx, config.Cluster); err != nil {
-		return fmt.Errorf("failed to get cluster: %s: %v", config.Cluster, err)
 	}
 
 	if _, err := session.Finder.Folder(ctx, config.Folder); err != nil {
@@ -546,7 +536,6 @@ func (p *provider) GetCloudConfig(spec v1alpha1.MachineSpec) (config string, nam
 			Password:     c.Password,
 			InsecureFlag: c.AllowInsecure,
 			VCenterPort:  u.Port(),
-			ClusterID:    c.Cluster,
 		},
 		Disk: vspheretypes.DiskOpts{
 			SCSIControllerType: "pvscsi",
@@ -582,7 +571,6 @@ func (p *provider) MachineMetricsLabels(machine *v1alpha1.Machine) (map[string]s
 	if err == nil {
 		labels["size"] = fmt.Sprintf("%d-cpus-%d-mb", c.CPUs, c.MemoryMB)
 		labels["dc"] = c.Datacenter
-		labels["cluster"] = c.Cluster
 	}
 
 	return labels, err

--- a/pkg/cloudprovider/provider/vsphere/provider_test.go
+++ b/pkg/cloudprovider/provider/vsphere/provider_test.go
@@ -47,7 +47,6 @@ func (v vsphereProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 	"cloudProvider": "vsphere",
 	"cloudProviderSpec": {
 		"allowInsecure": false,
-		"cluster": "DC0_C0",
 		"cpus": 1,
 		"datacenter": "DC0",
 		{{- if .Datastore }}

--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -78,6 +78,7 @@ type GlobalOpts struct {
 	Datacenter       string `gcfg:"datacenter"`
 	DefaultDatastore string `gcfg:"datastore"`
 	VCenterIP        string `gcfg:"server"`
+	ClusterID        string `gcfg:"cluster-id"`
 }
 
 type VirtualCenterConfig struct {

--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -78,7 +78,6 @@ type GlobalOpts struct {
 	Datacenter       string `gcfg:"datacenter"`
 	DefaultDatastore string `gcfg:"datastore"`
 	VCenterIP        string `gcfg:"server"`
-	ClusterID        string `gcfg:"cluster-id"`
 }
 
 type VirtualCenterConfig struct {

--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -28,7 +28,6 @@ type RawConfig struct {
 	Password       providerconfigtypes.ConfigVarString `json:"password"`
 	VSphereURL     providerconfigtypes.ConfigVarString `json:"vsphereURL"`
 	Datacenter     providerconfigtypes.ConfigVarString `json:"datacenter"`
-	Cluster        providerconfigtypes.ConfigVarString `json:"cluster"`
 	Folder         providerconfigtypes.ConfigVarString `json:"folder"`
 	ResourcePool   providerconfigtypes.ConfigVarString `json:"resourcePool"`
 

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -788,11 +788,10 @@ func getVSphereTestParams(t *testing.T) []string {
 	// test data
 	vsPassword := os.Getenv("VSPHERE_E2E_PASSWORD")
 	vsUsername := os.Getenv("VSPHERE_E2E_USERNAME")
-	vsCluster := os.Getenv("VSPHERE_E2E_CLUSTER")
 	vsAddress := os.Getenv("VSPHERE_E2E_ADDRESS")
 
-	if vsPassword == "" || vsUsername == "" || vsAddress == "" || vsCluster == "" {
-		t.Fatal("unable to run the test suite, VSPHERE_E2E_PASSWORD, VSPHERE_E2E_USERNAME, VSPHERE_E2E_CLUSTER " +
+	if vsPassword == "" || vsUsername == "" || vsAddress == "" {
+		t.Fatal("unable to run the test suite, VSPHERE_E2E_PASSWORD, VSPHERE_E2E_USERNAME" +
 			"or VSPHERE_E2E_ADDRESS environment variables cannot be empty")
 	}
 
@@ -800,7 +799,6 @@ func getVSphereTestParams(t *testing.T) []string {
 	params := []string{fmt.Sprintf("<< VSPHERE_PASSWORD >>=%s", vsPassword),
 		fmt.Sprintf("<< VSPHERE_USERNAME >>=%s", vsUsername),
 		fmt.Sprintf("<< VSPHERE_ADDRESS >>=%s", vsAddress),
-		fmt.Sprintf("<< VSPHERE_CLUSTER >>=%s", vsCluster),
 	}
 	return params
 }

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
@@ -31,7 +31,6 @@ spec:
             folder: '/dc-1/vm/e2e-tests'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            cluster: '<< VSPHERE_CLUSTER >>'
             datastoreCluster: 'dsc-1'
             cpus: 2
             MemoryMB: 2048

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
@@ -31,7 +31,6 @@ spec:
             folder: '/dc-1/vm/e2e-tests'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            cluster: '<< VSPHERE_CLUSTER >>'
             datastoreCluster: 'dsc-1'
             resourcePool: 'e2e-resource-pool'
             cpus: 2

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -31,7 +31,6 @@ spec:
             folder: '/Customer-A/vm/e2e-tests'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            cluster: '<< VSPHERE_CLUSTER >>'
             datastore: datastore1
             allowInsecure: true
             cpus: 2

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -31,7 +31,6 @@ spec:
             folder: '/dc-1/vm/e2e-tests'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            cluster: 'cl-1'
             datastore: HS-FreeNAS
             cpus: 2
             MemoryMB: 4096


### PR DESCRIPTION
**What this PR does / why we need it**:
The cluster id field for vSphere cloud provider, isn't used anywhere except in the labels of machines. It used to be part of the cloud-config however, it seems that it is not the case anymore. Thus we will remove it since it is not used by the provider. 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove cluster-id from vsphere cloud provider 
```
