### PR TITLE
Fix wrong CPU config

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -365,9 +365,6 @@ func (p *provider) Create(machine *clusterv1alpha1.Machine, _ *cloudprovidertype
 				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
 					Domain: kubevirtv1.DomainSpec{
-						CPU: &kubevirtv1.CPU{
-							Cores: 2,
-						},
 						Devices: kubevirtv1.Devices{
 							Disks: []kubevirtv1.Disk{
 								{


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
I got why changing in the MD ProviderSpec in the KKP Kubevirt e2e tests the CPU to 100m/1 did not work.
https://kubevirt.io/user-guide/virtual_machines/dedicated_cpu_resources/
Several issues:
- It has to be a whole number integer ([1-9]+)
- Users should not specify both spec.domain.cpu and spec.domain.resources.[requests/limits].cpu, which we did.
- We did hard-code `spec.domain.cpu=2`
- `Number of vCPUs is counted as sockets * cores * threads or if spec.domain.cpu is empty then it takes value from spec.domain.resources.requests.cpu or spec.domain.resources.limits.cpu`. As we did set `spec.domain.cpu` the value we did put in `spec.domain.resources.requests.cpu` was useless.

I removed the hard-coded  `spec.domain.cpu=2` to keep only the `spec.domain.resources.requests.cpu` (same value as `spec.domain.resources.limits.cpu`). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
