### PR TITLE
Validate max price in spot instance request

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -633,6 +633,12 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to validate instance profile: %v", err)
 	}
 
+	if config.IsSpotInstance != nil && *config.IsSpotInstance {
+		if config.SpotMaxPrice == nil {
+			return errors.New("failed to validate max price for the spot instance: max price cannot be empty when spot instance ")
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes sure that we validate the max price field of the machine deployment spec when the aws instance is marked as spot instance. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes kubermatic/machine-controller#1197

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
