### PR TITLE
consider pod cidr information during instance creation

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -166,7 +166,7 @@ func main() {
 	flag.Var(&nodeContainerdRegistryMirrors, "node-containerd-registry-mirrors", "Configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors")
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "path to a file containing all PEM-encoded CA certificates (will be used instead of the host's certificates if set)")
 	flag.BoolVar(&nodeCSRApprover, "node-csr-approver", true, "Enable NodeCSRApprover controller to automatically approve node serving certificate requests")
-	flag.StringVar(&podCIDRs, "pod-cidrs", "172.25.0.0/16,fd00::/104", "The network ranges from which POD networks are allocated")
+	flag.StringVar(&podCIDRs, "pod-cidrs", "172.25.0.0/16", "The network ranges from which POD networks are allocated")
 	flag.StringVar(&nodePortRange, "node-port-range", "30000-32767", "A port range to reserve for services with NodePort visibility")
 	flag.StringVar(&nodeRegistryCredentialsSecret, "node-registry-credentials-secret", "", "A Secret object reference, that containt auth info for image registry in namespace/secret-name form, example: kube-system/registry-credentials. See doc at https://github.com/kubermaric/machine-controller/blob/master/docs/registry-authentication.md")
 	flag.BoolVar(&useOSM, "use-osm", false, "use osm controller for node bootstrap")

