### PR TITLE
Add support for setting Azure disk types (OS and data)

### DIFF
--- a/pkg/cloudprovider/provider/azure/create_delete_resources.go
+++ b/pkg/cloudprovider/provider/azure/create_delete_resources.go
@@ -266,7 +266,7 @@ func getSKU(ctx context.Context, c *config) (compute.ResourceSku, error) {
 		return compute.ResourceSku{}, fmt.Errorf("failed to (create) SKU client: %w", err)
 	}
 
-	skuPages, err := skuClient.List(context.TODO(), fmt.Sprintf("location eq '%s'", c.Location), "false")
+	skuPages, err := skuClient.List(ctx, fmt.Sprintf("location eq '%s'", c.Location), "false")
 	if err != nil {
 		return compute.ResourceSku{}, fmt.Errorf("failed to list available SKUs: %w", err)
 	}
@@ -288,7 +288,7 @@ skuLoop:
 			}
 		}
 
-		if err := skuPages.NextWithContext(context.TODO()); err != nil {
+		if err := skuPages.NextWithContext(ctx); err != nil {
 			return compute.ResourceSku{}, fmt.Errorf("failed to list available SKUs: %w", err)
 		}
 	}

--- a/pkg/cloudprovider/provider/azure/create_delete_resources.go
+++ b/pkg/cloudprovider/provider/azure/create_delete_resources.go
@@ -294,7 +294,7 @@ skuLoop:
 	}
 
 	if sku == nil {
-		return compute.ResourceSku{}, fmt.Errorf("VM SKU '%s' not found in subscription '%s'", c.VMSize, c.SubscriptionID)
+		return compute.ResourceSku{}, fmt.Errorf("no VM SKU '%s' found for subscription '%s'", c.VMSize, c.SubscriptionID)
 	}
 
 	cache.SetDefault(cacheKey, *sku)

--- a/pkg/cloudprovider/provider/azure/get_client.go
+++ b/pkg/cloudprovider/provider/azure/get_client.go
@@ -78,6 +78,17 @@ func getVMClient(c *config) (*compute.VirtualMachinesClient, error) {
 	return &vmClient, nil
 }
 
+func getSKUClient(c *config) (*compute.ResourceSkusClient, error) {
+	var err error
+	skuClient := compute.NewResourceSkusClient(c.SubscriptionID)
+	skuClient.Authorizer, err = auth.NewClientCredentialsConfig(c.ClientID, c.ClientSecret, c.TenantID).Authorizer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create authorizer: %w", err)
+	}
+
+	return &skuClient, nil
+}
+
 func getInterfacesClient(c *config) (*network.InterfacesClient, error) {
 	var err error
 	ifClient := network.NewInterfacesClient(c.SubscriptionID)

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -88,7 +88,9 @@ type config struct {
 	ImageReference        *compute.ImageReference
 
 	OSDiskSize   int32
+	OSDiskType   *compute.StorageAccountTypes
 	DataDiskSize int32
+	DataDiskType *compute.StorageAccountTypes
 
 	AssignPublicIP bool
 	Tags           map[string]string
@@ -154,6 +156,19 @@ var osPlans = map[providerconfigtypes.OperatingSystem]*compute.Plan{
 		Publisher: pointer.StringPtr("redhat"),
 		Product:   pointer.StringPtr("rhel-byos"),
 	},
+}
+
+var osDiskTypes = []compute.StorageAccountTypes{
+	compute.StorageAccountTypesStandardLRS,    // Standard_LRS
+	compute.StorageAccountTypesStandardSSDLRS, // StandardSSD_LRS
+	compute.StorageAccountTypesPremiumLRS,     // Premium_LRS
+}
+
+var dataDiskTypes = []compute.StorageAccountTypes{
+	compute.StorageAccountTypesStandardLRS,    // Standard_LRS
+	compute.StorageAccountTypesStandardSSDLRS, // StandardSSD_LRS
+	compute.StorageAccountTypesPremiumLRS,     // Premium_LRS
+	compute.StorageAccountTypesUltraSSDLRS,    // UltraSSD_LRS
 }
 
 func getOSImageReference(c *config, os providerconfigtypes.OperatingSystem) (*compute.ImageReference, error) {
@@ -290,6 +305,14 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*config, *p
 	c.Tags = rawCfg.Tags
 	c.OSDiskSize = rawCfg.OSDiskSize
 	c.DataDiskSize = rawCfg.DataDiskSize
+
+	if rawCfg.OSDiskType != nil {
+		c.OSDiskType = StorageTypePtr(*rawCfg.OSDiskType)
+	}
+
+	if rawCfg.DataDiskType != nil {
+		c.DataDiskType = StorageTypePtr(*rawCfg.DataDiskType)
+	}
 
 	if rawCfg.ImagePlan != nil && rawCfg.ImagePlan.Name != "" {
 		c.ImagePlan = &compute.Plan{
@@ -465,6 +488,12 @@ func getStorageProfile(config *config, providerCfg *providerconfigtypes.Config) 
 			DiskSizeGB:   pointer.Int32Ptr(config.OSDiskSize),
 			CreateOption: compute.DiskCreateOptionTypesFromImage,
 		}
+
+		if config.OSDiskType != nil {
+			sp.OsDisk.ManagedDisk = &compute.ManagedDiskParameters{
+				StorageAccountType: *config.OSDiskType,
+			}
+		}
 	}
 
 	if config.DataDiskSize != 0 {
@@ -476,6 +505,13 @@ func getStorageProfile(config *config, providerCfg *providerconfigtypes.Config) 
 				CreateOption: compute.DiskCreateOptionTypesEmpty,
 			},
 		}
+
+		if config.DataDiskType != nil {
+			(*sp.DataDisks)[0].ManagedDisk = &compute.ManagedDiskParameters{
+				StorageAccountType: *config.DataDiskType,
+			}
+		}
+
 	}
 	return sp, nil
 }
