### PR TITLE
populate machine/node status with IPv6 address

### DIFF
--- a/pkg/cloudprovider/provider/anexia/helper_test.go
+++ b/pkg/cloudprovider/provider/anexia/helper_test.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/anexia-it/go-anxcloud/pkg/vsphere/search"
 	"github.com/gophercloud/gophercloud/testhelper"
+
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -25,16 +25,10 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/progress"
-	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/utils"
-	"k8s.io/apimachinery/pkg/api/meta"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog"
-
 	anxclient "github.com/anexia-it/go-anxcloud/pkg/client"
 	anxaddr "github.com/anexia-it/go-anxcloud/pkg/ipam/address"
 	"github.com/anexia-it/go-anxcloud/pkg/vsphere"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/progress"
 	anxvm "github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/vm"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
@@ -43,12 +37,17 @@ import (
 	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
 	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/utils"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
 )
 
 const (

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -28,11 +28,13 @@ import (
 	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/progress"
 	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/vm"
 	"github.com/gophercloud/gophercloud/testhelper"
+
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/utils"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -17,13 +17,14 @@ limitations under the License.
 package types
 
 import (
-	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
-	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
+	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
 	"github.com/kubermatic/machine-controller/pkg/jsonutil"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -799,6 +799,8 @@ func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidert
 
 	if util.ContainsCIDR(networkConfig.PodCIDRs, util.IPv6) {
 		instanceRequest.NetworkInterfaces[0].Ipv6AddressCount = aws.Int64(1)
+	} else {
+		klog.Infoln("PodCIDRs don't contain IPv6")
 	}
 
 	runOut, err := ec2Client.RunInstances(instanceRequest)

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -1003,10 +1003,21 @@ func (d *awsInstance) ID() string {
 
 func (d *awsInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{
-		aws.StringValue(d.instance.PublicIpAddress):  v1.NodeExternalIP,
-		aws.StringValue(d.instance.PublicDnsName):    v1.NodeExternalDNS,
-		aws.StringValue(d.instance.PrivateIpAddress): v1.NodeInternalIP,
-		aws.StringValue(d.instance.PrivateDnsName):   v1.NodeInternalDNS,
+		aws.StringValue(d.instance.PublicIpAddress):                                   v1.NodeExternalIP,
+		aws.StringValue(d.instance.PublicDnsName):                                     v1.NodeExternalDNS,
+		aws.StringValue(d.instance.PrivateIpAddress):                                  v1.NodeInternalIP,
+		aws.StringValue(d.instance.PrivateDnsName):                                    v1.NodeInternalDNS,
+		aws.StringValue(d.instance.NetworkInterfaces[0].Ipv6Addresses[0].Ipv6Address): util.IPv6Address,
+	}
+
+	if len(d.instance.NetworkInterfaces) > 0 {
+		netInterface := d.instance.NetworkInterfaces[0]
+		if netInterface != nil && len(netInterface.Ipv6Addresses) > 0 {
+			ipv6Addr := netInterface.Ipv6Addresses[0]
+			if ipv6Addr != nil {
+				addresses[aws.StringValue(ipv6Addr.Ipv6Address)] = util.IPv6Address
+			}
+		}
 	}
 
 	delete(addresses, "")

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -1003,19 +1003,17 @@ func (d *awsInstance) ID() string {
 
 func (d *awsInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{
-		aws.StringValue(d.instance.PublicIpAddress):                                   v1.NodeExternalIP,
-		aws.StringValue(d.instance.PublicDnsName):                                     v1.NodeExternalDNS,
-		aws.StringValue(d.instance.PrivateIpAddress):                                  v1.NodeInternalIP,
-		aws.StringValue(d.instance.PrivateDnsName):                                    v1.NodeInternalDNS,
-		aws.StringValue(d.instance.NetworkInterfaces[0].Ipv6Addresses[0].Ipv6Address): util.IPv6Address,
+		aws.StringValue(d.instance.PublicIpAddress):  v1.NodeExternalIP,
+		aws.StringValue(d.instance.PublicDnsName):    v1.NodeExternalDNS,
+		aws.StringValue(d.instance.PrivateIpAddress): v1.NodeInternalIP,
+		aws.StringValue(d.instance.PrivateDnsName):   v1.NodeInternalDNS,
 	}
 
-	if len(d.instance.NetworkInterfaces) > 0 {
-		netInterface := d.instance.NetworkInterfaces[0]
-		if netInterface != nil && len(netInterface.Ipv6Addresses) > 0 {
-			ipv6Addr := netInterface.Ipv6Addresses[0]
-			if ipv6Addr != nil {
-				addresses[aws.StringValue(ipv6Addr.Ipv6Address)] = util.IPv6Address
+	for _, netInterface := range d.instance.NetworkInterfaces {
+		for _, addr := range netInterface.Ipv6Addresses {
+			ipAddr := aws.StringValue(addr.Ipv6Address)
+			if !util.IsLinkLocal(ipAddr) {
+				addresses[ipAddr] = v1.NodeExternalIP
 			}
 		}
 	}

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -800,7 +800,7 @@ func (p *provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidert
 	if util.ContainsCIDR(networkConfig.PodCIDRs, util.IPv6) {
 		instanceRequest.NetworkInterfaces[0].Ipv6AddressCount = aws.Int64(1)
 	} else {
-		klog.Infoln("PodCIDRs don't contain IPv6")
+		klog.Infof("no IPv6 found for PodCIDR in network configs: %s", networkConfig.PodCIDRs)
 	}
 
 	runOut, err := ec2Client.RunInstances(instanceRequest)

--- a/pkg/cloudprovider/util/net.go
+++ b/pkg/cloudprovider/util/net.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 
+	v1 "k8s.io/api/core/v1"
 	net2 "k8s.io/utils/net"
 )
 
@@ -65,3 +66,5 @@ func ContainsCIDR(cidrs []string, version IPVersion) bool {
 
 	return false
 }
+
+const IPv6Address v1.NodeAddressType = "IPv6Address"

--- a/pkg/cloudprovider/util/net.go
+++ b/pkg/cloudprovider/util/net.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 
-	v1 "k8s.io/api/core/v1"
 	net2 "k8s.io/utils/net"
 )
 
@@ -67,4 +66,8 @@ func ContainsCIDR(cidrs []string, version IPVersion) bool {
 	return false
 }
 
-const IPv6Address v1.NodeAddressType = "IPv6Address"
+// IsLinkLocal checks if given ip address is link local
+func IsLinkLocal(ipAddr string) bool {
+	addr := net.ParseIP(ipAddr)
+	return addr.IsLinkLocalMulticast() || addr.IsLinkLocalUnicast()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This populates stats of Machine CRD with IPv6 address information. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Story https://github.com/kubermatic/kubermatic/issues/9294

**Optional Release Note**:

```release-note
NONE
```
