### PR TITLE
Alibaba Images names

### DIFF
--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	machineUIDTag   = "machine_uid"
-	centosImageName = "CentOS  7.7 64 bit"
+	centosImageName = "CentOS  7.9 64 bit"
 	ubuntuImageName = "Ubuntu  20.04 64 bit"
 
 	finalizerInstance = "kubermatic.io/cleanup-alibaba-instance"

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -753,7 +753,7 @@ func TestAlibabaProvisioningE2E(t *testing.T) {
 		t.Fatal("unable to run the test suite, ALIBABA_ACCESS_KEY_SECRET environment variable cannot be empty")
 	}
 
-	selector := Not(OsSelector("sles", "rhel", "flatcar"))
+	selector := OsSelector("ubuntu")
 
 	// act
 	params := []string{


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
The `ubuntu` and `centos` image names for Alibaba are hard-coded in https://github.com/kubermatic/machine-controller/blob/master/pkg/cloudprovider/provider/alibaba/provider.go#L46.
At the time ticket 7789 was created, both `ubuntu` and `centos` were failing.
Reproducing today and adding logs, the list of images we get is:
```
I0317 17:22:18.665019   17409 machine_controller.go:712]  image: Alibaba Cloud Linux  3.2104 LTS 64 bit Quick Boot-----------------------------------------------------
I0317 17:22:18.665041   17409 machine_controller.go:712]  image: Alibaba Cloud Linux  2.1903 LTS 64 bit Quick Boot-----------------------------------------------------
I0317 17:22:18.665048   17409 machine_controller.go:712]  image: Alibaba Cloud Linux  3.2104 LTS 64 bit-----------------------------------------------------
I0317 17:22:18.665052   17409 machine_controller.go:712]  image: Alibaba Cloud Linux 2.1903 LTS 64 bit-----------------------------------------------------
I0317 17:22:18.665057   17409 machine_controller.go:712]  image: Rocky Linux  8.5 64bit-----------------------------------------------------
I0317 17:22:18.665061   17409 machine_controller.go:712]  image: Ubuntu  20.04 64 bit-----------------------------------------------------
I0317 17:22:18.665066   17409 machine_controller.go:712]  image: OpenSUSE  15.3 64 bit-----------------------------------------------------
I0317 17:22:18.665086   17409 machine_controller.go:712]  image: Fedora  34 64 bit-----------------------------------------------------
I0317 17:22:18.665091   17409 machine_controller.go:712]  image: CentOS  7.9 64 bit-----------------------------------------------------
I0317 17:22:18.665096   17409 machine_controller.go:712]  image: Debian  10.11 64 bit-----------------------------------------------------
```

I have updated the `centos` image name to have a quick fix for this from `CentOS  7.7 64 bit` to `CentOS  7.9 64 bit` as currently returned by the client.

However, I'm not sure if it's the right fix to do.
Do we want to hard-code the image name ? Take any image name that contains `Ubuntu` or `Centos` ? 
Allow to configure this in the UI? Then it needs more updates than just a machine-controller fix.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes kubermatic/kubermatic#7789

**Special notes for your reviewer**:


**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