@@ -903,6 +939,32 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to get subnet: %v", err)
 	}
 
+	if c.OSDiskType != nil {
+		valid := false
+		for _, t := range osDiskTypes {
+			if t == *c.OSDiskType {
+				valid = true
+			}
+		}
+
+		if !valid {
+			return fmt.Errorf("invalid OS disk type '%s'", *c.OSDiskType)
+		}
+	}
+
+	if c.DataDiskType != nil {
+		valid := false
+		for _, t := range osDiskTypes {
+			if t == *c.DataDiskType {
+				valid = true
+			}
+		}
+
+		if !valid {
+			return fmt.Errorf("invalid data disk type '%s'", *c.DataDiskType)
+		}
+	}
+
 	_, err = getOSImageReference(c, providerCfg.OperatingSystem)
 	return err
 }
@@ -1007,4 +1069,9 @@ func getOSUsername(os providerconfigtypes.OperatingSystem) string {
 	default:
 		return string(os)
 	}
+}
+
+func StorageTypePtr(storageType string) *compute.StorageAccountTypes {
+	storage := compute.StorageAccountTypes(storageType)
+	return &storage
 }

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -954,7 +954,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 
 	if c.DataDiskType != nil {
 		valid := false
-		for _, t := range osDiskTypes {
+		for _, t := range dataDiskTypes {
 			if t == *c.DataDiskType {
 				valid = true
 			}

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -165,17 +165,17 @@ var osPlans = map[providerconfigtypes.OperatingSystem]*compute.Plan{
 	},
 }
 
-var osDiskSKUs = []compute.StorageAccountTypes{
-	compute.StorageAccountTypesStandardLRS,    // Standard_LRS
-	compute.StorageAccountTypesStandardSSDLRS, // StandardSSD_LRS
-	compute.StorageAccountTypesPremiumLRS,     // Premium_LRS
+var osDiskSKUs = map[compute.StorageAccountTypes]string{
+	compute.StorageAccountTypesStandardLRS:    "", // Standard_LRS
+	compute.StorageAccountTypesStandardSSDLRS: "", // StandardSSD_LRS
+	compute.StorageAccountTypesPremiumLRS:     "", // Premium_LRS
 }
 
-var dataDiskSKUs = []compute.StorageAccountTypes{
-	compute.StorageAccountTypesStandardLRS,    // Standard_LRS
-	compute.StorageAccountTypesStandardSSDLRS, // StandardSSD_LRS
-	compute.StorageAccountTypesPremiumLRS,     // Premium_LRS
-	compute.StorageAccountTypesUltraSSDLRS,    // UltraSSD_LRS
+var dataDiskSKUs = map[compute.StorageAccountTypes]string{
+	compute.StorageAccountTypesStandardLRS:    "", // Standard_LRS
+	compute.StorageAccountTypesStandardSSDLRS: "", // StandardSSD_LRS
+	compute.StorageAccountTypesPremiumLRS:     "", // Premium_LRS
+	compute.StorageAccountTypesUltraSSDLRS:    "", // UltraSSD_LRS
 }
 
 var (
@@ -969,14 +969,7 @@ func validateDiskSKUs(c *config) error {
 		}
 
 		if c.OSDiskSKU != nil {
-			valid := false
-			for _, t := range osDiskSKUs {
-				if t == *c.OSDiskSKU {
-					valid = true
-				}
-			}
-
-			if !valid {
+			if _, ok := osDiskSKUs[*c.OSDiskSKU]; !ok {
 				return fmt.Errorf("invalid OS disk SKU '%s'", *c.OSDiskSKU)
 			}
 
@@ -986,14 +979,7 @@ func validateDiskSKUs(c *config) error {
 		}
 
 		if c.DataDiskSKU != nil {
-			valid := false
-			for _, t := range dataDiskSKUs {
-				if t == *c.DataDiskSKU {
-					valid = true
-				}
-			}
-
-			if !valid {
+			if _, ok := dataDiskSKUs[*c.DataDiskSKU]; !ok {
 				return fmt.Errorf("invalid data disk SKU '%s'", *c.DataDiskSKU)
 			}
 

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -88,9 +88,9 @@ type config struct {
 	ImageReference        *compute.ImageReference
 
 	OSDiskSize   int32
-	OSDiskType   *compute.StorageAccountTypes
+	OSDiskSKU    *compute.StorageAccountTypes
 	DataDiskSize int32
-	DataDiskType *compute.StorageAccountTypes
+	DataDiskSKU  *compute.StorageAccountTypes
 
 	AssignPublicIP bool
 	Tags           map[string]string
@@ -306,12 +306,12 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*config, *p
 	c.OSDiskSize = rawCfg.OSDiskSize
 	c.DataDiskSize = rawCfg.DataDiskSize
 
-	if rawCfg.OSDiskType != nil {
-		c.OSDiskType = StorageTypePtr(*rawCfg.OSDiskType)
+	if rawCfg.OSDiskSKU != nil {
+		c.OSDiskSKU = StorageTypePtr(*rawCfg.OSDiskSKU)
 	}
 
-	if rawCfg.DataDiskType != nil {
-		c.DataDiskType = StorageTypePtr(*rawCfg.DataDiskType)
+	if rawCfg.DataDiskSKU != nil {
+		c.DataDiskSKU = StorageTypePtr(*rawCfg.DataDiskSKU)
 	}
 
 	if rawCfg.ImagePlan != nil && rawCfg.ImagePlan.Name != "" {
@@ -489,9 +489,9 @@ func getStorageProfile(config *config, providerCfg *providerconfigtypes.Config) 
 			CreateOption: compute.DiskCreateOptionTypesFromImage,
 		}
 
-		if config.OSDiskType != nil {
+		if config.OSDiskSKU != nil {
 			sp.OsDisk.ManagedDisk = &compute.ManagedDiskParameters{
-				StorageAccountType: *config.OSDiskType,
+				StorageAccountType: *config.OSDiskSKU,
 			}
 		}
 	}
@@ -506,9 +506,9 @@ func getStorageProfile(config *config, providerCfg *providerconfigtypes.Config) 
 			},
 		}
 
-		if config.DataDiskType != nil {
+		if config.DataDiskSKU != nil {
 			(*sp.DataDisks)[0].ManagedDisk = &compute.ManagedDiskParameters{
-				StorageAccountType: *config.DataDiskType,
+				StorageAccountType: *config.DataDiskSKU,
 			}
 		}
 
@@ -939,29 +939,29 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to get subnet: %v", err)
 	}
 
-	if c.OSDiskType != nil {
+	if c.OSDiskSKU != nil {
 		valid := false
 		for _, t := range osDiskTypes {
-			if t == *c.OSDiskType {
+			if t == *c.OSDiskSKU {
 				valid = true
 			}
 		}
 
 		if !valid {
-			return fmt.Errorf("invalid OS disk type '%s'", *c.OSDiskType)
+			return fmt.Errorf("invalid OS disk SKU '%s'", *c.OSDiskSKU)
 		}
 	}
 
-	if c.DataDiskType != nil {
+	if c.DataDiskSKU != nil {
 		valid := false
 		for _, t := range dataDiskTypes {
-			if t == *c.DataDiskType {
+			if t == *c.DataDiskSKU {
 				valid = true
 			}
 		}
 
 		if !valid {
-			return fmt.Errorf("invalid data disk type '%s'", *c.DataDiskType)
+			return fmt.Errorf("invalid data disk SKU '%s'", *c.DataDiskSKU)
 		}
 	}
 

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -22,10 +22,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-05-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
+	gocache "github.com/patrickmn/go-cache"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -173,6 +176,13 @@ var dataDiskSKUs = []compute.StorageAccountTypes{
 	compute.StorageAccountTypesPremiumLRS,     // Premium_LRS
 	compute.StorageAccountTypesUltraSSDLRS,    // UltraSSD_LRS
 }
+
+var (
+	// cacheLock protects concurrent cache misses against a single key. This usually happens when multiple machines get created simultaneously
+	// We lock so the first access updates/writes the data to the cache and afterwards everyone reads the cached data
+	cacheLock = &sync.Mutex{}
+	cache     = gocache.New(10*time.Minute, 10*time.Minute)
+)
 
 func getOSImageReference(c *config, os providerconfigtypes.OperatingSystem) (*compute.ImageReference, error) {
 	if c.ImageID != "" {

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -46,6 +46,9 @@ import (
 )
 
 const (
+	CapabilityPremiumIO = "PremiumIO"
+	CapabilityValueTrue = "True"
+
 	machineUIDTag = "Machine-UID"
 
 	finalizerPublicIP = "kubermatic.io/cleanup-azure-public-ip"
@@ -158,13 +161,13 @@ var osPlans = map[providerconfigtypes.OperatingSystem]*compute.Plan{
 	},
 }
 
-var osDiskTypes = []compute.StorageAccountTypes{
+var osDiskSKUs = []compute.StorageAccountTypes{
 	compute.StorageAccountTypesStandardLRS,    // Standard_LRS
 	compute.StorageAccountTypesStandardSSDLRS, // StandardSSD_LRS
 	compute.StorageAccountTypesPremiumLRS,     // Premium_LRS
 }
 
-var dataDiskTypes = []compute.StorageAccountTypes{
+var dataDiskSKUs = []compute.StorageAccountTypes{
 	compute.StorageAccountTypesStandardLRS,    // Standard_LRS
 	compute.StorageAccountTypesStandardSSDLRS, // StandardSSD_LRS
 	compute.StorageAccountTypesPremiumLRS,     // Premium_LRS
@@ -307,11 +310,11 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*config, *p
 	c.DataDiskSize = rawCfg.DataDiskSize
 
 	if rawCfg.OSDiskSKU != nil {
-		c.OSDiskSKU = StorageTypePtr(*rawCfg.OSDiskSKU)
+		c.OSDiskSKU = storageTypePtr(*rawCfg.OSDiskSKU)
 	}
 
 	if rawCfg.DataDiskSKU != nil {
-		c.DataDiskSKU = StorageTypePtr(*rawCfg.DataDiskSKU)
+		c.DataDiskSKU = storageTypePtr(*rawCfg.DataDiskSKU)
 	}
 
 	if rawCfg.ImagePlan != nil && rawCfg.ImagePlan.Name != "" {
@@ -939,9 +942,15 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to get subnet: %v", err)
 	}
 
+	var sku compute.ResourceSku
+
+	if sku, err = getSKU(context.TODO(), c); err != nil {
+		return fmt.Errorf("failed to get SKU: %w", err)
+	}
+
 	if c.OSDiskSKU != nil {
 		valid := false
-		for _, t := range osDiskTypes {
+		for _, t := range osDiskSKUs {
 			if t == *c.OSDiskSKU {
 				valid = true
 			}
@@ -950,11 +959,15 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 		if !valid {
 			return fmt.Errorf("invalid OS disk SKU '%s'", *c.OSDiskSKU)
 		}
+
+		if err := supportsDiskSKU(sku, *c.OSDiskSKU); err != nil {
+			return err
+		}
 	}
 
 	if c.DataDiskSKU != nil {
 		valid := false
-		for _, t := range dataDiskTypes {
+		for _, t := range dataDiskSKUs {
 			if t == *c.DataDiskSKU {
 				valid = true
 			}
@@ -962,6 +975,10 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 
 		if !valid {
 			return fmt.Errorf("invalid data disk SKU '%s'", *c.DataDiskSKU)
+		}
+
+		if err := supportsDiskSKU(sku, *c.OSDiskSKU); err != nil {
+			return err
 		}
 	}
 
@@ -1071,7 +1088,28 @@ func getOSUsername(os providerconfigtypes.OperatingSystem) string {
 	}
 }
 
-func StorageTypePtr(storageType string) *compute.StorageAccountTypes {
+func storageTypePtr(storageType string) *compute.StorageAccountTypes {
 	storage := compute.StorageAccountTypes(storageType)
 	return &storage
+}
+
+// supportsDiskSKU validates some disk SKU types against the chosen VM SKU / VM type.
+func supportsDiskSKU(vmSKU compute.ResourceSku, diskSKU compute.StorageAccountTypes) error {
+	// sanity check to make sure the Azure API did not return something bad
+	if vmSKU.Name == nil || vmSKU.Capabilities == nil {
+		return fmt.Errorf("invalid VM SKU object")
+	}
+
+	switch diskSKU {
+	case compute.StorageAccountTypesPremiumLRS:
+		for _, capability := range *vmSKU.Capabilities {
+			if *capability.Name == CapabilityPremiumIO {
+				if *capability.Value != CapabilityValueTrue {
+					return fmt.Errorf("VM SKU '%s' does not support disk SKU '%s'", *vmSKU.Name, diskSKU)
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -50,6 +50,7 @@ import (
 
 const (
 	CapabilityPremiumIO = "PremiumIO"
+	CapabilityUltraSSD  = "UltraSSDAvailable"
 	CapabilityValueTrue = "True"
 
 	machineUIDTag = "Machine-UID"
@@ -952,43 +953,51 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to get subnet: %v", err)
 	}
 
-	var sku compute.ResourceSku
+	if c.OSDiskSKU != nil || c.DataDiskSKU != nil {
+		var sku compute.ResourceSku
 
-	if sku, err = getSKU(context.TODO(), c); err != nil {
-		return fmt.Errorf("failed to get SKU: %w", err)
-	}
+		if sku, err = getSKU(context.TODO(), c); err != nil {
+			return fmt.Errorf("failed to get SKU: %w", err)
+		}
 
-	if c.OSDiskSKU != nil {
-		valid := false
-		for _, t := range osDiskSKUs {
-			if t == *c.OSDiskSKU {
-				valid = true
+		if c.OSDiskSKU != nil {
+			valid := false
+			for _, t := range osDiskSKUs {
+				if t == *c.OSDiskSKU {
+					valid = true
+				}
+			}
+
+			if !valid {
+				return fmt.Errorf("invalid OS disk SKU '%s'", *c.OSDiskSKU)
+			}
+
+			if err := supportsDiskSKU(sku, *c.OSDiskSKU, c.Zones); err != nil {
+				return err
 			}
 		}
 
-		if !valid {
-			return fmt.Errorf("invalid OS disk SKU '%s'", *c.OSDiskSKU)
-		}
-
-		if err := supportsDiskSKU(sku, *c.OSDiskSKU); err != nil {
-			return err
-		}
-	}
-
-	if c.DataDiskSKU != nil {
-		valid := false
-		for _, t := range dataDiskSKUs {
-			if t == *c.DataDiskSKU {
-				valid = true
+		if c.DataDiskSKU != nil {
+			valid := false
+			for _, t := range dataDiskSKUs {
+				if t == *c.DataDiskSKU {
+					valid = true
+				}
 			}
-		}
 
-		if !valid {
-			return fmt.Errorf("invalid data disk SKU '%s'", *c.DataDiskSKU)
-		}
+			if !valid {
+				return fmt.Errorf("invalid data disk SKU '%s'", *c.DataDiskSKU)
+			}
 
-		if err := supportsDiskSKU(sku, *c.OSDiskSKU); err != nil {
-			return err
+			// Ultra SSDs do not support availability sets, see for reference:
+			// https://docs.microsoft.com/en-us/azure/virtual-machines/disks-enable-ultra-ssd#ga-scope-and-limitations
+			if *c.DataDiskSKU == compute.StorageAccountTypesUltraSSDLRS && ((c.AssignAvailabilitySet != nil && *c.AssignAvailabilitySet) || c.AvailabilitySet != "") {
+				return fmt.Errorf("data disk SKU '%s' does not support availability sets", *c.DataDiskSKU)
+			}
+
+			if err := supportsDiskSKU(sku, *c.DataDiskSKU, c.Zones); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1104,7 +1113,7 @@ func storageTypePtr(storageType string) *compute.StorageAccountTypes {
 }
 
 // supportsDiskSKU validates some disk SKU types against the chosen VM SKU / VM type.
-func supportsDiskSKU(vmSKU compute.ResourceSku, diskSKU compute.StorageAccountTypes) error {
+func supportsDiskSKU(vmSKU compute.ResourceSku, diskSKU compute.StorageAccountTypes, zones []string) error {
 	// sanity check to make sure the Azure API did not return something bad
 	if vmSKU.Name == nil || vmSKU.Capabilities == nil {
 		return fmt.Errorf("invalid VM SKU object")
@@ -1112,10 +1121,59 @@ func supportsDiskSKU(vmSKU compute.ResourceSku, diskSKU compute.StorageAccountTy
 
 	switch diskSKU {
 	case compute.StorageAccountTypesPremiumLRS:
+		found := false
 		for _, capability := range *vmSKU.Capabilities {
-			if *capability.Name == CapabilityPremiumIO {
-				if *capability.Value != CapabilityValueTrue {
-					return fmt.Errorf("VM SKU '%s' does not support disk SKU '%s'", *vmSKU.Name, diskSKU)
+			if *capability.Name == CapabilityPremiumIO && *capability.Value == CapabilityValueTrue {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("VM SKU '%s' does not support disk SKU '%s'", *vmSKU.Name, diskSKU)
+		}
+
+	case compute.StorageAccountTypesUltraSSDLRS:
+		if vmSKU.LocationInfo == nil || len(*vmSKU.LocationInfo) == 0 || (*vmSKU.LocationInfo)[0].Zones == nil || len(*(*vmSKU.LocationInfo)[0].Zones) == 0 {
+			// no zone information found, let's check for capability
+			found := false
+			for _, capability := range *vmSKU.Capabilities {
+				if *capability.Name == CapabilityUltraSSD && *capability.Value == CapabilityValueTrue {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("VM SKU '%s' does not support disk SKU '%s'", *vmSKU.Name, diskSKU)
+			}
+		} else {
+			if (*vmSKU.LocationInfo)[0].ZoneDetails != nil {
+				for _, zone := range zones {
+					found := false
+					for _, details := range *(*vmSKU.LocationInfo)[0].ZoneDetails {
+						matchesZone := false
+						for _, zoneName := range *details.Name {
+							if zone == zoneName {
+								matchesZone = true
+								break
+							}
+						}
+
+						// we only check this zone details for capabilities if it actually includes the zone we're checking for
+						if matchesZone {
+							for _, capability := range *details.Capabilities {
+								if *capability.Name == CapabilityUltraSSD && *capability.Value == CapabilityValueTrue {
+									found = true
+									break
+								}
+							}
+						}
+					}
+
+					if !found {
+						return fmt.Errorf("VM SKU '%s' does not support disk SKU '%s' in zone '%s'", *vmSKU.Name, diskSKU, zone)
+					}
 				}
 			}
 		}

--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -45,9 +45,9 @@ type RawConfig struct {
 
 	ImageID        providerconfigtypes.ConfigVarString `json:"imageID"`
 	OSDiskSize     int32                               `json:"osDiskSize"`
-	OSDiskType     *string                             `json:"osDiskType,omitempty"`
+	OSDiskSKU      *string                             `json:"osDiskSKU,omitempty"`
 	DataDiskSize   int32                               `json:"dataDiskSize"`
-	DataDiskType   *string                             `json:"dataDiskType,omitempty"`
+	DataDiskSKU    *string                             `json:"dataDiskSKU,omitempty"`
 	AssignPublicIP providerconfigtypes.ConfigVarBool   `json:"assignPublicIP"`
 	Tags           map[string]string                   `json:"tags,omitempty"`
 }

--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -45,7 +45,9 @@ type RawConfig struct {
 
 	ImageID        providerconfigtypes.ConfigVarString `json:"imageID"`
 	OSDiskSize     int32                               `json:"osDiskSize"`
+	OSDiskType     *string                             `json:"osDiskType,omitempty"`
 	DataDiskSize   int32                               `json:"dataDiskSize"`
+	DataDiskType   *string                             `json:"dataDiskType,omitempty"`
 	AssignPublicIP providerconfigtypes.ConfigVarBool   `json:"assignPublicIP"`
 	Tags           map[string]string                   `json:"tags,omitempty"`
 }

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -612,6 +612,8 @@ func TestAzureProvisioningE2E(t *testing.T) {
 		fmt.Sprintf("<< AZURE_SUBSCRIPTION_ID >>=%s", azureSubscriptionID),
 		fmt.Sprintf("<< AZURE_CLIENT_ID >>=%s", azureClientID),
 		fmt.Sprintf("<< AZURE_CLIENT_SECRET >>=%s", azureClientSecret),
+		fmt.Sprintf("<< AZURE_OS_DISK_SKU >>=%s", "Standard_LRS"),
+		fmt.Sprintf("<< AZURE_DATA_DISK_SKU >>=%s", "Standard_LRS"),
 	}
 	runScenarios(t, selector, params, AzureManifest, fmt.Sprintf("azure-%s", *testRunIdentifier))
 }
@@ -637,6 +639,8 @@ func TestAzureCustomImageReferenceProvisioningE2E(t *testing.T) {
 		fmt.Sprintf("<< AZURE_SUBSCRIPTION_ID >>=%s", azureSubscriptionID),
 		fmt.Sprintf("<< AZURE_CLIENT_ID >>=%s", azureClientID),
 		fmt.Sprintf("<< AZURE_CLIENT_SECRET >>=%s", azureClientSecret),
+		fmt.Sprintf("<< AZURE_OS_DISK_SKU >>=%s", "Standard_LRS"),
+		fmt.Sprintf("<< AZURE_DATA_DISK_SKU >>=%s", "Standard_LRS"),
 	}
 	runScenarios(t, selector, params, AzureCustomImageReferenceManifest, fmt.Sprintf("azure-%s", *testRunIdentifier))
 }
@@ -662,6 +666,8 @@ func TestAzureRedhatSatelliteProvisioningE2E(t *testing.T) {
 		fmt.Sprintf("<< AZURE_SUBSCRIPTION_ID >>=%s", azureSubscriptionID),
 		fmt.Sprintf("<< AZURE_CLIENT_ID >>=%s", azureClientID),
 		fmt.Sprintf("<< AZURE_CLIENT_SECRET >>=%s", azureClientSecret),
+		fmt.Sprintf("<< AZURE_OS_DISK_SKU >>=%s", "Standard_LRS"),
+		fmt.Sprintf("<< AZURE_DATA_DISK_SKU >>=%s", "Standard_LRS"),
 	}
 
 	scenario := scenario{

--- a/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
@@ -34,7 +34,9 @@ spec:
             vmSize: "Standard_F2"
             # optional disk size values in GB. If not set, the defaults for the vmSize will be used.
             osDiskSize: << OS_DISK_SIZE >>
+            osDiskSKU: << AZURE_OS_DISK_SKU >>
             dataDiskSize: << DATA_DISK_SIZE >>
+            dataDiskSKU: << AZURE_DATA_DISK_SKU >>
             vnetName: "machine-controller-e2e"
             subnetName: "machine-controller-e2e"
             routeTableName: "machine-controller-e2e"


### PR DESCRIPTION
**What this PR does / why we need it**:

The provider spec for Azure did not support setting storage types for disks in Azure, thus spawning nodes with the high cost premium storage type by default. More cost-effective storage types might be sufficient for some workloads and users should be able to chose to optimise their cloud billing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1191

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Azure provider supports optionally setting OS disk and data disk SKUs via `osDiskSKU` and `dataDiskSKU` provider fields. If unset, disk SKUs are picked by Azure based on the VM SKU
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
