### PR TITLE
Kubevirt: fixed randomised MAC address for VM

### DIFF
--- a/pkg/cloudprovider/util/net.go
+++ b/pkg/cloudprovider/util/net.go
@@ -39,17 +39,18 @@ func CIDRToIPAndNetMask(ipv4 string) (string, string, int, error) {
 }
 
 // GenerateRandMAC generates a random unicast and locally administered MAC address.
-func GenerateRandMAC() net.HardwareAddr {
+func GenerateRandMAC() (net.HardwareAddr, error) {
 	buf := make([]byte, 6)
 	var mac net.HardwareAddr
 
 	_, err := rand.Read(buf)
 	if err != nil {
+		return mac, err
 	}
 
 	// Set locally administered addresses bit and reset multicast bit
 	buf[0] = (buf[0] | 0x02) & 0xfe
 	mac = append(mac, buf[0], buf[1], buf[2], buf[3], buf[4], buf[5])
 
-	return mac
+	return mac, nil
 }

--- a/pkg/cloudprovider/util/net.go
+++ b/pkg/cloudprovider/util/net.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"net"
@@ -35,4 +36,20 @@ func CIDRToIPAndNetMask(ipv4 string) (string, string, int, error) {
 
 	netmask := fmt.Sprintf("%d.%d.%d.%d", ipNet.Mask[0], ipNet.Mask[1], ipNet.Mask[2], ipNet.Mask[3])
 	return ip.String(), netmask, size, nil
+}
+
+// GenerateRandMAC generates a random unicast and locally administered MAC address.
+func GenerateRandMAC() net.HardwareAddr {
+	buf := make([]byte, 6)
+	var mac net.HardwareAddr
+
+	_, err := rand.Read(buf)
+	if err != nil {
+	}
+
+	// Set locally administered addresses bit and reset multicast bit
+	buf[0] = (buf[0] | 0x02) & 0xfe
+	mac = append(mac, buf[0], buf[1], buf[2], buf[3], buf[4], buf[5])
+
+	return mac
 }


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
The PR is the first part to fix #1202. We force a fixed MAC address in the VM to have the device recognised when VM is restarted so that the system keeps the interface in the Up state.
After this PR the `Node` will be `Ready` state.
What remains to fix:
- the kubelet starts with the old ip as `--node-ip`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1202

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubevirt: VM are created with a fixed randomised MAC address.
```
