### PR TITLE
Remove 'alpha' status of Nutanix implementation

### DIFF
--- a/docs/nutanix.md
+++ b/docs/nutanix.md
@@ -1,6 +1,6 @@
 # Nutanix Prism Central
 
-This provider implementation is currently in **alpha** stage. Currently, the only supported API version is [Prism v3](https://www.nutanix.dev/reference/prism_central/v3/).
+Currently the `machine-controller` implementation of Nutanix supports the [Prism v3 API](https://www.nutanix.dev/reference/prism_central/v3/) to create `Machines`.
 
 ## Prerequisites
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We fully support Nutanix now in `machine-controller` and KKP, thus this PR removes the mention of "alpha status" in `docs/nutanix.md`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