--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -79,7 +79,7 @@ var (
 	nodeRegistryMirrors           string
 	nodePauseImage                string
 	nodeContainerRuntime          string
-	podCIDRs                      string
+	podCIDRs                      listFlag
 	nodePortRange                 string
 	nodeRegistryCredentialsSecret string
 	nodeContainerdRegistryMirrors = containerruntime.RegistryMirrorsFlags{}
@@ -134,6 +134,17 @@ type controllerRunOptions struct {
 	nodePortRange string
 }
 
+type listFlag []string
+
+func (i *listFlag) String() string {
+	return "my string representation"
+}
+
+func (i *listFlag) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+
 func main() {
 	nodeFlags := node.NewFlags(flag.CommandLine)
 
@@ -166,7 +177,7 @@ func main() {
 	flag.Var(&nodeContainerdRegistryMirrors, "node-containerd-registry-mirrors", "Configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors")
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "path to a file containing all PEM-encoded CA certificates (will be used instead of the host's certificates if set)")
 	flag.BoolVar(&nodeCSRApprover, "node-csr-approver", true, "Enable NodeCSRApprover controller to automatically approve node serving certificate requests")
-	flag.StringVar(&podCIDRs, "pod-cidrs", "172.25.0.0/16", "The network ranges from which POD networks are allocated")
+	flag.Var(&podCIDRs, "pod-cidr", "The network ranges from which POD networks are allocated. Can be passed multiple times.")
 	flag.StringVar(&nodePortRange, "node-port-range", "30000-32767", "A port range to reserve for services with NodePort visibility")
 	flag.StringVar(&nodeRegistryCredentialsSecret, "node-registry-credentials-secret", "", "A Secret object reference, that containt auth info for image registry in namespace/secret-name form, example: kube-system/registry-credentials. See doc at https://github.com/kubermaric/machine-controller/blob/master/docs/registry-authentication.md")
 	flag.BoolVar(&useOSM, "use-osm", false, "use osm controller for node bootstrap")
@@ -178,6 +189,10 @@ func main() {
 	clusterDNSIPs, err := parseClusterDNSIPs(clusterDNSIPs)
 	if err != nil {
 		klog.Fatalf("invalid cluster dns specified: %v", err)
+	}
+
+	if len(podCIDRs) == 0 {
+		podCIDRs = append(podCIDRs, "172.25.0.0/16")
 	}
 
 	var parsedJoinClusterTimeout *time.Duration
@@ -266,7 +281,7 @@ func main() {
 			ContainerRuntime:             containerRuntimeConfig,
 		},
 		useOSM:        useOSM,
-		podCIDRs:      strings.Split(podCIDRs, ","),
+		podCIDRs:      podCIDRs,
 		nodePortRange: nodePortRange,
 	}
 

--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -134,17 +134,6 @@ type controllerRunOptions struct {
 	nodePortRange string
 }
 
-type listFlag []string
-
-func (i *listFlag) String() string {
-	return "my string representation"
-}
-
-func (i *listFlag) Set(value string) error {
-	*i = append(*i, value)
-	return nil
-}
-
 func main() {
 	nodeFlags := node.NewFlags(flag.CommandLine)
 

--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -79,7 +79,7 @@ var (
 	nodeRegistryMirrors           string
 	nodePauseImage                string
 	nodeContainerRuntime          string
-	podCIDRs                      listFlag
+	podCIDRs                      string
 	nodePortRange                 string
 	nodeRegistryCredentialsSecret string
 	nodeContainerdRegistryMirrors = containerruntime.RegistryMirrorsFlags{}
@@ -177,7 +177,7 @@ func main() {
 	flag.Var(&nodeContainerdRegistryMirrors, "node-containerd-registry-mirrors", "Configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors")
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "path to a file containing all PEM-encoded CA certificates (will be used instead of the host's certificates if set)")
 	flag.BoolVar(&nodeCSRApprover, "node-csr-approver", true, "Enable NodeCSRApprover controller to automatically approve node serving certificate requests")
-	flag.Var(&podCIDRs, "pod-cidr", "The network ranges from which POD networks are allocated. Can be passed multiple times.")
+	flag.StringVar(&podCIDRs, "pod-cidr", "172.25.0.0/16", "Comma separated network ranges from which POD networks are allocated. Example: 172.25.0.0/16,fd00::/104")
 	flag.StringVar(&nodePortRange, "node-port-range", "30000-32767", "A port range to reserve for services with NodePort visibility")
 	flag.StringVar(&nodeRegistryCredentialsSecret, "node-registry-credentials-secret", "", "A Secret object reference, that containt auth info for image registry in namespace/secret-name form, example: kube-system/registry-credentials. See doc at https://github.com/kubermaric/machine-controller/blob/master/docs/registry-authentication.md")
 	flag.BoolVar(&useOSM, "use-osm", false, "use osm controller for node bootstrap")
@@ -189,10 +189,6 @@ func main() {
 	clusterDNSIPs, err := parseClusterDNSIPs(clusterDNSIPs)
 	if err != nil {
 		klog.Fatalf("invalid cluster dns specified: %v", err)
-	}
-
-	if len(podCIDRs) == 0 {
-		podCIDRs = append(podCIDRs, "172.25.0.0/16")
 	}
 
 	var parsedJoinClusterTimeout *time.Duration
@@ -281,7 +277,7 @@ func main() {
 			ContainerRuntime:             containerRuntimeConfig,
 		},
 		useOSM:        useOSM,
-		podCIDRs:      podCIDRs,
+		podCIDRs:      strings.Split(podCIDRs, ","),
 		nodePortRange: nodePortRange,
 	}
 

--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -79,7 +79,7 @@ var (
 	nodeRegistryMirrors           string
 	nodePauseImage                string
 	nodeContainerRuntime          string
-	podCidr                       string
+	podCIDRs                      string
 	nodePortRange                 string
 	nodeRegistryCredentialsSecret string
 	nodeContainerdRegistryMirrors = containerruntime.RegistryMirrorsFlags{}
@@ -128,7 +128,7 @@ type controllerRunOptions struct {
 	useOSM bool
 
 	// Assigns the POD networks that will be allocated.
-	podCidr string
+	podCIDRs []string
 
 	// A port range to reserve for services with NodePort visibility
 	nodePortRange string
@@ -166,7 +166,7 @@ func main() {
 	flag.Var(&nodeContainerdRegistryMirrors, "node-containerd-registry-mirrors", "Configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors")
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "path to a file containing all PEM-encoded CA certificates (will be used instead of the host's certificates if set)")
 	flag.BoolVar(&nodeCSRApprover, "node-csr-approver", true, "Enable NodeCSRApprover controller to automatically approve node serving certificate requests")
-	flag.StringVar(&podCidr, "pod-cidr", "172.25.0.0/16", "The network ranges from which POD networks are allocated")
+	flag.StringVar(&podCIDRs, "pod-cidrs", "172.25.0.0/16,fd00::/104", "The network ranges from which POD networks are allocated")
 	flag.StringVar(&nodePortRange, "node-port-range", "30000-32767", "A port range to reserve for services with NodePort visibility")
 	flag.StringVar(&nodeRegistryCredentialsSecret, "node-registry-credentials-secret", "", "A Secret object reference, that containt auth info for image registry in namespace/secret-name form, example: kube-system/registry-credentials. See doc at https://github.com/kubermaric/machine-controller/blob/master/docs/registry-authentication.md")
 	flag.BoolVar(&useOSM, "use-osm", false, "use osm controller for node bootstrap")
@@ -266,7 +266,7 @@ func main() {
 			ContainerRuntime:             containerRuntimeConfig,
 		},
 		useOSM:        useOSM,
-		podCidr:       podCidr,
+		podCIDRs:      strings.Split(podCIDRs, ","),
 		nodePortRange: nodePortRange,
 	}
 
@@ -402,7 +402,7 @@ func (bs *controllerBootstrap) Start(ctx context.Context) error {
 		bs.opt.skipEvictionAfter,
 		bs.opt.node,
 		bs.opt.useOSM,
-		bs.opt.podCidr,
+		bs.opt.podCIDRs,
 		bs.opt.nodePortRange,
 	); err != nil {
 		return fmt.Errorf("failed to add Machine controller to manager: %v", err)

--- a/pkg/apis/plugin/plugin.go
+++ b/pkg/apis/plugin/plugin.go
@@ -54,7 +54,7 @@ type UserDataRequest struct {
 	KubeletFeatureGates      map[string]bool
 	KubeletConfigs           map[string]string
 	ContainerRuntime         containerruntime.Config
-	PodCIDR                  string
+	PodCIDRs                 []string
 	NodePortRange            string
 }
 

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -198,7 +198,7 @@ func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config stri
 	return "", "", nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -198,7 +198,7 @@ func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config stri
 	return "", "", nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -255,7 +255,7 @@ func (p *provider) Create(machine *clusterv1alpha1.Machine, providerData *cloudp
 		}
 
 		status.ProvisioningID = provisionResponse.Identifier
-		if err := updateStatus(machine, status, providerData.Update); err != nil {
+		if err := updateStatus(machine, status, data.Update); err != nil {
 			return nil, newError(common.UpdateMachineError, "machine status update failed: %v", err)
 		}
 	}
@@ -266,11 +266,11 @@ func (p *provider) Create(machine *clusterv1alpha1.Machine, providerData *cloudp
 	}
 
 	status.InstanceID = instanceID
-	if err := updateStatus(machine, status, providerData.Update); err != nil {
+	if err := updateStatus(machine, status, data.Update); err != nil {
 		return nil, newError(common.UpdateMachineError, "machine status update failed: %v", err)
 	}
 
-	return p.Get(machine, providerData)
+	return p.Get(machine, data)
 }
 
 func (p *provider) Cleanup(machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {

--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -190,7 +190,7 @@ func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (string, str
 }
 
 // Create creates a cloud instance according to the given machine
-func (p *provider) Create(machine *clusterv1alpha1.Machine, providerData *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	config, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, newError(common.InvalidConfigurationMachineError, "failed to parse MachineSpec: %v", err)

--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -190,7 +190,7 @@ func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (string, str
 }
 
 // Create creates a cloud instance according to the given machine
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	config, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, newError(common.InvalidConfigurationMachineError, "failed to parse MachineSpec: %v", err)

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -660,7 +660,7 @@ func getVpc(client *ec2.EC2, id string) (*ec2.Vpc, error) {
 	return vpcOut.Vpcs[0], nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	config, pc, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -660,7 +660,7 @@ func getVpc(client *ec2.EC2, id string) (*ec2.Vpc, error) {
 	return vpcOut.Vpcs[0], nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	config, pc, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -480,7 +480,7 @@ func getStorageProfile(config *config, providerCfg *providerconfigtypes.Config) 
 	return sp, nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	config, providerCfg, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -480,7 +480,7 @@ func getStorageProfile(config *config, providerCfg *providerconfigtypes.Config) 
 	return sp, nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	config, providerCfg, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/baremetal/provider.go
+++ b/pkg/cloudprovider/provider/baremetal/provider.go
@@ -210,7 +210,7 @@ func (p provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config strin
 	return "", "", nil
 }
 
-func (p provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/baremetal/provider.go
+++ b/pkg/cloudprovider/provider/baremetal/provider.go
@@ -210,7 +210,7 @@ func (p provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config strin
 	return "", "", nil
 }
 
-func (p provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -263,7 +263,7 @@ func uploadRandomSSHPublicKey(ctx context.Context, service godo.KeysService) (st
 	return newDoKey.Fingerprint, nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -263,7 +263,7 @@ func uploadRandomSSHPublicKey(ctx context.Context, service godo.KeysService) (st
 	return newDoKey.Fingerprint, nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/equinixmetal/provider.go
+++ b/pkg/cloudprovider/provider/equinixmetal/provider.go
@@ -214,7 +214,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, _, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/equinixmetal/provider.go
+++ b/pkg/cloudprovider/provider/equinixmetal/provider.go
@@ -214,7 +214,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, _, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -94,7 +94,7 @@ func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (string, str
 }
 
 // Create creates a cloud instance according to the given machine
-func (p *provider) Create(_ *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, _ string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	return CloudProviderInstance{}, nil
 }
 

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -94,7 +94,7 @@ func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (string, str
 }
 
 // Create creates a cloud instance according to the given machine
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	return CloudProviderInstance{}, nil
 }
 

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -195,11 +195,7 @@ func (p *Provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config stri
 }
 
 // Create inserts a cloud instance according to the given machine.
-func (p *Provider) Create(
-	machine *clusterv1alpha1.Machine,
-	data *cloudprovidertypes.ProviderData,
-	userdata string,
-) (instance.Instance, error) {
+func (p *Provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	// Read configuration.
 	cfg, err := newConfig(p.resolver, machine.Spec.ProviderSpec)
 	if err != nil {

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -195,7 +195,7 @@ func (p *Provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config stri
 }
 
 // Create inserts a cloud instance according to the given machine.
-func (p *Provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *Provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	// Read configuration.
 	cfg, err := newConfig(p.resolver, machine.Spec.ProviderSpec)
 	if err != nil {

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -245,7 +245,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -245,7 +245,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -356,7 +356,7 @@ func (p *provider) MachineMetricsLabels(machine *clusterv1alpha1.Machine) (map[s
 	return labels, err
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -356,7 +356,7 @@ func (p *provider) MachineMetricsLabels(machine *clusterv1alpha1.Machine) (map[s
 	return labels, err
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -212,7 +212,7 @@ func createRandomPassword() (string, error) {
 	return rootPass, nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -212,7 +212,7 @@ func createRandomPassword() (string, error) {
 	return rootPass, nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -241,7 +241,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	vm, err := p.create(machine, userdata)
 	if err != nil {
 		_, cleanupErr := p.Cleanup(machine, data)

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -241,7 +241,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	vm, err := p.create(machine, userdata)
 	if err != nil {
 		_, cleanupErr := p.Cleanup(machine, data)

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -553,7 +553,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	cfg, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -553,7 +553,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	cfg, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -295,7 +295,7 @@ func TestCreateServer(t *testing.T) {
 			// It only verifies that the content of the create request matches
 			// the expectation
 			// TODO(irozzo) check the returned instance too
-			_, err := p.Create(m, tt.data, tt.userdata)
+			_, err := p.Create(m, tt.data, tt.userdata, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("provider.Create() or = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cloudprovider/provider/scaleway/provider.go
+++ b/pkg/cloudprovider/provider/scaleway/provider.go
@@ -172,7 +172,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (cloudInstance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (cloudInstance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/scaleway/provider.go
+++ b/pkg/cloudprovider/provider/scaleway/provider.go
@@ -172,7 +172,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	return nil
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (cloudInstance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (cloudInstance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -262,7 +262,7 @@ func machineInvalidConfigurationTerminalError(err error) error {
 	}
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	vm, err := p.create(machine, userdata)
 	if err != nil {
 		_, cleanupErr := p.Cleanup(machine, data)

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -262,7 +262,7 @@ func machineInvalidConfigurationTerminalError(err error) error {
 	}
 }
 
-func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	vm, err := p.create(machine, userdata)
 	if err != nil {
 		_, cleanupErr := p.Cleanup(machine, data)

--- a/pkg/cloudprovider/types/types.go
+++ b/pkg/cloudprovider/types/types.go
@@ -52,7 +52,7 @@ type Provider interface {
 	GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config string, name string, err error)
 
 	// Create creates a cloud instance according to the given machine
-	Create(machine *clusterv1alpha1.Machine, data *ProviderData, userdata string, networkConfig NetworkConfig) (instance.Instance, error)
+	Create(machine *clusterv1alpha1.Machine, data *ProviderData, userdata string, networkConfig *NetworkConfig) (instance.Instance, error)
 
 	// Cleanup will delete the instance associated with the machine and all associated resources.
 	// If all resources have been cleaned up, true will be returned.

--- a/pkg/cloudprovider/types/types.go
+++ b/pkg/cloudprovider/types/types.go
@@ -77,9 +77,8 @@ type Provider interface {
 }
 
 // NetworkConfig holds information about cluster networking.
-// PodCIDRs fields is used to choose IPv4, IPv6 or dual-stack modes. 
 type NetworkConfig struct {
-	PodCIDRs []string `json:"podCIDRs"`
+	PodCIDRs []string `json:"podCIDRs"` // PodCIDRs fields is used to choose IPv4, IPv6 or dual-stack modes.
 }
 
 // MachineModifier defines a function to modify a machine

--- a/pkg/cloudprovider/types/types.go
+++ b/pkg/cloudprovider/types/types.go
@@ -76,6 +76,8 @@ type Provider interface {
 	SetMetricsForMachines(machines clusterv1alpha1.MachineList) error
 }
 
+// NetworkConfig holds information about cluster networking.
+// PodCIDRs fields is used to choose IPv4, IPv6 or dual-stack modes. 
 type NetworkConfig struct {
 	PodCIDRs []string `json:"podCIDRs"`
 }

--- a/pkg/cloudprovider/types/types.go
+++ b/pkg/cloudprovider/types/types.go
@@ -52,7 +52,7 @@ type Provider interface {
 	GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config string, name string, err error)
 
 	// Create creates a cloud instance according to the given machine
-	Create(machine *clusterv1alpha1.Machine, data *ProviderData, userdata string) (instance.Instance, error)
+	Create(machine *clusterv1alpha1.Machine, data *ProviderData, userdata string, networkConfig NetworkConfig) (instance.Instance, error)
 
 	// Cleanup will delete the instance associated with the machine and all associated resources.
 	// If all resources have been cleaned up, true will be returned.
@@ -74,6 +74,10 @@ type Provider interface {
 	// SetMetricsForMachines allows providers to provide provider-specific metrics. This may be implemented
 	// as no-op
 	SetMetricsForMachines(machines clusterv1alpha1.MachineList) error
+}
+
+type NetworkConfig struct {
+	PodCIDRs []string `json:"podCIDRs"`
 }
 
 // MachineModifier defines a function to modify a machine

--- a/pkg/cloudprovider/validationwrapper.go
+++ b/pkg/cloudprovider/validationwrapper.go
@@ -73,8 +73,8 @@ func (w *cachingValidationWrapper) GetCloudConfig(spec v1alpha1.MachineSpec) (st
 }
 
 // Create just calls the underlying cloudproviders Create
-func (w *cachingValidationWrapper) Create(m *v1alpha1.Machine, mcd *cloudprovidertypes.ProviderData, cloudConfig string) (instance.Instance, error) {
-	return w.actualProvider.Create(m, mcd, cloudConfig)
+func (w *cachingValidationWrapper) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+	return w.actualProvider.Create(machine, data, userdata, networkConfig)
 }
 
 // Cleanup just calls the underlying cloudproviders Cleanup

--- a/pkg/cloudprovider/validationwrapper.go
+++ b/pkg/cloudprovider/validationwrapper.go
@@ -73,7 +73,7 @@ func (w *cachingValidationWrapper) GetCloudConfig(spec v1alpha1.MachineSpec) (st
 }
 
 // Create just calls the underlying cloudproviders Create
-func (w *cachingValidationWrapper) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (w *cachingValidationWrapper) Create(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	return w.actualProvider.Create(machine, data, userdata, networkConfig)
 }
 

--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -117,7 +117,7 @@ type Reconciler struct {
 	satelliteSubscriptionManager     rhsm.SatelliteSubscriptionManager
 
 	useOSM        bool
-	podCIDR       string
+	podCIDRs      []string
 	nodePortRange string
 }
 
@@ -175,7 +175,7 @@ func Add(
 	skipEvictionAfter time.Duration,
 	nodeSettings NodeSettings,
 	useOSM bool,
-	podCIDR string,
+	podCIDRs []string,
 	nodePortRange string,
 ) error {
 	reconciler := &Reconciler{
@@ -194,7 +194,7 @@ func Add(
 		satelliteSubscriptionManager:     rhsm.NewSatelliteSubscriptionManager(),
 
 		useOSM:        useOSM,
-		podCIDR:       podCIDR,
+		podCIDRs:      podCIDRs,
 		nodePortRange: nodePortRange,
 	}
 	m, err := userdatamanager.New()
@@ -802,7 +802,7 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 				NoProxy:                  r.nodeSettings.NoProxy,
 				HTTPProxy:                r.nodeSettings.HTTPProxy,
 				ContainerRuntime:         crRuntime,
-				PodCIDR:                  r.podCIDR,
+				PodCIDRs:                 r.podCIDRs,
 				NodePortRange:            r.nodePortRange,
 			}
 

--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -340,7 +340,7 @@ func (r *Reconciler) updateMachineErrorIfTerminalError(machine *clusterv1alpha1.
 	return fmt.Errorf("%s, due to %v", errMsg, err)
 }
 
-func (r *Reconciler) createProviderInstance(prov cloudprovidertypes.Provider, machine *clusterv1alpha1.Machine, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
+func (r *Reconciler) createProviderInstance(prov cloudprovidertypes.Provider, machine *clusterv1alpha1.Machine, userdata string, networkConfig *cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	// Ensure finalizer is there
 	_, err := r.ensureDeleteFinalizerExists(machine)
 	if err != nil {
@@ -844,7 +844,7 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 				}
 			}
 
-			networkConfig := cloudprovidertypes.NetworkConfig{
+			networkConfig := &cloudprovidertypes.NetworkConfig{
 				PodCIDRs: r.podCIDRs,
 			}
 

--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -340,13 +340,13 @@ func (r *Reconciler) updateMachineErrorIfTerminalError(machine *clusterv1alpha1.
 	return fmt.Errorf("%s, due to %v", errMsg, err)
 }
 
-func (r *Reconciler) createProviderInstance(prov cloudprovidertypes.Provider, machine *clusterv1alpha1.Machine, userdata string) (instance.Instance, error) {
+func (r *Reconciler) createProviderInstance(prov cloudprovidertypes.Provider, machine *clusterv1alpha1.Machine, userdata string, networkConfig cloudprovidertypes.NetworkConfig) (instance.Instance, error) {
 	// Ensure finalizer is there
 	_, err := r.ensureDeleteFinalizerExists(machine)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add %q finalizer: %v", FinalizerDeleteInstance, err)
 	}
-	instance, err := prov.Create(machine, r.providerData, userdata)
+	instance, err := prov.Create(machine, r.providerData, userdata, networkConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -844,8 +844,12 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 				}
 			}
 
+			networkConfig := cloudprovidertypes.NetworkConfig{
+				PodCIDRs: r.podCIDRs,
+			}
+
 			// Create the instance
-			if _, err = r.createProviderInstance(prov, machine, userdata); err != nil {
+			if _, err = r.createProviderInstance(prov, machine, userdata, networkConfig); err != nil {
 				message := fmt.Sprintf("%v. Unable to create a machine.", err)
 				return nil, r.updateMachineErrorIfTerminalError(machine, common.CreateMachineError, message, err, "failed to create machine at cloudprovider")
 			}

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -241,9 +241,9 @@ write_files:
     /opt/bin/setup_net_env.sh
 
     {{ if eq .CloudProviderName "azure" }}
-	{{- range .PodCIDRs }} 
-    firewall-cmd --permanent --zone=trusted --add-source={{ . -}}
-	{{- end }}
+	{{- range $idx, $podCIDR := .PodCIDRs }} 
+    firewall-cmd --permanent --zone=trusted --add-source={{ $podCIDR}}
+	{{ end }}
     firewall-cmd --permanent --add-port=8472/udp
     firewall-cmd --permanent --add-port={{ .NodePortRange }}/tcp
     firewall-cmd --permanent --add-port={{ .NodePortRange }}/udp

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -241,7 +241,9 @@ write_files:
     /opt/bin/setup_net_env.sh
 
     {{ if eq .CloudProviderName "azure" }}
-    firewall-cmd --permanent --zone=trusted --add-source={{ .PodCIDR }}
+	{{- range .PodCIDRs }} 
+    firewall-cmd --permanent --zone=trusted --add-source={{ . -}}
+	{{- end }}
     firewall-cmd --permanent --add-port=8472/udp
     firewall-cmd --permanent --add-port={{ .NodePortRange }}/tcp
     firewall-cmd --permanent --add-port={{ .NodePortRange }}/udp

--- a/pkg/userdata/rhel/provider_test.go
+++ b/pkg/userdata/rhel/provider_test.go
@@ -203,6 +203,16 @@ func TestUserDataGeneration(t *testing.T) {
 			},
 			cloudProviderName: stringPtr("nutanix"),
 		},
+		{
+			name: "pod-cidr-azure-rhel",
+			spec: clusterv1alpha1.MachineSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Versions: clusterv1alpha1.MachineVersionInfo{
+					Kubelet: "1.22.2",
+				},
+			},
+			cloudProviderName: stringPtr("azure"),
+		},
 	}
 
 	defaultCloudProvider := &fakeCloudConfigProvider{
@@ -273,6 +283,7 @@ func TestUserDataGeneration(t *testing.T) {
 				PauseImage:               test.pauseImage,
 				KubeletFeatureGates:      kubeletFeatureGates,
 				ContainerRuntime:         containerRuntimeConfig,
+				PodCIDRs:                 []string{"172.25.0.0/16", "fd00::/104"},
 			}
 			s, err := provider.UserData(req)
 			if err != nil {

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -43,6 +43,7 @@ write_files:
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
     fs.inotify.max_user_watches = 1048576
+    fs.inotify.max_user_instances = 8192
 
 
 - path: /etc/selinux/config

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -1,6 +1,6 @@
 #cloud-config
 bootcmd:
-  - modprobe ip_tables
+- modprobe ip_tables
 
 hostname: node1
 fqdn: node1
@@ -10,460 +10,466 @@ ssh_pwauth: false
 
 write_files:
 
-  - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
-    content: |
-      [Journal]
-      SystemMaxUse=5G
+- path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+  content: |
+    [Journal]
+    SystemMaxUse=5G
 
 
-  - path: "/opt/load-kernel-modules.sh"
-    permissions: "0755"
-    content: |
-      #!/usr/bin/env bash
-      set -euo pipefail
-      
-      modprobe ip_vs
-      modprobe ip_vs_rr
-      modprobe ip_vs_wrr
-      modprobe ip_vs_sh
-      
-      if modinfo nf_conntrack_ipv4 &> /dev/null; then
-        modprobe nf_conntrack_ipv4
-      else
-        modprobe nf_conntrack
-      fi
+- path: "/opt/load-kernel-modules.sh"
+  permissions: "0755"
+  content: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    modprobe ip_vs
+    modprobe ip_vs_rr
+    modprobe ip_vs_wrr
+    modprobe ip_vs_sh
+
+    if modinfo nf_conntrack_ipv4 &> /dev/null; then
+      modprobe nf_conntrack_ipv4
+    else
+      modprobe nf_conntrack
+    fi
 
 
-  - path: "/etc/sysctl.d/k8s.conf"
-    content: |
-      net.bridge.bridge-nf-call-ip6tables = 1
-      net.bridge.bridge-nf-call-iptables = 1
-      kernel.panic_on_oops = 1
-      kernel.panic = 10
-      net.ipv4.ip_forward = 1
-      vm.overcommit_memory = 1
-      fs.inotify.max_user_watches = 1048576
+- path: "/etc/sysctl.d/k8s.conf"
+  content: |
+    net.bridge.bridge-nf-call-ip6tables = 1
+    net.bridge.bridge-nf-call-iptables = 1
+    kernel.panic_on_oops = 1
+    kernel.panic = 10
+    net.ipv4.ip_forward = 1
+    vm.overcommit_memory = 1
+    fs.inotify.max_user_watches = 1048576
 
 
-  - path: /etc/selinux/config
-    content: |
-      # This file controls the state of SELinux on the system.
-      # SELINUX= can take one of these three values:
-      #     enforcing - SELinux security policy is enforced.
-      #     permissive - SELinux prints warnings instead of enforcing.
-      #     disabled - No SELinux policy is loaded.
-      SELINUX=permissive
-      # SELINUXTYPE= can take one of three two values:
-      #     targeted - Targeted processes are protected,
-      #     minimum - Modification of targeted policy. Only selected processes are protected.
-      #     mls - Multi Level Security protection.
-      SELINUXTYPE=targeted
+- path: /etc/selinux/config
+  content: |
+    # This file controls the state of SELinux on the system.
+    # SELINUX= can take one of these three values:
+    #     enforcing - SELinux security policy is enforced.
+    #     permissive - SELinux prints warnings instead of enforcing.
+    #     disabled - No SELinux policy is loaded.
+    SELINUX=permissive
+    # SELINUXTYPE= can take one of three two values:
+    #     targeted - Targeted processes are protected,
+    #     minimum - Modification of targeted policy. Only selected processes are protected.
+    #     mls - Multi Level Security protection.
+    SELINUXTYPE=targeted
 
-  - path: "/opt/bin/setup"
-    permissions: "0755"
-    content: |
-      #!/bin/bash
-      set -xeuo pipefail
-      
-      setenforce 0 || true
-      systemctl restart systemd-modules-load.service
-      sysctl --system
-      sed -i.orig '/.*swap.*/d' /etc/fstab
-      swapoff -a
-      
-      hostnamectl set-hostname node1
-      
-      
-      yum update -y --disablerepo='*' --enablerepo='*microsoft*'
-      
-      yum install -y \
-        device-mapper-persistent-data \
-        lvm2 \
-        ebtables \
-        ethtool \
-        nfs-utils \
-        bash-completion \
-        sudo \
-        socat \
-        wget \
-        curl \
-        ipvsadm
-      
-      yum install -y yum-utils
-      yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
-      yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
-      
-      mkdir -p /etc/systemd/system/containerd.service.d /etc/systemd/system/docker.service.d
-      
-      cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf /etc/systemd/system/docker.service.d/environment.conf
-      [Service]
-      Restart=always
-      EnvironmentFile=-/etc/environment
-      EOF
-      
-      yum install -y \
-          docker-ce-cli-19.03* \
-          containerd.io-1.4* \
-          docker-ce-19.03* \
-          yum-plugin-versionlock
-      yum versionlock add docker-ce* containerd.io
-      
-      systemctl daemon-reload
-      systemctl enable --now docker
-      
-      opt_bin=/opt/bin
-      usr_local_bin=/usr/local/bin
-      cni_bin_dir=/opt/cni/bin
-      mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
-      arch=${HOST_ARCH-}
-      if [ -z "$arch" ]
-      then
-      case $(uname -m) in
-      x86_64)
-          arch="amd64"
-          ;;
-      aarch64)
-          arch="arm64"
-          ;;
-      *)
-          echo "unsupported CPU architecture, exiting"
-          exit 1
-          ;;
-      esac
-      fi
-      CNI_VERSION="${CNI_VERSION:-v0.8.7}"
-      cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
-      cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
-      curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
-      cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
-      cd "$cni_bin_dir"
-      sha256sum -c <<<"$cni_sum"
-      tar xvf "$cni_filename"
-      rm -f "$cni_filename"
-      cd -
-      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
-      cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
-      cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
-      curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
-      cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
-      cd "$opt_bin"
-      sha256sum -c <<<"$cri_tools_sum"
-      tar xvf "$cri_tools_filename"
-      rm -f "$cri_tools_filename"
-      ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
-      cd -
-      KUBE_VERSION="${KUBE_VERSION:-v1.22.2}"
-      kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
-      kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
-      kube_sum_file="$kube_dir/sha256"
-      mkdir -p "$kube_dir"
-      : >"$kube_sum_file"
-      
-      for bin in kubelet kubeadm kubectl; do
-          curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
-          chmod +x "$kube_dir/$bin"
-          sum=$(curl -Lf "$kube_base_url/$bin.sha256")
-          echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
-      done
-      sha256sum -c "$kube_sum_file"
-      
-      for bin in kubelet kubeadm kubectl; do
-          ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
-      done
-      
-      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
-          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
-          chmod +x /opt/bin/health-monitor.sh
-      fi
-      
-      # set kubelet nodeip environment variable
-      mkdir -p /etc/systemd/system/kubelet.service.d/
-      /opt/bin/setup_net_env.sh
-      
-      
-      firewall-cmd --permanent --zone=trusted --add-source=172.25.0.0/16 
-      firewall-cmd --permanent --zone=trusted --add-source=fd00::/104
-      firewall-cmd --permanent --add-port=8472/udp
-      firewall-cmd --permanent --add-port=/tcp
-      firewall-cmd --permanent --add-port=/udp
-      firewall-cmd --reload
-      systemctl restart firewalld
-      systemctl enable --now kubelet
-      systemctl enable --now --no-block kubelet-healthcheck.service
+- path: "/opt/bin/setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
 
-  - path: "/opt/bin/supervise.sh"
-    permissions: "0755"
-    content: |
-      #!/bin/bash
-      set -xeuo pipefail
-      while ! "$@"; do
-        sleep 1
-      done
+    setenforce 0 || true
+    systemctl restart systemd-modules-load.service
+    sysctl --system
+    sed -i.orig '/.*swap.*/d' /etc/fstab
+    swapoff -a
 
-  - path: "/etc/systemd/system/kubelet.service"
-    content: |
-      [Unit]
-      After=docker.service
-      Requires=docker.service
-      
-      Description=kubelet: The Kubernetes Node Agent
-      Documentation=https://kubernetes.io/docs/home/
-      
-      [Service]
-      Restart=always
-      StartLimitInterval=0
-      RestartSec=10
-      CPUAccounting=true
-      MemoryAccounting=true
-      
-      Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
-      EnvironmentFile=-/etc/environment
-      
-      ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
-      ExecStartPre=/bin/bash /opt/bin/setup_net_env.sh
-      ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
-        --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
-        --kubeconfig=/var/lib/kubelet/kubeconfig \
-        --config=/etc/kubernetes/kubelet.conf \
-        --network-plugin=cni \
-        --cert-dir=/etc/kubernetes/pki \
-        --cloud-provider=azure \
-        --cloud-config=/etc/kubernetes/cloud-config \
-        --hostname-override=node1 \
-        --exit-on-lock-contention \
-        --lock-file=/tmp/kubelet.lock \
-        --container-runtime=docker \
-        --container-runtime-endpoint=unix:///var/run/dockershim.sock \
-        --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
-        --feature-gates=DynamicKubeletConfig=true \
-        --node-ip ${KUBELET_NODE_IP}
-      
-      [Install]
-      WantedBy=multi-user.target
-
-  - path: "/etc/kubernetes/cloud-config"
-    permissions: "0600"
-    content: |
-      {config:true}
-
-  - path: "/opt/bin/setup_net_env.sh"
-    permissions: "0755"
-    content: |
-      #!/usr/bin/env bash
-      echodate() {
-        echo "[$(date -Is)]" "$@"
-      }
-      
-      # get the default interface IP address
-      DEFAULT_IFC_IP=$(ip -o  route get 1 | grep -oP "src \K\S+")
-      
-      # get the full hostname
-      FULL_HOSTNAME=$(hostname -f)
-      
-      if [ -z "${DEFAULT_IFC_IP}" ]
-      then
-      	echodate "Failed to get IP address for the default route interface"
-      	exit 1
-      fi
-      
-      # write the nodeip_env file
-      # we need the line below because flatcar has the same string "coreos" in that file
-      if grep -q coreos /etc/os-release
-      then
-        echo -e "KUBELET_NODE_IP=${DEFAULT_IFC_IP}\nKUBELET_HOSTNAME=${FULL_HOSTNAME}" > /etc/kubernetes/nodeip.conf
-      elif [ ! -d /etc/systemd/system/kubelet.service.d ]
-      then
-      	echodate "Can't find kubelet service extras directory"
-      	exit 1
-      else
-        echo -e "[Service]\nEnvironment=\"KUBELET_NODE_IP=${DEFAULT_IFC_IP}\"\nEnvironment=\"KUBELET_HOSTNAME=${FULL_HOSTNAME}\"" > /etc/systemd/system/kubelet.service.d/nodeip.conf
-      fi
+    hostnamectl set-hostname node1
 
 
-  - path: "/etc/kubernetes/bootstrap-kubelet.conf"
-    permissions: "0600"
-    content: |
-      apiVersion: v1
-      clusters:
-      - cluster:
-          certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVXakNDQTBLZ0F3SUJBZ0lKQUxmUmxXc0k4WVFITUEwR0NTcUdTSWIzRFFFQkJRVUFNSHN4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlFd0pEUVRFV01CUUdBMVVFQnhNTlUyRnVJRVp5WVc1amFYTmpiekVVTUJJRwpBMVVFQ2hNTFFuSmhaR1pwZEhwcGJtTXhFakFRQmdOVkJBTVRDV3h2WTJGc2FHOXpkREVkTUJzR0NTcUdTSWIzCkRRRUpBUllPWW5KaFpFQmtZVzVuWVM1amIyMHdIaGNOTVRRd056RTFNakEwTmpBMVdoY05NVGN3TlRBME1qQTAKTmpBMVdqQjdNUXN3Q1FZRFZRUUdFd0pWVXpFTE1Ba0dBMVVFQ0JNQ1EwRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhGREFTQmdOVkJBb1RDMEp5WVdSbWFYUjZhVzVqTVJJd0VBWURWUVFERXdsc2IyTmhiR2h2CmMzUXhIVEFiQmdrcWhraUc5dzBCQ1FFV0RtSnlZV1JBWkdGdVoyRXVZMjl0TUlJQklqQU5CZ2txaGtpRzl3MEIKQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBdDVmQWpwNGZUY2VrV1VUZnpzcDBreWloMU9ZYnNHTDBLWDFlUmJTUwpSOE9kMCs5UTYySHlueStHRndNVGI0QS9LVThtc3NvSHZjY2VTQUFid2ZieEZLLytzNTFUb2JxVW5PUlpyT29UClpqa1V5Z2J5WERTSzk5WUJiY1IxUGlwOHZ3TVRtNFhLdUx0Q2lnZUJCZGpqQVFkZ1VPMjhMRU5HbHNNbm1lWWsKSmZPRFZHblZtcjVMdGI5QU5BOElLeVRmc25ISjRpT0NTL1BsUGJVajJxN1lub1ZMcG9zVUJNbGdVYi9DeWtYMwptT29MYjR5SkpReUEvaVNUNlp4aUlFajM2RDR5V1o1bGc3WUpsK1VpaUJRSEdDblBkR3lpcHFWMDZleDBoZVlXCmNhaVc4TFdaU1VROTNqUStXVkNIOGhUN0RRTzFkbXN2VW1YbHEvSmVBbHdRL1FJREFRQUJvNEhnTUlIZE1CMEcKQTFVZERnUVdCQlJjQVJPdGhTNFA0VTd2VGZqQnlDNTY5UjdFNkRDQnJRWURWUjBqQklHbE1JR2lnQlJjQVJPdApoUzRQNFU3dlRmakJ5QzU2OVI3RTZLRi9wSDB3ZXpFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ1RBa05CCk1SWXdGQVlEVlFRSEV3MVRZVzRnUm5KaGJtTnBjMk52TVJRd0VnWURWUVFLRXd0Q2NtRmtabWwwZW1sdVl6RVMKTUJBR0ExVUVBeE1KYkc5allXeG9iM04wTVIwd0d3WUpLb1pJaHZjTkFRa0JGZzVpY21Ga1FHUmhibWRoTG1OdgpiWUlKQUxmUmxXc0k4WVFITUF3R0ExVWRFd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVGQlFBRGdnRUJBRzZoClU5ZjlzTkgwLzZvQmJHR3kyRVZVMFVnSVRVUUlyRldvOXJGa3JXNWsvWGtEalFtKzNsempUMGlHUjRJeEUvQW8KZVU2c1FodWE3d3JXZUZFbjQ3R0w5OGxuQ3NKZEQ3b1pOaEZtUTk1VGIvTG5EVWpzNVlqOWJyUDBOV3pYZllVNApVSzJabklOSlJjSnBCOGlSQ2FDeEU4RGRjVUYwWHFJRXE2cEEyNzJzbm9MbWlYTE12Tmwza1lFZG0ramU2dm9ECjU4U05WRVVzenR6UXlYbUpFaENwd1ZJMEE2UUNqelhqK3F2cG13M1paSGk4SndYZWk4WlpCTFRTRkJraThaN24Kc0g5QkJIMzgvU3pVbUFONFFIU1B5MWdqcW0wME9BRThOYVlEa2gvYnpFNGQ3bUxHR01XcC9XRTNLUFN1ODJIRgprUGU2WG9TYmlMbS9reGszMlQwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
-          server: https://server:443
-        name: ""
-      contexts: null
-      current-context: ""
-      kind: Config
-      preferences: {}
-      users:
-      - name: ""
-        user:
-          token: my-token
+    yum update -y --disablerepo='*' --enablerepo='*microsoft*'
+
+    yum install -y \
+      device-mapper-persistent-data \
+      lvm2 \
+      ebtables \
+      ethtool \
+      nfs-utils \
+      bash-completion \
+      sudo \
+      socat \
+      wget \
+      curl \
+      ipvsadm
+
+    yum install -y yum-utils
+    yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+    yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+
+    mkdir -p /etc/systemd/system/containerd.service.d /etc/systemd/system/docker.service.d
+
+    cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf /etc/systemd/system/docker.service.d/environment.conf
+    [Service]
+    Restart=always
+    EnvironmentFile=-/etc/environment
+    EOF
+
+    yum install -y \
+        docker-ce-cli-19.03* \
+        containerd.io-1.4* \
+        docker-ce-19.03* \
+        yum-plugin-versionlock
+    yum versionlock add docker-ce* containerd.io
+
+    systemctl daemon-reload
+    systemctl enable --now docker
+
+    opt_bin=/opt/bin
+    usr_local_bin=/usr/local/bin
+    cni_bin_dir=/opt/cni/bin
+    mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
+    arch=${HOST_ARCH-}
+    if [ -z "$arch" ]
+    then
+    case $(uname -m) in
+    x86_64)
+        arch="amd64"
+        ;;
+    aarch64)
+        arch="arm64"
+        ;;
+    *)
+        echo "unsupported CPU architecture, exiting"
+        exit 1
+        ;;
+    esac
+    fi
+    CNI_VERSION="${CNI_VERSION:-v0.8.7}"
+    cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
+    cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
+    curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
+    cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
+    cd "$cni_bin_dir"
+    sha256sum -c <<<"$cni_sum"
+    tar xvf "$cni_filename"
+    rm -f "$cni_filename"
+    cd -
+    CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
+    cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
+    cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
+    curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
+    cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
+    cd "$opt_bin"
+    sha256sum -c <<<"$cri_tools_sum"
+    tar xvf "$cri_tools_filename"
+    rm -f "$cri_tools_filename"
+    ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
+    cd -
+    KUBE_VERSION="${KUBE_VERSION:-v1.22.2}"
+    kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
+    kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
+    kube_sum_file="$kube_dir/sha256"
+    mkdir -p "$kube_dir"
+    : >"$kube_sum_file"
+
+    for bin in kubelet kubeadm kubectl; do
+        curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
+        chmod +x "$kube_dir/$bin"
+        sum=$(curl -Lf "$kube_base_url/$bin.sha256")
+        echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
+    done
+    sha256sum -c "$kube_sum_file"
+
+    for bin in kubelet kubeadm kubectl; do
+        ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
+    done
+
+    if [[ ! -x /opt/bin/health-monitor.sh ]]; then
+        curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
+        chmod +x /opt/bin/health-monitor.sh
+    fi
+
+    # set kubelet nodeip environment variable
+    mkdir -p /etc/systemd/system/kubelet.service.d/
+    /opt/bin/setup_net_env.sh
 
 
-  - path: "/etc/kubernetes/kubelet.conf"
-    content: |
-      apiVersion: kubelet.config.k8s.io/v1beta1
-      authentication:
-        anonymous:
-          enabled: false
-        webhook:
-          cacheTTL: 0s
-          enabled: true
-        x509:
-          clientCAFile: /etc/kubernetes/pki/ca.crt
-      authorization:
-        mode: Webhook
-        webhook:
-          cacheAuthorizedTTL: 0s
-          cacheUnauthorizedTTL: 0s
-      cgroupDriver: systemd
-      clusterDomain: cluster.local
-      containerLogMaxSize: 100Mi
-      cpuManagerReconcilePeriod: 0s
-      evictionHard:
-        imagefs.available: 15%
-        memory.available: 100Mi
-        nodefs.available: 10%
-        nodefs.inodesFree: 5%
-      evictionPressureTransitionPeriod: 0s
-      featureGates:
-        RotateKubeletServerCertificate: true
-      fileCheckFrequency: 0s
-      httpCheckFrequency: 0s
-      imageMinimumGCAge: 0s
-      kind: KubeletConfiguration
-      kubeReserved:
-        cpu: 200m
-        ephemeral-storage: 1Gi
-        memory: 200Mi
-      logging: {}
-      memorySwap: {}
-      nodeStatusReportFrequency: 0s
-      nodeStatusUpdateFrequency: 0s
-      protectKernelDefaults: true
-      rotateCertificates: true
-      runtimeRequestTimeout: 0s
-      serverTLSBootstrap: true
-      shutdownGracePeriod: 0s
-      shutdownGracePeriodCriticalPods: 0s
-      staticPodPath: /etc/kubernetes/manifests
-      streamingConnectionIdleTimeout: 0s
-      syncFrequency: 0s
-      systemReserved:
-        cpu: 200m
-        ephemeral-storage: 1Gi
-        memory: 200Mi
-      tlsCipherSuites:
-      - TLS_AES_128_GCM_SHA256
-      - TLS_AES_256_GCM_SHA384
-      - TLS_CHACHA20_POLY1305_SHA256
-      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
-      volumePluginDir: /var/lib/kubelet/volumeplugins
-      volumeStatsAggPeriod: 0s
+    firewall-cmd --permanent --zone=trusted --add-source=172.25.0.0/16
+
+    firewall-cmd --permanent --zone=trusted --add-source=fd00::/104
+
+    firewall-cmd --permanent --add-port=8472/udp
+    firewall-cmd --permanent --add-port=/tcp
+    firewall-cmd --permanent --add-port=/udp
+    firewall-cmd --reload
+    systemctl restart firewalld
+    systemctl enable --now kubelet
+    systemctl enable --now --no-block kubelet-healthcheck.service
+
+- path: "/opt/bin/supervise.sh"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    while ! "$@"; do
+      sleep 1
+    done
+
+- path: "/etc/systemd/system/kubelet.service"
+  content: |
+    [Unit]
+    After=docker.service
+    Requires=docker.service
+
+    Description=kubelet: The Kubernetes Node Agent
+    Documentation=https://kubernetes.io/docs/home/
+
+    [Service]
+    Restart=always
+    StartLimitInterval=0
+    RestartSec=10
+    CPUAccounting=true
+    MemoryAccounting=true
+
+    Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+    EnvironmentFile=-/etc/environment
+
+    ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
+    ExecStartPre=/bin/bash /opt/bin/setup_net_env.sh
+    ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
+      --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
+      --kubeconfig=/var/lib/kubelet/kubeconfig \
+      --config=/etc/kubernetes/kubelet.conf \
+      --network-plugin=cni \
+      --cert-dir=/etc/kubernetes/pki \
+      --cloud-provider=azure \
+      --cloud-config=/etc/kubernetes/cloud-config \
+      --hostname-override=node1 \
+      --exit-on-lock-contention \
+      --lock-file=/tmp/kubelet.lock \
+      --container-runtime=docker \
+      --container-runtime-endpoint=unix:///var/run/dockershim.sock \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
+      --feature-gates=DynamicKubeletConfig=true \
+      --node-ip ${KUBELET_NODE_IP}
+
+    [Install]
+    WantedBy=multi-user.target
+
+- path: "/etc/kubernetes/cloud-config"
+  permissions: "0600"
+  content: |
+    {config:true}
+
+- path: "/opt/bin/setup_net_env.sh"
+  permissions: "0755"
+  content: |
+    #!/usr/bin/env bash
+    echodate() {
+      echo "[$(date -Is)]" "$@"
+    }
+
+    # get the default interface IP address
+    DEFAULT_IFC_IP=$(ip -o  route get 1 | grep -oP "src \K\S+")
+
+    # get the full hostname
+    FULL_HOSTNAME=$(hostname -f)
+
+    if [ -z "${DEFAULT_IFC_IP}" ]
+    then
+    	echodate "Failed to get IP address for the default route interface"
+    	exit 1
+    fi
+
+    # write the nodeip_env file
+    # we need the line below because flatcar has the same string "coreos" in that file
+    if grep -q coreos /etc/os-release
+    then
+      echo -e "KUBELET_NODE_IP=${DEFAULT_IFC_IP}\nKUBELET_HOSTNAME=${FULL_HOSTNAME}" > /etc/kubernetes/nodeip.conf
+    elif [ ! -d /etc/systemd/system/kubelet.service.d ]
+    then
+    	echodate "Can't find kubelet service extras directory"
+    	exit 1
+    else
+      echo -e "[Service]\nEnvironment=\"KUBELET_NODE_IP=${DEFAULT_IFC_IP}\"\nEnvironment=\"KUBELET_HOSTNAME=${FULL_HOSTNAME}\"" > /etc/systemd/system/kubelet.service.d/nodeip.conf
+    fi
 
 
-  - path: "/etc/kubernetes/pki/ca.crt"
-    content: |
-      -----BEGIN CERTIFICATE-----
-      MIIEWjCCA0KgAwIBAgIJALfRlWsI8YQHMA0GCSqGSIb3DQEBBQUAMHsxCzAJBgNV
-      BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEUMBIG
-      A1UEChMLQnJhZGZpdHppbmMxEjAQBgNVBAMTCWxvY2FsaG9zdDEdMBsGCSqGSIb3
-      DQEJARYOYnJhZEBkYW5nYS5jb20wHhcNMTQwNzE1MjA0NjA1WhcNMTcwNTA0MjA0
-      NjA1WjB7MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBG
-      cmFuY2lzY28xFDASBgNVBAoTC0JyYWRmaXR6aW5jMRIwEAYDVQQDEwlsb2NhbGhv
-      c3QxHTAbBgkqhkiG9w0BCQEWDmJyYWRAZGFuZ2EuY29tMIIBIjANBgkqhkiG9w0B
-      AQEFAAOCAQ8AMIIBCgKCAQEAt5fAjp4fTcekWUTfzsp0kyih1OYbsGL0KX1eRbSS
-      R8Od0+9Q62Hyny+GFwMTb4A/KU8mssoHvcceSAAbwfbxFK/+s51TobqUnORZrOoT
-      ZjkUygbyXDSK99YBbcR1Pip8vwMTm4XKuLtCigeBBdjjAQdgUO28LENGlsMnmeYk
-      JfODVGnVmr5Ltb9ANA8IKyTfsnHJ4iOCS/PlPbUj2q7YnoVLposUBMlgUb/CykX3
-      mOoLb4yJJQyA/iST6ZxiIEj36D4yWZ5lg7YJl+UiiBQHGCnPdGyipqV06ex0heYW
-      caiW8LWZSUQ93jQ+WVCH8hT7DQO1dmsvUmXlq/JeAlwQ/QIDAQABo4HgMIHdMB0G
-      A1UdDgQWBBRcAROthS4P4U7vTfjByC569R7E6DCBrQYDVR0jBIGlMIGigBRcAROt
-      hS4P4U7vTfjByC569R7E6KF/pH0wezELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
-      MRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQKEwtCcmFkZml0emluYzES
-      MBAGA1UEAxMJbG9jYWxob3N0MR0wGwYJKoZIhvcNAQkBFg5icmFkQGRhbmdhLmNv
-      bYIJALfRlWsI8YQHMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAG6h
-      U9f9sNH0/6oBbGGy2EVU0UgITUQIrFWo9rFkrW5k/XkDjQm+3lzjT0iGR4IxE/Ao
-      eU6sQhua7wrWeFEn47GL98lnCsJdD7oZNhFmQ95Tb/LnDUjs5Yj9brP0NWzXfYU4
-      UK2ZnINJRcJpB8iRCaCxE8DdcUF0XqIEq6pA272snoLmiXLMvNl3kYEdm+je6voD
-      58SNVEUsztzQyXmJEhCpwVI0A6QCjzXj+qvpmw3ZZHi8JwXei8ZZBLTSFBki8Z7n
-      sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
-      kPe6XoSbiLm/kxk32T0=
-      -----END CERTIFICATE-----
-
-  - path: "/etc/systemd/system/setup.service"
-    permissions: "0644"
-    content: |
-      [Install]
-      WantedBy=multi-user.target
-      
-      [Unit]
-      Requires=network-online.target
-      After=network-online.target
-      
-      [Service]
-      Type=oneshot
-      RemainAfterExit=true
-      EnvironmentFile=-/etc/environment
-      ExecStart=/opt/bin/supervise.sh /opt/bin/setup
-
-  - path: "/etc/profile.d/opt-bin-path.sh"
-    permissions: "0644"
-    content: |
-      export PATH="/opt/bin:$PATH"
-
-  - path: /etc/docker/daemon.json
-    permissions: "0644"
-    content: |
-      {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","log-driver":"json-file","log-opts":{"max-file":"5","max-size":"100m"}}
-
-  - path: /etc/systemd/system/kubelet-healthcheck.service
-    permissions: "0644"
-    content: |
-      [Unit]
-      Requires=kubelet.service
-      After=kubelet.service
-      
-      [Service]
-      ExecStart=/opt/bin/health-monitor.sh kubelet
-      
-      [Install]
-      WantedBy=multi-user.target
+- path: "/etc/kubernetes/bootstrap-kubelet.conf"
+  permissions: "0600"
+  content: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVXakNDQTBLZ0F3SUJBZ0lKQUxmUmxXc0k4WVFITUEwR0NTcUdTSWIzRFFFQkJRVUFNSHN4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlFd0pEUVRFV01CUUdBMVVFQnhNTlUyRnVJRVp5WVc1amFYTmpiekVVTUJJRwpBMVVFQ2hNTFFuSmhaR1pwZEhwcGJtTXhFakFRQmdOVkJBTVRDV3h2WTJGc2FHOXpkREVkTUJzR0NTcUdTSWIzCkRRRUpBUllPWW5KaFpFQmtZVzVuWVM1amIyMHdIaGNOTVRRd056RTFNakEwTmpBMVdoY05NVGN3TlRBME1qQTAKTmpBMVdqQjdNUXN3Q1FZRFZRUUdFd0pWVXpFTE1Ba0dBMVVFQ0JNQ1EwRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhGREFTQmdOVkJBb1RDMEp5WVdSbWFYUjZhVzVqTVJJd0VBWURWUVFERXdsc2IyTmhiR2h2CmMzUXhIVEFiQmdrcWhraUc5dzBCQ1FFV0RtSnlZV1JBWkdGdVoyRXVZMjl0TUlJQklqQU5CZ2txaGtpRzl3MEIKQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBdDVmQWpwNGZUY2VrV1VUZnpzcDBreWloMU9ZYnNHTDBLWDFlUmJTUwpSOE9kMCs5UTYySHlueStHRndNVGI0QS9LVThtc3NvSHZjY2VTQUFid2ZieEZLLytzNTFUb2JxVW5PUlpyT29UClpqa1V5Z2J5WERTSzk5WUJiY1IxUGlwOHZ3TVRtNFhLdUx0Q2lnZUJCZGpqQVFkZ1VPMjhMRU5HbHNNbm1lWWsKSmZPRFZHblZtcjVMdGI5QU5BOElLeVRmc25ISjRpT0NTL1BsUGJVajJxN1lub1ZMcG9zVUJNbGdVYi9DeWtYMwptT29MYjR5SkpReUEvaVNUNlp4aUlFajM2RDR5V1o1bGc3WUpsK1VpaUJRSEdDblBkR3lpcHFWMDZleDBoZVlXCmNhaVc4TFdaU1VROTNqUStXVkNIOGhUN0RRTzFkbXN2VW1YbHEvSmVBbHdRL1FJREFRQUJvNEhnTUlIZE1CMEcKQTFVZERnUVdCQlJjQVJPdGhTNFA0VTd2VGZqQnlDNTY5UjdFNkRDQnJRWURWUjBqQklHbE1JR2lnQlJjQVJPdApoUzRQNFU3dlRmakJ5QzU2OVI3RTZLRi9wSDB3ZXpFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ1RBa05CCk1SWXdGQVlEVlFRSEV3MVRZVzRnUm5KaGJtTnBjMk52TVJRd0VnWURWUVFLRXd0Q2NtRmtabWwwZW1sdVl6RVMKTUJBR0ExVUVBeE1KYkc5allXeG9iM04wTVIwd0d3WUpLb1pJaHZjTkFRa0JGZzVpY21Ga1FHUmhibWRoTG1OdgpiWUlKQUxmUmxXc0k4WVFITUF3R0ExVWRFd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVGQlFBRGdnRUJBRzZoClU5ZjlzTkgwLzZvQmJHR3kyRVZVMFVnSVRVUUlyRldvOXJGa3JXNWsvWGtEalFtKzNsempUMGlHUjRJeEUvQW8KZVU2c1FodWE3d3JXZUZFbjQ3R0w5OGxuQ3NKZEQ3b1pOaEZtUTk1VGIvTG5EVWpzNVlqOWJyUDBOV3pYZllVNApVSzJabklOSlJjSnBCOGlSQ2FDeEU4RGRjVUYwWHFJRXE2cEEyNzJzbm9MbWlYTE12Tmwza1lFZG0ramU2dm9ECjU4U05WRVVzenR6UXlYbUpFaENwd1ZJMEE2UUNqelhqK3F2cG13M1paSGk4SndYZWk4WlpCTFRTRkJraThaN24Kc0g5QkJIMzgvU3pVbUFONFFIU1B5MWdqcW0wME9BRThOYVlEa2gvYnpFNGQ3bUxHR01XcC9XRTNLUFN1ODJIRgprUGU2WG9TYmlMbS9reGszMlQwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+        server: https://server:443
+      name: ""
+    contexts: null
+    current-context: ""
+    kind: Config
+    preferences: {}
+    users:
+    - name: ""
+      user:
+        token: my-token
 
 
-  - path: "/opt/bin/disable-nm-cloud-setup"
-    permissions: "0755"
-    content: |
-      #!/bin/bash
-      set -xeuo pipefail
-      if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
-              systemctl stop nm-cloud-setup.timer
-              systemctl disable nm-cloud-setup.service
-              systemctl disable nm-cloud-setup.timer
-              reboot
-      fi
+- path: "/etc/kubernetes/kubelet.conf"
+  content: |
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous:
+        enabled: false
+      webhook:
+        cacheTTL: 0s
+        enabled: true
+      x509:
+        clientCAFile: /etc/kubernetes/pki/ca.crt
+    authorization:
+      mode: Webhook
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    cgroupDriver: systemd
+    clusterDomain: cluster.local
+    containerLogMaxSize: 100Mi
+    cpuManagerReconcilePeriod: 0s
+    evictionHard:
+      imagefs.available: 15%
+      memory.available: 100Mi
+      nodefs.available: 10%
+      nodefs.inodesFree: 5%
+    evictionPressureTransitionPeriod: 0s
+    featureGates:
+      RotateKubeletServerCertificate: true
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 200m
+      ephemeral-storage: 1Gi
+      memory: 200Mi
+    logging: {}
+    memorySwap: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    protectKernelDefaults: true
+    rotateCertificates: true
+    runtimeRequestTimeout: 0s
+    serverTLSBootstrap: true
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    staticPodPath: /etc/kubernetes/manifests
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      cpu: 200m
+      ephemeral-storage: 1Gi
+      memory: 200Mi
+    tlsCipherSuites:
+    - TLS_AES_128_GCM_SHA256
+    - TLS_AES_256_GCM_SHA384
+    - TLS_CHACHA20_POLY1305_SHA256
+    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+    volumePluginDir: /var/lib/kubelet/volumeplugins
+    volumeStatsAggPeriod: 0s
 
-  - path: "/etc/systemd/system/disable-nm-cloud-setup.service"
-    permissions: "0644"
-    content: |
-      [Install]
-      WantedBy=multi-user.target
-      
-      [Unit]
-      Requires=network-online.target
-      After=network-online.target
-      
-      [Service]
-      Type=oneshot
-      RemainAfterExit=true
-      EnvironmentFile=-/etc/environment
-      ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
+- path: "/etc/kubernetes/pki/ca.crt"
+  content: |
+    -----BEGIN CERTIFICATE-----
+    MIIEWjCCA0KgAwIBAgIJALfRlWsI8YQHMA0GCSqGSIb3DQEBBQUAMHsxCzAJBgNV
+    BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEUMBIG
+    A1UEChMLQnJhZGZpdHppbmMxEjAQBgNVBAMTCWxvY2FsaG9zdDEdMBsGCSqGSIb3
+    DQEJARYOYnJhZEBkYW5nYS5jb20wHhcNMTQwNzE1MjA0NjA1WhcNMTcwNTA0MjA0
+    NjA1WjB7MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBG
+    cmFuY2lzY28xFDASBgNVBAoTC0JyYWRmaXR6aW5jMRIwEAYDVQQDEwlsb2NhbGhv
+    c3QxHTAbBgkqhkiG9w0BCQEWDmJyYWRAZGFuZ2EuY29tMIIBIjANBgkqhkiG9w0B
+    AQEFAAOCAQ8AMIIBCgKCAQEAt5fAjp4fTcekWUTfzsp0kyih1OYbsGL0KX1eRbSS
+    R8Od0+9Q62Hyny+GFwMTb4A/KU8mssoHvcceSAAbwfbxFK/+s51TobqUnORZrOoT
+    ZjkUygbyXDSK99YBbcR1Pip8vwMTm4XKuLtCigeBBdjjAQdgUO28LENGlsMnmeYk
+    JfODVGnVmr5Ltb9ANA8IKyTfsnHJ4iOCS/PlPbUj2q7YnoVLposUBMlgUb/CykX3
+    mOoLb4yJJQyA/iST6ZxiIEj36D4yWZ5lg7YJl+UiiBQHGCnPdGyipqV06ex0heYW
+    caiW8LWZSUQ93jQ+WVCH8hT7DQO1dmsvUmXlq/JeAlwQ/QIDAQABo4HgMIHdMB0G
+    A1UdDgQWBBRcAROthS4P4U7vTfjByC569R7E6DCBrQYDVR0jBIGlMIGigBRcAROt
+    hS4P4U7vTfjByC569R7E6KF/pH0wezELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+    MRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQKEwtCcmFkZml0emluYzES
+    MBAGA1UEAxMJbG9jYWxob3N0MR0wGwYJKoZIhvcNAQkBFg5icmFkQGRhbmdhLmNv
+    bYIJALfRlWsI8YQHMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAG6h
+    U9f9sNH0/6oBbGGy2EVU0UgITUQIrFWo9rFkrW5k/XkDjQm+3lzjT0iGR4IxE/Ao
+    eU6sQhua7wrWeFEn47GL98lnCsJdD7oZNhFmQ95Tb/LnDUjs5Yj9brP0NWzXfYU4
+    UK2ZnINJRcJpB8iRCaCxE8DdcUF0XqIEq6pA272snoLmiXLMvNl3kYEdm+je6voD
+    58SNVEUsztzQyXmJEhCpwVI0A6QCjzXj+qvpmw3ZZHi8JwXei8ZZBLTSFBki8Z7n
+    sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
+    kPe6XoSbiLm/kxk32T0=
+    -----END CERTIFICATE-----
+
+- path: "/etc/systemd/system/setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/setup
+
+- path: "/etc/profile.d/opt-bin-path.sh"
+  permissions: "0644"
+  content: |
+    export PATH="/opt/bin:$PATH"
+
+- path: /etc/docker/daemon.json
+  permissions: "0644"
+  content: |
+    {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","log-driver":"json-file","log-opts":{"max-file":"5","max-size":"100m"}}
+
+- path: /etc/systemd/system/kubelet-healthcheck.service
+  permissions: "0644"
+  content: |
+    [Unit]
+    Requires=kubelet.service
+    After=kubelet.service
+
+    [Service]
+    ExecStart=/opt/bin/health-monitor.sh kubelet
+
+    [Install]
+    WantedBy=multi-user.target
+
+
+- path: "/opt/bin/disable-nm-cloud-setup"
+  permissions: "0755"
+  content: |
+    #!/bin/bash
+    set -xeuo pipefail
+    if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+            systemctl stop nm-cloud-setup.timer
+            systemctl disable nm-cloud-setup.service
+            systemctl disable nm-cloud-setup.timer
+            reboot
+    fi
+
+- path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+  permissions: "0644"
+  content: |
+    [Install]
+    WantedBy=multi-user.target
+
+    [Unit]
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Type=oneshot
+    RemainAfterExit=true
+    EnvironmentFile=-/etc/environment
+    ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
 
 rh_subscription:
-  username: ""
-  password: ""
-  auto-attach: false
+    username: ""
+    password: ""
+    auto-attach: false
+
+runcmd:
+- systemctl start setup.service
+- systemctl start disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -1,0 +1,469 @@
+#cloud-config
+bootcmd:
+  - modprobe ip_tables
+
+hostname: node1
+fqdn: node1
+
+
+ssh_pwauth: false
+
+write_files:
+
+  - path: "/etc/systemd/journald.conf.d/max_disk_use.conf"
+    content: |
+      [Journal]
+      SystemMaxUse=5G
+
+
+  - path: "/opt/load-kernel-modules.sh"
+    permissions: "0755"
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      
+      modprobe ip_vs
+      modprobe ip_vs_rr
+      modprobe ip_vs_wrr
+      modprobe ip_vs_sh
+      
+      if modinfo nf_conntrack_ipv4 &> /dev/null; then
+        modprobe nf_conntrack_ipv4
+      else
+        modprobe nf_conntrack
+      fi
+
+
+  - path: "/etc/sysctl.d/k8s.conf"
+    content: |
+      net.bridge.bridge-nf-call-ip6tables = 1
+      net.bridge.bridge-nf-call-iptables = 1
+      kernel.panic_on_oops = 1
+      kernel.panic = 10
+      net.ipv4.ip_forward = 1
+      vm.overcommit_memory = 1
+      fs.inotify.max_user_watches = 1048576
+
+
+  - path: /etc/selinux/config
+    content: |
+      # This file controls the state of SELinux on the system.
+      # SELINUX= can take one of these three values:
+      #     enforcing - SELinux security policy is enforced.
+      #     permissive - SELinux prints warnings instead of enforcing.
+      #     disabled - No SELinux policy is loaded.
+      SELINUX=permissive
+      # SELINUXTYPE= can take one of three two values:
+      #     targeted - Targeted processes are protected,
+      #     minimum - Modification of targeted policy. Only selected processes are protected.
+      #     mls - Multi Level Security protection.
+      SELINUXTYPE=targeted
+
+  - path: "/opt/bin/setup"
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      set -xeuo pipefail
+      
+      setenforce 0 || true
+      systemctl restart systemd-modules-load.service
+      sysctl --system
+      sed -i.orig '/.*swap.*/d' /etc/fstab
+      swapoff -a
+      
+      hostnamectl set-hostname node1
+      
+      
+      yum update -y --disablerepo='*' --enablerepo='*microsoft*'
+      
+      yum install -y \
+        device-mapper-persistent-data \
+        lvm2 \
+        ebtables \
+        ethtool \
+        nfs-utils \
+        bash-completion \
+        sudo \
+        socat \
+        wget \
+        curl \
+        ipvsadm
+      
+      yum install -y yum-utils
+      yum-config-manager --add-repo=https://download.docker.com/linux/centos/docker-ce.repo
+      yum-config-manager --save --setopt=docker-ce-stable.module_hotfixes=true
+      
+      mkdir -p /etc/systemd/system/containerd.service.d /etc/systemd/system/docker.service.d
+      
+      cat <<EOF | tee /etc/systemd/system/containerd.service.d/environment.conf /etc/systemd/system/docker.service.d/environment.conf
+      [Service]
+      Restart=always
+      EnvironmentFile=-/etc/environment
+      EOF
+      
+      yum install -y \
+          docker-ce-cli-19.03* \
+          containerd.io-1.4* \
+          docker-ce-19.03* \
+          yum-plugin-versionlock
+      yum versionlock add docker-ce* containerd.io
+      
+      systemctl daemon-reload
+      systemctl enable --now docker
+      
+      opt_bin=/opt/bin
+      usr_local_bin=/usr/local/bin
+      cni_bin_dir=/opt/cni/bin
+      mkdir -p /etc/cni/net.d /etc/kubernetes/dynamic-config-dir /etc/kubernetes/manifests "$opt_bin" "$cni_bin_dir"
+      arch=${HOST_ARCH-}
+      if [ -z "$arch" ]
+      then
+      case $(uname -m) in
+      x86_64)
+          arch="amd64"
+          ;;
+      aarch64)
+          arch="arm64"
+          ;;
+      *)
+          echo "unsupported CPU architecture, exiting"
+          exit 1
+          ;;
+      esac
+      fi
+      CNI_VERSION="${CNI_VERSION:-v0.8.7}"
+      cni_base_url="https://github.com/containernetworking/plugins/releases/download/$CNI_VERSION"
+      cni_filename="cni-plugins-linux-$arch-$CNI_VERSION.tgz"
+      curl -Lfo "$cni_bin_dir/$cni_filename" "$cni_base_url/$cni_filename"
+      cni_sum=$(curl -Lf "$cni_base_url/$cni_filename.sha256")
+      cd "$cni_bin_dir"
+      sha256sum -c <<<"$cni_sum"
+      tar xvf "$cni_filename"
+      rm -f "$cni_filename"
+      cd -
+      CRI_TOOLS_RELEASE="${CRI_TOOLS_RELEASE:-v1.22.0}"
+      cri_tools_base_url="https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRI_TOOLS_RELEASE}"
+      cri_tools_filename="crictl-${CRI_TOOLS_RELEASE}-linux-${arch}.tar.gz"
+      curl -Lfo "$opt_bin/$cri_tools_filename" "$cri_tools_base_url/$cri_tools_filename"
+      cri_tools_sum=$(curl -Lf "$cri_tools_base_url/$cri_tools_filename.sha256" | sed 's/\*\///')
+      cd "$opt_bin"
+      sha256sum -c <<<"$cri_tools_sum"
+      tar xvf "$cri_tools_filename"
+      rm -f "$cri_tools_filename"
+      ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
+      cd -
+      KUBE_VERSION="${KUBE_VERSION:-v1.22.2}"
+      kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
+      kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
+      kube_sum_file="$kube_dir/sha256"
+      mkdir -p "$kube_dir"
+      : >"$kube_sum_file"
+      
+      for bin in kubelet kubeadm kubectl; do
+          curl -Lfo "$kube_dir/$bin" "$kube_base_url/$bin"
+          chmod +x "$kube_dir/$bin"
+          sum=$(curl -Lf "$kube_base_url/$bin.sha256")
+          echo "$sum  $kube_dir/$bin" >>"$kube_sum_file"
+      done
+      sha256sum -c "$kube_sum_file"
+      
+      for bin in kubelet kubeadm kubectl; do
+          ln -sf "$kube_dir/$bin" "$opt_bin"/$bin
+      done
+      
+      if [[ ! -x /opt/bin/health-monitor.sh ]]; then
+          curl -Lfo /opt/bin/health-monitor.sh https://raw.githubusercontent.com/kubermatic/machine-controller/7967a0af2b75f29ad2ab227eeaa26ea7b0f2fbde/pkg/userdata/scripts/health-monitor.sh
+          chmod +x /opt/bin/health-monitor.sh
+      fi
+      
+      # set kubelet nodeip environment variable
+      mkdir -p /etc/systemd/system/kubelet.service.d/
+      /opt/bin/setup_net_env.sh
+      
+      
+      firewall-cmd --permanent --zone=trusted --add-source=172.25.0.0/16 
+      firewall-cmd --permanent --zone=trusted --add-source=fd00::/104
+      firewall-cmd --permanent --add-port=8472/udp
+      firewall-cmd --permanent --add-port=/tcp
+      firewall-cmd --permanent --add-port=/udp
+      firewall-cmd --reload
+      systemctl restart firewalld
+      systemctl enable --now kubelet
+      systemctl enable --now --no-block kubelet-healthcheck.service
+
+  - path: "/opt/bin/supervise.sh"
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      set -xeuo pipefail
+      while ! "$@"; do
+        sleep 1
+      done
+
+  - path: "/etc/systemd/system/kubelet.service"
+    content: |
+      [Unit]
+      After=docker.service
+      Requires=docker.service
+      
+      Description=kubelet: The Kubernetes Node Agent
+      Documentation=https://kubernetes.io/docs/home/
+      
+      [Service]
+      Restart=always
+      StartLimitInterval=0
+      RestartSec=10
+      CPUAccounting=true
+      MemoryAccounting=true
+      
+      Environment="PATH=/opt/bin:/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin/"
+      EnvironmentFile=-/etc/environment
+      
+      ExecStartPre=/bin/bash /opt/load-kernel-modules.sh
+      ExecStartPre=/bin/bash /opt/bin/setup_net_env.sh
+      ExecStart=/opt/bin/kubelet $KUBELET_EXTRA_ARGS \
+        --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf \
+        --kubeconfig=/var/lib/kubelet/kubeconfig \
+        --config=/etc/kubernetes/kubelet.conf \
+        --network-plugin=cni \
+        --cert-dir=/etc/kubernetes/pki \
+        --cloud-provider=azure \
+        --cloud-config=/etc/kubernetes/cloud-config \
+        --hostname-override=node1 \
+        --exit-on-lock-contention \
+        --lock-file=/tmp/kubelet.lock \
+        --container-runtime=docker \
+        --container-runtime-endpoint=unix:///var/run/dockershim.sock \
+        --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
+        --feature-gates=DynamicKubeletConfig=true \
+        --node-ip ${KUBELET_NODE_IP}
+      
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: "/etc/kubernetes/cloud-config"
+    permissions: "0600"
+    content: |
+      {config:true}
+
+  - path: "/opt/bin/setup_net_env.sh"
+    permissions: "0755"
+    content: |
+      #!/usr/bin/env bash
+      echodate() {
+        echo "[$(date -Is)]" "$@"
+      }
+      
+      # get the default interface IP address
+      DEFAULT_IFC_IP=$(ip -o  route get 1 | grep -oP "src \K\S+")
+      
+      # get the full hostname
+      FULL_HOSTNAME=$(hostname -f)
+      
+      if [ -z "${DEFAULT_IFC_IP}" ]
+      then
+      	echodate "Failed to get IP address for the default route interface"
+      	exit 1
+      fi
+      
+      # write the nodeip_env file
+      # we need the line below because flatcar has the same string "coreos" in that file
+      if grep -q coreos /etc/os-release
+      then
+        echo -e "KUBELET_NODE_IP=${DEFAULT_IFC_IP}\nKUBELET_HOSTNAME=${FULL_HOSTNAME}" > /etc/kubernetes/nodeip.conf
+      elif [ ! -d /etc/systemd/system/kubelet.service.d ]
+      then
+      	echodate "Can't find kubelet service extras directory"
+      	exit 1
+      else
+        echo -e "[Service]\nEnvironment=\"KUBELET_NODE_IP=${DEFAULT_IFC_IP}\"\nEnvironment=\"KUBELET_HOSTNAME=${FULL_HOSTNAME}\"" > /etc/systemd/system/kubelet.service.d/nodeip.conf
+      fi
+
+
+  - path: "/etc/kubernetes/bootstrap-kubelet.conf"
+    permissions: "0600"
+    content: |
+      apiVersion: v1
+      clusters:
+      - cluster:
+          certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVXakNDQTBLZ0F3SUJBZ0lKQUxmUmxXc0k4WVFITUEwR0NTcUdTSWIzRFFFQkJRVUFNSHN4Q3pBSkJnTlYKQkFZVEFsVlRNUXN3Q1FZRFZRUUlFd0pEUVRFV01CUUdBMVVFQnhNTlUyRnVJRVp5WVc1amFYTmpiekVVTUJJRwpBMVVFQ2hNTFFuSmhaR1pwZEhwcGJtTXhFakFRQmdOVkJBTVRDV3h2WTJGc2FHOXpkREVkTUJzR0NTcUdTSWIzCkRRRUpBUllPWW5KaFpFQmtZVzVuWVM1amIyMHdIaGNOTVRRd056RTFNakEwTmpBMVdoY05NVGN3TlRBME1qQTAKTmpBMVdqQjdNUXN3Q1FZRFZRUUdFd0pWVXpFTE1Ba0dBMVVFQ0JNQ1EwRXhGakFVQmdOVkJBY1REVk5oYmlCRwpjbUZ1WTJselkyOHhGREFTQmdOVkJBb1RDMEp5WVdSbWFYUjZhVzVqTVJJd0VBWURWUVFERXdsc2IyTmhiR2h2CmMzUXhIVEFiQmdrcWhraUc5dzBCQ1FFV0RtSnlZV1JBWkdGdVoyRXVZMjl0TUlJQklqQU5CZ2txaGtpRzl3MEIKQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBdDVmQWpwNGZUY2VrV1VUZnpzcDBreWloMU9ZYnNHTDBLWDFlUmJTUwpSOE9kMCs5UTYySHlueStHRndNVGI0QS9LVThtc3NvSHZjY2VTQUFid2ZieEZLLytzNTFUb2JxVW5PUlpyT29UClpqa1V5Z2J5WERTSzk5WUJiY1IxUGlwOHZ3TVRtNFhLdUx0Q2lnZUJCZGpqQVFkZ1VPMjhMRU5HbHNNbm1lWWsKSmZPRFZHblZtcjVMdGI5QU5BOElLeVRmc25ISjRpT0NTL1BsUGJVajJxN1lub1ZMcG9zVUJNbGdVYi9DeWtYMwptT29MYjR5SkpReUEvaVNUNlp4aUlFajM2RDR5V1o1bGc3WUpsK1VpaUJRSEdDblBkR3lpcHFWMDZleDBoZVlXCmNhaVc4TFdaU1VROTNqUStXVkNIOGhUN0RRTzFkbXN2VW1YbHEvSmVBbHdRL1FJREFRQUJvNEhnTUlIZE1CMEcKQTFVZERnUVdCQlJjQVJPdGhTNFA0VTd2VGZqQnlDNTY5UjdFNkRDQnJRWURWUjBqQklHbE1JR2lnQlJjQVJPdApoUzRQNFU3dlRmakJ5QzU2OVI3RTZLRi9wSDB3ZXpFTE1Ba0dBMVVFQmhNQ1ZWTXhDekFKQmdOVkJBZ1RBa05CCk1SWXdGQVlEVlFRSEV3MVRZVzRnUm5KaGJtTnBjMk52TVJRd0VnWURWUVFLRXd0Q2NtRmtabWwwZW1sdVl6RVMKTUJBR0ExVUVBeE1KYkc5allXeG9iM04wTVIwd0d3WUpLb1pJaHZjTkFRa0JGZzVpY21Ga1FHUmhibWRoTG1OdgpiWUlKQUxmUmxXc0k4WVFITUF3R0ExVWRFd1FGTUFNQkFmOHdEUVlKS29aSWh2Y05BUUVGQlFBRGdnRUJBRzZoClU5ZjlzTkgwLzZvQmJHR3kyRVZVMFVnSVRVUUlyRldvOXJGa3JXNWsvWGtEalFtKzNsempUMGlHUjRJeEUvQW8KZVU2c1FodWE3d3JXZUZFbjQ3R0w5OGxuQ3NKZEQ3b1pOaEZtUTk1VGIvTG5EVWpzNVlqOWJyUDBOV3pYZllVNApVSzJabklOSlJjSnBCOGlSQ2FDeEU4RGRjVUYwWHFJRXE2cEEyNzJzbm9MbWlYTE12Tmwza1lFZG0ramU2dm9ECjU4U05WRVVzenR6UXlYbUpFaENwd1ZJMEE2UUNqelhqK3F2cG13M1paSGk4SndYZWk4WlpCTFRTRkJraThaN24Kc0g5QkJIMzgvU3pVbUFONFFIU1B5MWdqcW0wME9BRThOYVlEa2gvYnpFNGQ3bUxHR01XcC9XRTNLUFN1ODJIRgprUGU2WG9TYmlMbS9reGszMlQwPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+          server: https://server:443
+        name: ""
+      contexts: null
+      current-context: ""
+      kind: Config
+      preferences: {}
+      users:
+      - name: ""
+        user:
+          token: my-token
+
+
+  - path: "/etc/kubernetes/kubelet.conf"
+    content: |
+      apiVersion: kubelet.config.k8s.io/v1beta1
+      authentication:
+        anonymous:
+          enabled: false
+        webhook:
+          cacheTTL: 0s
+          enabled: true
+        x509:
+          clientCAFile: /etc/kubernetes/pki/ca.crt
+      authorization:
+        mode: Webhook
+        webhook:
+          cacheAuthorizedTTL: 0s
+          cacheUnauthorizedTTL: 0s
+      cgroupDriver: systemd
+      clusterDomain: cluster.local
+      containerLogMaxSize: 100Mi
+      cpuManagerReconcilePeriod: 0s
+      evictionHard:
+        imagefs.available: 15%
+        memory.available: 100Mi
+        nodefs.available: 10%
+        nodefs.inodesFree: 5%
+      evictionPressureTransitionPeriod: 0s
+      featureGates:
+        RotateKubeletServerCertificate: true
+      fileCheckFrequency: 0s
+      httpCheckFrequency: 0s
+      imageMinimumGCAge: 0s
+      kind: KubeletConfiguration
+      kubeReserved:
+        cpu: 200m
+        ephemeral-storage: 1Gi
+        memory: 200Mi
+      logging: {}
+      memorySwap: {}
+      nodeStatusReportFrequency: 0s
+      nodeStatusUpdateFrequency: 0s
+      protectKernelDefaults: true
+      rotateCertificates: true
+      runtimeRequestTimeout: 0s
+      serverTLSBootstrap: true
+      shutdownGracePeriod: 0s
+      shutdownGracePeriodCriticalPods: 0s
+      staticPodPath: /etc/kubernetes/manifests
+      streamingConnectionIdleTimeout: 0s
+      syncFrequency: 0s
+      systemReserved:
+        cpu: 200m
+        ephemeral-storage: 1Gi
+        memory: 200Mi
+      tlsCipherSuites:
+      - TLS_AES_128_GCM_SHA256
+      - TLS_AES_256_GCM_SHA384
+      - TLS_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+      volumePluginDir: /var/lib/kubelet/volumeplugins
+      volumeStatsAggPeriod: 0s
+
+
+  - path: "/etc/kubernetes/pki/ca.crt"
+    content: |
+      -----BEGIN CERTIFICATE-----
+      MIIEWjCCA0KgAwIBAgIJALfRlWsI8YQHMA0GCSqGSIb3DQEBBQUAMHsxCzAJBgNV
+      BAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UEBxMNU2FuIEZyYW5jaXNjbzEUMBIG
+      A1UEChMLQnJhZGZpdHppbmMxEjAQBgNVBAMTCWxvY2FsaG9zdDEdMBsGCSqGSIb3
+      DQEJARYOYnJhZEBkYW5nYS5jb20wHhcNMTQwNzE1MjA0NjA1WhcNMTcwNTA0MjA0
+      NjA1WjB7MQswCQYDVQQGEwJVUzELMAkGA1UECBMCQ0ExFjAUBgNVBAcTDVNhbiBG
+      cmFuY2lzY28xFDASBgNVBAoTC0JyYWRmaXR6aW5jMRIwEAYDVQQDEwlsb2NhbGhv
+      c3QxHTAbBgkqhkiG9w0BCQEWDmJyYWRAZGFuZ2EuY29tMIIBIjANBgkqhkiG9w0B
+      AQEFAAOCAQ8AMIIBCgKCAQEAt5fAjp4fTcekWUTfzsp0kyih1OYbsGL0KX1eRbSS
+      R8Od0+9Q62Hyny+GFwMTb4A/KU8mssoHvcceSAAbwfbxFK/+s51TobqUnORZrOoT
+      ZjkUygbyXDSK99YBbcR1Pip8vwMTm4XKuLtCigeBBdjjAQdgUO28LENGlsMnmeYk
+      JfODVGnVmr5Ltb9ANA8IKyTfsnHJ4iOCS/PlPbUj2q7YnoVLposUBMlgUb/CykX3
+      mOoLb4yJJQyA/iST6ZxiIEj36D4yWZ5lg7YJl+UiiBQHGCnPdGyipqV06ex0heYW
+      caiW8LWZSUQ93jQ+WVCH8hT7DQO1dmsvUmXlq/JeAlwQ/QIDAQABo4HgMIHdMB0G
+      A1UdDgQWBBRcAROthS4P4U7vTfjByC569R7E6DCBrQYDVR0jBIGlMIGigBRcAROt
+      hS4P4U7vTfjByC569R7E6KF/pH0wezELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNB
+      MRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRQwEgYDVQQKEwtCcmFkZml0emluYzES
+      MBAGA1UEAxMJbG9jYWxob3N0MR0wGwYJKoZIhvcNAQkBFg5icmFkQGRhbmdhLmNv
+      bYIJALfRlWsI8YQHMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAG6h
+      U9f9sNH0/6oBbGGy2EVU0UgITUQIrFWo9rFkrW5k/XkDjQm+3lzjT0iGR4IxE/Ao
+      eU6sQhua7wrWeFEn47GL98lnCsJdD7oZNhFmQ95Tb/LnDUjs5Yj9brP0NWzXfYU4
+      UK2ZnINJRcJpB8iRCaCxE8DdcUF0XqIEq6pA272snoLmiXLMvNl3kYEdm+je6voD
+      58SNVEUsztzQyXmJEhCpwVI0A6QCjzXj+qvpmw3ZZHi8JwXei8ZZBLTSFBki8Z7n
+      sH9BBH38/SzUmAN4QHSPy1gjqm00OAE8NaYDkh/bzE4d7mLGGMWp/WE3KPSu82HF
+      kPe6XoSbiLm/kxk32T0=
+      -----END CERTIFICATE-----
+
+  - path: "/etc/systemd/system/setup.service"
+    permissions: "0644"
+    content: |
+      [Install]
+      WantedBy=multi-user.target
+      
+      [Unit]
+      Requires=network-online.target
+      After=network-online.target
+      
+      [Service]
+      Type=oneshot
+      RemainAfterExit=true
+      EnvironmentFile=-/etc/environment
+      ExecStart=/opt/bin/supervise.sh /opt/bin/setup
+
+  - path: "/etc/profile.d/opt-bin-path.sh"
+    permissions: "0644"
+    content: |
+      export PATH="/opt/bin:$PATH"
+
+  - path: /etc/docker/daemon.json
+    permissions: "0644"
+    content: |
+      {"exec-opts":["native.cgroupdriver=systemd"],"storage-driver":"overlay2","log-driver":"json-file","log-opts":{"max-file":"5","max-size":"100m"}}
+
+  - path: /etc/systemd/system/kubelet-healthcheck.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Requires=kubelet.service
+      After=kubelet.service
+      
+      [Service]
+      ExecStart=/opt/bin/health-monitor.sh kubelet
+      
+      [Install]
+      WantedBy=multi-user.target
+
+
+  - path: "/opt/bin/disable-nm-cloud-setup"
+    permissions: "0755"
+    content: |
+      #!/bin/bash
+      set -xeuo pipefail
+      if systemctl status 'nm-cloud-setup.timer' 2> /dev/null | grep -Fq "Active:"; then
+              systemctl stop nm-cloud-setup.timer
+              systemctl disable nm-cloud-setup.service
+              systemctl disable nm-cloud-setup.timer
+              reboot
+      fi
+
+  - path: "/etc/systemd/system/disable-nm-cloud-setup.service"
+    permissions: "0644"
+    content: |
+      [Install]
+      WantedBy=multi-user.target
+      
+      [Unit]
+      Requires=network-online.target
+      After=network-online.target
+      
+      [Service]
+      Type=oneshot
+      RemainAfterExit=true
+      EnvironmentFile=-/etc/environment
+      ExecStart=/opt/bin/supervise.sh /opt/bin/disable-nm-cloud-setup
+
+rh_subscription:
+  username: ""
+  password: ""
+  auto-attach: false

--- a/test/e2e/provisioning/migrateuidscenario.go
+++ b/test/e2e/provisioning/migrateuidscenario.go
@@ -96,7 +96,7 @@ func verifyMigrateUID(kubeConfig, manifestPath string, parameters []string, time
 				}
 				return fmt.Errorf("failed to get machine %s before creating it: %v", machine.Name, err)
 			}
-			_, err := prov.Create(machine, providerData, "#cloud-config\n")
+			_, err := prov.Create(machine, providerData, "#cloud-config\n", nil)
 			if err != nil {
 				if i < maxTries-1 {
 					time.Sleep(10 * time.Second)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `pod-cidrs` command line flag to accept pod-cidrs information from command line.
Changes `provider.Create` method to use the information during machine instance creation. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Implements part of [#9294](https://github.com/kubermatic/kubermatic/issues/9294)

**Special notes for your reviewer**:

**Optional Release Note**:
```release-note
NONE
```
