### PR TITLE
Disable firewalld on supported OSes

### DIFF
--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -229,6 +229,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     {{ if eq .CloudProviderName "vsphere" }}
     systemctl enable --now vmtoolsd.service
     {{ end -}}

--- a/pkg/userdata/amzn2/testdata/containerd-kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/containerd-kubelet-v1.20-aws.yaml
@@ -172,6 +172,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.20-aws.yaml
@@ -169,6 +169,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
@@ -169,6 +169,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
@@ -169,6 +169,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -182,6 +182,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -182,6 +182,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
@@ -174,6 +174,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
@@ -169,6 +169,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
@@ -169,6 +169,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -243,6 +243,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     {{ if eq .CloudProviderName "vsphere" }}
     systemctl enable --now vmtoolsd.service
     {{ end -}}

--- a/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -177,6 +177,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.20-aws.yaml
@@ -178,6 +178,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
@@ -178,6 +178,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
@@ -178,6 +178,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-nutanix.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-nutanix.yaml
@@ -185,6 +185,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -191,6 +191,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -191,6 +191,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
@@ -183,6 +183,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
@@ -178,6 +178,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
@@ -178,6 +178,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -240,16 +240,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
-    {{ if eq .CloudProviderName "azure" }}
-	{{- range $idx, $podCIDR := .PodCIDRs }} 
-    firewall-cmd --permanent --zone=trusted --add-source={{ $podCIDR}}
-	{{ end }}
-    firewall-cmd --permanent --add-port=8472/udp
-    firewall-cmd --permanent --add-port={{ .NodePortRange }}/tcp
-    firewall-cmd --permanent --add-port={{ .NodePortRange }}/udp
-    firewall-cmd --reload
-    systemctl restart firewalld
-    {{ end -}}
+    systemctl disable --now firewalld || true
     {{ if eq .CloudProviderName "vsphere" }}
     systemctl enable --now vmtoolsd.service
     {{ end -}}

--- a/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -173,6 +173,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
@@ -174,6 +174,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -174,6 +174,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -174,6 +174,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
@@ -182,6 +182,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -174,6 +174,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
@@ -174,6 +174,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -188,6 +188,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -188,6 +188,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -180,6 +180,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -181,16 +181,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
-
-    firewall-cmd --permanent --zone=trusted --add-source=172.25.0.0/16
-
-    firewall-cmd --permanent --zone=trusted --add-source=fd00::/104
-
-    firewall-cmd --permanent --add-port=8472/udp
-    firewall-cmd --permanent --add-port=/tcp
-    firewall-cmd --permanent --add-port=/udp
-    firewall-cmd --reload
-    systemctl restart firewalld
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Out of context (i.e. not kubernetes aware iptables operations) ip filtering is fundamentally incompatible with the Kubernetes. Network resources should be protect by the cloud security groups or network policies (or both!).

XRef: https://github.com/kubermatic/kubermatic/issues/8768

```release-note
Disable firewalld on supported OSes
```
