### PR TITLE
Improve nil pointer checks and consider VPC overlay networks for Nutanix

### DIFF
--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -315,6 +315,10 @@ func (p *provider) cleanup(machine *clusterv1alpha1.Machine, data *cloudprovider
 		return false, err
 	}
 
+	if vm.Metadata == nil || vm.Metadata.UUID == nil {
+		return false, fmt.Errorf("failed to get valid VM metadata for machine '%s'", machine.Name)
+	}
+
 	// TODO: figure out if VM is already in deleting state
 
 	resp, err := client.Prism.V3.DeleteVM(*vm.Metadata.UUID)


### PR DESCRIPTION
**What this PR does / why we need it**:

Our Nutanix provider implementation assumed that all networks would have a cluster reference. That does not seem to be the case, as e.g. VPC overlay networks do not have one (also see https://github.com/nutanix/terraform-provider-nutanix/pull/328).

This PR includes that as a possible scenario when checking the cluster reference on a discovered subnet.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1192

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support VPC overlay network types in Nutanix
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
