### PR TITLE
define static ip config

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -79,7 +79,7 @@ var (
 	nodeRegistryMirrors           string
 	nodePauseImage                string
 	nodeContainerRuntime          string
-	podCIDRs                      string
+	podCIDR                       string
 	nodePortRange                 string
 	nodeRegistryCredentialsSecret string
 	nodeContainerdRegistryMirrors = containerruntime.RegistryMirrorsFlags{}
@@ -127,9 +127,6 @@ type controllerRunOptions struct {
 
 	useOSM bool
 
-	// Assigns the POD networks that will be allocated.
-	podCIDRs []string
-
 	// A port range to reserve for services with NodePort visibility
 	nodePortRange string
 }
@@ -140,7 +137,7 @@ func main() {
 	klog.InitFlags(nil)
 	// This is also being registered in kubevirt.io/kubevirt/pkg/kubecli/kubecli.go so
 	// we have to guard it
-	//TODO: Evaluate alternatives to importing the CLI. Generate our own client? Use a dynamic client?
+	// TODO: Evaluate alternatives to importing the CLI. Generate our own client? Use a dynamic client?
 	if flag.Lookup("kubeconfig") == nil {
 		flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	}
@@ -166,7 +163,7 @@ func main() {
 	flag.Var(&nodeContainerdRegistryMirrors, "node-containerd-registry-mirrors", "Configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors")
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "path to a file containing all PEM-encoded CA certificates (will be used instead of the host's certificates if set)")
 	flag.BoolVar(&nodeCSRApprover, "node-csr-approver", true, "Enable NodeCSRApprover controller to automatically approve node serving certificate requests")
-	flag.StringVar(&podCIDRs, "pod-cidr", "172.25.0.0/16", "Comma separated network ranges from which POD networks are allocated. Example: 172.25.0.0/16,fd00::/104")
+	flag.StringVar(&podCIDR, "pod-cidr", "172.25.0.0/16", "WARNING: flag is unused, kept only for backwards compatibility")
 	flag.StringVar(&nodePortRange, "node-port-range", "30000-32767", "A port range to reserve for services with NodePort visibility")
 	flag.StringVar(&nodeRegistryCredentialsSecret, "node-registry-credentials-secret", "", "A Secret object reference, that containt auth info for image registry in namespace/secret-name form, example: kube-system/registry-credentials. See doc at https://github.com/kubermaric/machine-controller/blob/master/docs/registry-authentication.md")
 	flag.BoolVar(&useOSM, "use-osm", false, "use osm controller for node bootstrap")
@@ -266,7 +263,6 @@ func main() {
 			ContainerRuntime:             containerRuntimeConfig,
 		},
 		useOSM:        useOSM,
-		podCIDRs:      strings.Split(podCIDRs, ","),
 		nodePortRange: nodePortRange,
 	}
 

--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -398,7 +398,6 @@ func (bs *controllerBootstrap) Start(ctx context.Context) error {
 		bs.opt.skipEvictionAfter,
 		bs.opt.node,
 		bs.opt.useOSM,
-		bs.opt.podCIDRs,
 		bs.opt.nodePortRange,
 	); err != nil {
 		return fmt.Errorf("failed to add Machine controller to manager: %v", err)

--- a/pkg/apis/plugin/plugin.go
+++ b/pkg/apis/plugin/plugin.go
@@ -54,7 +54,6 @@ type UserDataRequest struct {
 	KubeletFeatureGates      map[string]bool
 	KubeletConfigs           map[string]string
 	ContainerRuntime         containerruntime.Config
-	PodCIDRs                 []string
 	NodePortRange            string
 }
 

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -363,10 +363,6 @@ func getDefaultRootDevicePath(os providerconfigtypes.OperatingSystem) (string, e
 }
 
 func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *providerconfigtypes.Config, *awstypes.RawConfig, error) {
-	if provSpec.Value == nil {
-		return nil, nil, nil, fmt.Errorf("machine.spec.providerconfig.value is nil")
-	}
-
 	pconfig, err := providerconfigtypes.GetConfig(provSpec)
 	if err != nil {
 		return nil, nil, nil, err
@@ -848,7 +844,7 @@ func (p *provider) Cleanup(machine *clusterv1alpha1.Machine, _ *cloudprovidertyp
 		return false, err
 	}
 
-	//(*Config, *providerconfigtypes.Config, *awstypes.RawConfig, error)
+	// (*Config, *providerconfigtypes.Config, *awstypes.RawConfig, error)
 	config, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 
 	if err != nil {

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -362,6 +362,7 @@ func getDefaultRootDevicePath(os providerconfigtypes.OperatingSystem) (string, e
 	return "", fmt.Errorf("no default root path found for %s operating system", os)
 }
 
+//gocyclo:ignore
 func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *providerconfigtypes.Config, *awstypes.RawConfig, error) {
 	pconfig, err := providerconfigtypes.GetConfig(provSpec)
 	if err != nil {

--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -118,7 +118,6 @@ type Reconciler struct {
 	satelliteSubscriptionManager     rhsm.SatelliteSubscriptionManager
 
 	useOSM        bool
-	podCIDRs      []string
 	nodePortRange string
 }
 
@@ -176,7 +175,6 @@ func Add(
 	skipEvictionAfter time.Duration,
 	nodeSettings NodeSettings,
 	useOSM bool,
-	podCIDRs []string,
 	nodePortRange string,
 ) error {
 	reconciler := &Reconciler{
@@ -195,7 +193,6 @@ func Add(
 		satelliteSubscriptionManager:     rhsm.NewSatelliteSubscriptionManager(),
 
 		useOSM:        useOSM,
-		podCIDRs:      podCIDRs,
 		nodePortRange: nodePortRange,
 	}
 	m, err := userdatamanager.New()

--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -426,7 +426,7 @@ func (r *Reconciler) reconcile(ctx context.Context, machine *clusterv1alpha1.Mac
 
 	node, err := r.getNodeByNodeRef(ctx, machine.Status.NodeRef)
 	if err != nil {
-		//In case we cannot find a node for the NodeRef we must remove the NodeRef & recreate an instance on the next sync
+		// In case we cannot find a node for the NodeRef we must remove the NodeRef & recreate an instance on the next sync
 		if kerrors.IsNotFound(err) {
 			klog.V(3).Infof("found invalid NodeRef on machine %s. Deleting reference...", machine.Name)
 			return nil, r.updateMachine(machine, func(m *clusterv1alpha1.Machine) {
@@ -803,7 +803,6 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 				NoProxy:                  r.nodeSettings.NoProxy,
 				HTTPProxy:                r.nodeSettings.HTTPProxy,
 				ContainerRuntime:         crRuntime,
-				PodCIDRs:                 r.podCIDRs,
 				NodePortRange:            r.nodePortRange,
 			}
 

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -115,6 +115,15 @@ type NetworkConfig struct {
 	IPFamily util.IPFamily `json:"ipFamily,omitempty"`
 }
 
+func (n *NetworkConfig) IsStaticIPConfig() bool {
+	if n == nil {
+		return false
+	}
+	return n.CIDR != "" ||
+		n.Gateway != "" ||
+		len(n.DNS.Servers) != 0
+}
+
 func (n *NetworkConfig) GetIPFamily() util.IPFamily {
 	if n == nil {
 		return util.Unspecified

--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -57,7 +57,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		req.CloudConfig = *pconfig.OverwriteCloudConfig
 	}
 
-	if pconfig.Network != nil {
+	if pconfig.Network.IsStaticIPConfig() {
 		return "", errors.New("static IP config is not supported with Amazon Linux 2")
 	}
 

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -57,7 +57,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		req.CloudConfig = *pconfig.OverwriteCloudConfig
 	}
 
-	if pconfig.Network != nil {
+	if pconfig.Network.IsStaticIPConfig() {
 		return "", errors.New("static IP config is not supported with CentOS")
 	}
 

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -57,7 +57,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		req.CloudConfig = *pconfig.OverwriteCloudConfig
 	}
 
-	if pconfig.Network != nil {
+	if pconfig.Network.IsStaticIPConfig() {
 		return "", errors.New("static IP config is not supported with RHEL")
 	}
 

--- a/pkg/userdata/rhel/provider_test.go
+++ b/pkg/userdata/rhel/provider_test.go
@@ -283,7 +283,6 @@ func TestUserDataGeneration(t *testing.T) {
 				PauseImage:               test.pauseImage,
 				KubeletFeatureGates:      kubeletFeatureGates,
 				ContainerRuntime:         containerRuntimeConfig,
-				PodCIDRs:                 []string{"172.25.0.0/16", "fd00::/104"},
 			}
 			s, err := provider.UserData(req)
 			if err != nil {

--- a/pkg/userdata/rockylinux/provider.go
+++ b/pkg/userdata/rockylinux/provider.go
@@ -57,7 +57,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		req.CloudConfig = *pconfig.OverwriteCloudConfig
 	}
 
-	if pconfig.Network != nil {
+	if pconfig.Network.IsStaticIPConfig() {
 		return "", errors.New("static IP config is not supported with RockyLinux")
 	}
 

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -58,7 +58,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		req.CloudConfig = *pconfig.OverwriteCloudConfig
 	}
 
-	if pconfig.Network != nil {
+	if pconfig.Network.IsStaticIPConfig() {
 		return "", errors.New("static IP config is not supported with SLES")
 	}
 

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -57,7 +57,7 @@ func (p Provider) UserData(req plugin.UserDataRequest) (string, error) {
 		req.CloudConfig = *pconfig.OverwriteCloudConfig
 	}
 
-	if pconfig.Network != nil {
+	if pconfig.Network.IsStaticIPConfig() {
 		return "", errors.New("static IP config is not supported with Ubuntu")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Without  this change IP config  is static or not is decided just by checking if `.Network` is `nil`. 
All the fields in the `NetworkConfig` are not for static IP configuration anymore due to addition  of `IPFamily` field. 
This PR checks if the fields that specify static IP config are set or not and updates the code accordingly.  

PR also removes leftover refs to podCIDRs command  line flag. It was just wired through the code but never actually used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubermatic/kubermatic/issues/9617

**Optional Release Note**:
```release-note
NONE
```
