### PR TITLE
Create VM in dedicated namespace

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/cloudconfig.go
@@ -23,6 +23,8 @@ import (
 type CloudConfig struct {
 	// Kubeconfig used to connect to the cluster that runs KubeVirt
 	Kubeconfig string `yaml:"kubeconfig"`
+	// Namespace used in KubeVirt CCM as infra cluster namespace.
+	Namespace string `yaml:"namespace"`
 }
 
 func (c *CloudConfig) String() (string, error) {


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Last piece needed in machine-controller to implement https://app.zenhub.com/workspaces/work-in-progress---team-caffeine-overflow-6166fa570192a800141b6db9/issues/kubermatic/kubermatic/8489.
After this PR, a last PR in KKP will be done.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes kubermatic/kubermatic#9095

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt VMs are created in a dedicated namespace <cluster-id>
```
