### PR TITLE
Kubevirt Add common label to all VMs linked to the same MachineDeployment

### DIFF
--- a/examples/kubevirt-machinedeployment.yaml
+++ b/examples/kubevirt-machinedeployment.yaml
@@ -26,14 +26,17 @@ spec:
             - "<< YOUR_PUBLIC_KEY >>"
           cloudProvider: "kubevirt"
           cloudProviderSpec:
-            storageClassName: kubermatic-fast
-            pvcSize: "10Gi"
-            sourceURL: http://10.109.79.210/<< OS_NAME >>.img
-            cpus: "1"
-            memory: "2048M"
-            kubeconfig:
-              value: '<< KUBECONFIG >>'
-            namespace: kube-system
+            auth:
+              kubeconfig:
+                value: '<< KUBECONFIG >>'
+            virtualMachine:
+              template:
+                cpus: "1"
+                memory: "2048M"
+                primaryDisk:
+                  osImage: http://10.109.79.210/<< OS_NAME >>.img
+                  size: "10Gi"
+                  storageClassName: kubermatic-fast
           # Can also be `centos`, must align with he configured registryImage above
           operatingSystem: "ubuntu"
           operatingSystemSpec:

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -36,6 +37,7 @@ import (
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -46,7 +48,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 	utilpointer "k8s.io/utils/pointer"
-	"net/url"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -373,6 +374,10 @@ func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidert
 
 	resourceRequirements := kubevirtv1.ResourceRequirements{}
 	labels := map[string]string{"kubevirt.io/vm": machine.Name}
+	// Add a common label to all VirtualMachines spawned by the same MachineDeployment
+	if mdLabel, ok := machine.Labels["machine"]; ok {
+		labels["machine"] = mdLabel
+	}
 
 	sigClient, err := client.New(c.RestConfig, client.Options{})
 	if err != nil {

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -35,6 +35,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
 	kubevirttypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/kubevirt/types"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+	controllerutil "github.com/kubermatic/machine-controller/pkg/controller/util"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
@@ -374,9 +375,9 @@ func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidert
 
 	resourceRequirements := kubevirtv1.ResourceRequirements{}
 	labels := map[string]string{"kubevirt.io/vm": machine.Name}
-	// Add a common label to all VirtualMachines spawned by the same MachineDeployment
-	if mdLabel, ok := machine.Labels["machine"]; ok {
-		labels["machine"] = mdLabel
+	// Add a common label to all VirtualMachines spawned by the same MachineDeployment (= MachineDeployment name)
+	if mdName, err := controllerutil.GetMachineDeploymentNameForMachine(context.Background(), machine, data.Client); err == nil {
+		labels["md"] = mdName
 	}
 
 	sigClient, err := client.New(c.RestConfig, client.Options{})


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
This PR adds a common label `machine: md-<machine-id>` to all VM spawned by the same MachineDeployment.
We already have in all `machine` this common label. Re-using it to add it to the `VirtualMachines`.
Also taking this PR opportunity to update the `example` for the Kubevirt MachineDeployment specification.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
