### PR TITLE
Flatcar stop disabled units

### DIFF
--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -450,10 +450,12 @@ coreos:
 {{- end }}
 {{- if .FlatcarConfig.DisableUpdateEngine }}
   - name: update-engine.service
+    command: stop
     mask: true
 {{- end }}
 {{- if .FlatcarConfig.DisableLocksmithD }}
   - name: locksmithd.service
+    command: stop
     mask: true
 {{- end }}
 {{- if .HTTPProxy }}

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -184,12 +184,10 @@ systemd:
   units:
 {{- if .FlatcarConfig.DisableUpdateEngine }}
     - name: update-engine.service
-      command: stop
       mask: true
 {{- end }}
 {{- if .FlatcarConfig.DisableLocksmithD }}
     - name: locksmithd.service
-      command: stop
       mask: true
 {{- end }}
 

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -184,10 +184,12 @@ systemd:
   units:
 {{- if .FlatcarConfig.DisableUpdateEngine }}
     - name: update-engine.service
+      command: stop
       mask: true
 {{- end }}
 {{- if .FlatcarConfig.DisableLocksmithD }}
     - name: locksmithd.service
+      command: stop
       mask: true
 {{- end }}
 

--- a/pkg/userdata/flatcar/testdata/cloud-init_v1.20.14.yaml
+++ b/pkg/userdata/flatcar/testdata/cloud-init_v1.20.14.yaml
@@ -24,8 +24,10 @@ coreos:
       DNS=8.8.8.8
 
   - name: update-engine.service
+    command: stop
     mask: true
   - name: locksmithd.service
+    command: stop
     mask: true
   - name: download-script.service
     enable: true

--- a/pkg/userdata/flatcar/testdata/cloud-init_v1.21.8.yaml
+++ b/pkg/userdata/flatcar/testdata/cloud-init_v1.21.8.yaml
@@ -24,8 +24,10 @@ coreos:
       DNS=8.8.8.8
 
   - name: update-engine.service
+    command: stop
     mask: true
   - name: locksmithd.service
+    command: stop
     mask: true
   - name: download-script.service
     enable: true

--- a/pkg/userdata/flatcar/testdata/cloud-init_v1.22.5.yaml
+++ b/pkg/userdata/flatcar/testdata/cloud-init_v1.22.5.yaml
@@ -24,8 +24,10 @@ coreos:
       DNS=8.8.8.8
 
   - name: update-engine.service
+    command: stop
     mask: true
   - name: locksmithd.service
+    command: stop
     mask: true
   - name: download-script.service
     enable: true

--- a/pkg/userdata/flatcar/testdata/cloud-init_v1.23.0.yaml
+++ b/pkg/userdata/flatcar/testdata/cloud-init_v1.23.0.yaml
@@ -24,8 +24,10 @@ coreos:
       DNS=8.8.8.8
 
   - name: update-engine.service
+    command: stop
     mask: true
   - name: locksmithd.service
+    command: stop
     mask: true
   - name: download-script.service
     enable: true

--- a/pkg/userdata/flatcar/testdata/containerd.yaml
+++ b/pkg/userdata/flatcar/testdata/containerd.yaml
@@ -9,8 +9,10 @@ users:
 coreos:
   units:
   - name: update-engine.service
+    command: stop
     mask: true
   - name: locksmithd.service
+    command: stop
     mask: true
   - name: download-script.service
     enable: true


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

When `FlatcarConfig.DisableUpdateEngine` is set to true the update-engine.service is not stopped on new provisioned machines, which lead to an unwanted auto-updates to the latest flatcar version with a followed reboot. 
Only after this first reboot the service is then disabled.
The stop command stop the systemd service instantly to suppress the first auto-update on new provisioned machines.

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix disable auto-update when FlatcarConfig.DisableUpdateEngine is set to true
```
