### PR TITLE
Add Helene and Sankalp to OWNERS_ALIASES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ examples/*.srl
 /webhook
 /vendor
 .vscode
+.gitpod.yml

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,10 +4,12 @@ aliases:
   machine-controller-maintainers:
     - ahmedwaleedmalik
     - embik
+    - hdurand0710
     - kron4eg
     - mfranczy
     - moadqassem
     - moelsayed
+    - sankalp-r
     - themue
     - xmudrii
     - xrstf


### PR DESCRIPTION
Signed-off-by: themue <frank.mueller@themue.dev>

**What this PR does / why we need it**:

Add Helene and Sankalp to the OWNERS_ALIASES to the group `machine-controller-maintainers`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
