### PR TITLE
Expose google provisioning model to be able to acquire spot instances

### DIFF
--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -101,7 +101,7 @@ type config struct {
 	network               string
 	subnetwork            string
 	preemptible           bool
-	automaticRestart      bool
+	automaticRestart      *bool
 	provisioningModel     string
 	labels                map[string]string
 	tags                  []string
@@ -169,15 +169,16 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 		return nil, fmt.Errorf("cannot retrieve preemptible: %v", err)
 	}
 
-	cfg.automaticRestart = !cfg.preemptible
+	cfg.automaticRestart = nil
 	if cpSpec.AutomaticRestart != nil {
-		cfg.automaticRestart, _, err = resolver.GetConfigVarBoolValue(*cpSpec.AutomaticRestart)
+		var automaticRestart, _, err = resolver.GetConfigVarBoolValue(*cpSpec.AutomaticRestart)
 		if err != nil {
 			return nil, fmt.Errorf("cannot retrieve automaticRestart: %v", err)
 		}
+		cfg.automaticRestart = &automaticRestart
 	}
 
-	cfg.provisioningModel = "STANDARD"
+	cfg.provisioningModel = ""
 	if cpSpec.ProvisioningModel != nil {
 		cfg.provisioningModel, err = resolver.GetConfigVarStringValue(*cpSpec.ProvisioningModel)
 		if err != nil {

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -101,6 +101,8 @@ type config struct {
 	network               string
 	subnetwork            string
 	preemptible           bool
+	automaticRestart      bool
+	provisioningModel     string
 	labels                map[string]string
 	tags                  []string
 	jwtConfig             *jwt.Config

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -169,6 +169,22 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 		return nil, fmt.Errorf("cannot retrieve preemptible: %v", err)
 	}
 
+	cfg.automaticRestart = !cfg.preemptible
+	if cpSpec.AutomaticRestart != nil {
+		cfg.automaticRestart, _, err = resolver.GetConfigVarBoolValue(*cpSpec.AutomaticRestart)
+		if err != nil {
+			return nil, fmt.Errorf("cannot retrieve automaticRestart: %v", err)
+		}
+	}
+
+	cfg.provisioningModel = "STANDARD"
+	if cpSpec.ProvisioningModel != nil {
+		cfg.provisioningModel, err = resolver.GetConfigVarStringValue(*cpSpec.ProvisioningModel)
+		if err != nil {
+			return nil, fmt.Errorf("cannot retrieve provisioningModel: %v", err)
+		}
+	}
+
 	// make it true by default
 	cfg.assignPublicIPAddress = true
 

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -266,7 +266,7 @@ func (p *Provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidert
 		Labels:            labels,
 		Scheduling: &compute.Scheduling{
 			Preemptible:       cfg.preemptible,
-			AutomaticRestart:  &cfg.automaticRestart,
+			AutomaticRestart:  cfg.automaticRestart,
 			ProvisioningModel: cfg.provisioningModel,
 		},
 		ServiceAccounts: []*compute.ServiceAccount{

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -265,7 +265,9 @@ func (p *Provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidert
 		Disks:             disks,
 		Labels:            labels,
 		Scheduling: &compute.Scheduling{
-			Preemptible: cfg.preemptible,
+			Preemptible:       cfg.preemptible,
+			AutomaticRestart:  &cfg.automaticRestart,
+			ProvisioningModel: cfg.provisioningModel,
 		},
 		ServiceAccounts: []*compute.ServiceAccount{
 			{

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -265,9 +265,7 @@ func (p *Provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidert
 		Disks:             disks,
 		Labels:            labels,
 		Scheduling: &compute.Scheduling{
-			Preemptible:       cfg.preemptible,
-			AutomaticRestart:  cfg.automaticRestart,
-			ProvisioningModel: cfg.provisioningModel,
+			Preemptible: cfg.preemptible,
 		},
 		ServiceAccounts: []*compute.ServiceAccount{
 			{
@@ -292,6 +290,15 @@ func (p *Provider) Create(machine *clusterv1alpha1.Machine, data *cloudprovidert
 			Items: cfg.tags,
 		},
 	}
+
+	if cfg.automaticRestart != nil {
+		inst.Scheduling.AutomaticRestart = cfg.automaticRestart
+	}
+
+	if cfg.provisioningModel != nil {
+		inst.Scheduling.ProvisioningModel = *cfg.provisioningModel
+	}
+
 	op, err := svc.Instances.Insert(cfg.projectID, cfg.zone, inst).Do()
 	if err != nil {
 		return nil, newError(common.InvalidConfigurationMachineError, errInsertInstance, err)

--- a/pkg/cloudprovider/provider/gce/provider_test.go
+++ b/pkg/cloudprovider/provider/gce/provider_test.go
@@ -44,6 +44,7 @@ func testProviderSpec() map[string]interface{} {
 			"multizone":             false,
 			"network":               "global/networks/default",
 			"preemptible":           false,
+			"provisioningModel":     "STANDARD",
 			"regional":              false,
 			"serviceAccount":        "",
 			"subnetwork":            "",

--- a/pkg/cloudprovider/provider/gce/types/types.go
+++ b/pkg/cloudprovider/provider/gce/types/types.go
@@ -30,20 +30,22 @@ import (
 // CloudProviderSpec contains the specification of the cloud provider taken
 // from the provider configuration.
 type CloudProviderSpec struct {
-	ServiceAccount        providerconfigtypes.ConfigVarString `json:"serviceAccount,omitempty"`
-	Zone                  providerconfigtypes.ConfigVarString `json:"zone"`
-	MachineType           providerconfigtypes.ConfigVarString `json:"machineType"`
-	DiskSize              int64                               `json:"diskSize"`
-	DiskType              providerconfigtypes.ConfigVarString `json:"diskType"`
-	Network               providerconfigtypes.ConfigVarString `json:"network"`
-	Subnetwork            providerconfigtypes.ConfigVarString `json:"subnetwork"`
-	Preemptible           providerconfigtypes.ConfigVarBool   `json:"preemptible"`
-	Labels                map[string]string                   `json:"labels,omitempty"`
-	Tags                  []string                            `json:"tags,omitempty"`
-	AssignPublicIPAddress *providerconfigtypes.ConfigVarBool  `json:"assignPublicIPAddress,omitempty"`
-	MultiZone             providerconfigtypes.ConfigVarBool   `json:"multizone"`
-	Regional              providerconfigtypes.ConfigVarBool   `json:"regional"`
-	CustomImage           providerconfigtypes.ConfigVarString `json:"customImage,omitempty"`
+	ServiceAccount        providerconfigtypes.ConfigVarString  `json:"serviceAccount,omitempty"`
+	Zone                  providerconfigtypes.ConfigVarString  `json:"zone"`
+	MachineType           providerconfigtypes.ConfigVarString  `json:"machineType"`
+	DiskSize              int64                                `json:"diskSize"`
+	DiskType              providerconfigtypes.ConfigVarString  `json:"diskType"`
+	Network               providerconfigtypes.ConfigVarString  `json:"network"`
+	Subnetwork            providerconfigtypes.ConfigVarString  `json:"subnetwork"`
+	Preemptible           providerconfigtypes.ConfigVarBool    `json:"preemptible"`
+	AutomaticRestart      *providerconfigtypes.ConfigVarBool   `json:"automaticRestart,omitempty"`
+	ProvisioningModel     *providerconfigtypes.ConfigVarString `json:"provisioningModel,omitempty"`
+	Labels                map[string]string                    `json:"labels,omitempty"`
+	Tags                  []string                             `json:"tags,omitempty"`
+	AssignPublicIPAddress *providerconfigtypes.ConfigVarBool   `json:"assignPublicIPAddress,omitempty"`
+	MultiZone             providerconfigtypes.ConfigVarBool    `json:"multizone"`
+	Regional              providerconfigtypes.ConfigVarBool    `json:"regional"`
+	CustomImage           providerconfigtypes.ConfigVarString  `json:"customImage,omitempty"`
 }
 
 // UpdateProviderSpec updates the given provider spec with changed


### PR DESCRIPTION
Signed-off-by: Tomas Lamr <tomas@lamr.org>

**What this PR does / why we need it**:
Hello, we wanted to expose node selection API from google (SPOT/STANDARD) so that we can create a node pool of spot instances as in was.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for specifying provisioning model for instances on GCE
```