### PR TITLE
make openstack provider work on ovh cloud

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,3 +36,4 @@ issues:
   - 'cyclomatic complexity 31 of func `verifyMigrateUID` is high'
   - 'cyclomatic complexity 31 of func `main` is high'
   - 'cyclomatic complexity 34 of func `\(\*provider\)\.getConfig` is high'
+  - 'cyclomatic complexity 31 of func `\(\*provider\)\.Validate` is high'

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -115,6 +115,7 @@ type Config struct {
 const (
 	machineUIDMetaKey = "machine-uid"
 	securityGroupName = "kubernetes-v1"
+	ovhAuthURL        = "auth.cloud.ovh.net"
 )
 
 // Protects floating ip assignment
@@ -439,7 +440,6 @@ func (p *provider) AddDefaults(spec clusterv1alpha1.MachineSpec) (clusterv1alpha
 	return spec, nil
 }
 
-//nolint:gocyclo
 func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	c, pc, _, err := p.getConfig(spec.ProviderSpec)
 	if err != nil {
@@ -481,7 +481,7 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	}
 
 	// Required fields
-	if !strings.Contains(c.IdentityEndpoint, "auth.cloud.ovh.net") {
+	if !strings.Contains(c.IdentityEndpoint, ovhAuthURL) {
 		if _, err := getRegion(client, c.Region); err != nil {
 			return fmt.Errorf("failed to get region %q: %v", c.Region, err)
 		}

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -480,8 +480,10 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	}
 
 	// Required fields
-	if _, err := getRegion(client, c.Region); err != nil {
-		return fmt.Errorf("failed to get region %q: %v", c.Region, err)
+	if !strings.Contains(c.IdentityEndpoint, "auth.cloud.ovh.net") {
+		if _, err := getRegion(client, c.Region); err != nil {
+			return fmt.Errorf("failed to get region %q: %v", c.Region, err)
+		}
 	}
 
 	// Get OS Compute Client

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -439,6 +439,7 @@ func (p *provider) AddDefaults(spec clusterv1alpha1.MachineSpec) (clusterv1alpha
 	return spec, nil
 }
 
+//nolint:gocyclo
 func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	c, pc, _, err := p.getConfig(spec.ProviderSpec)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
In this PR we workaround Opestack limitation in OVH Cloud. They do not allow to call GET regions endpoint.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc: @ovh @cbourgois