### PR TITLE
fix: returned vSphere RawConfig.Cluster

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -29,8 +29,12 @@ type RawConfig struct {
 	Password       providerconfigtypes.ConfigVarString `json:"password"`
 	VSphereURL     providerconfigtypes.ConfigVarString `json:"vsphereURL"`
 	Datacenter     providerconfigtypes.ConfigVarString `json:"datacenter"`
-	Folder         providerconfigtypes.ConfigVarString `json:"folder"`
-	ResourcePool   providerconfigtypes.ConfigVarString `json:"resourcePool"`
+
+	// Cluster is a noop field, it's not used anywhere but left here intentionally for backward compatibility purposes
+	Cluster providerconfigtypes.ConfigVarString `json:"cluster"`
+
+	Folder       providerconfigtypes.ConfigVarString `json:"folder"`
+	ResourcePool providerconfigtypes.ConfigVarString `json:"resourcePool"`
 
 	// Either Datastore or DatastoreCluster have to be provided.
 	DatastoreCluster providerconfigtypes.ConfigVarString `json:"datastoreCluster"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Removal of this field is a backward compatibility issue and will break all the vSphere machineDeployment objects that had .Cluster in their ProviderSpec.

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: returned vSphere RawConfig.Cluster
```
