### PR TITLE
Publish image to quay.io/kubermatic/machine-controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export GIT_TAG ?= $(shell git tag --points-at HEAD)
 
 export GOFLAGS?=-mod=readonly -trimpath
 
-REGISTRY ?= docker.io
+REGISTRY ?= quay.io
 REGISTRY_NAMESPACE ?= kubermatic
 
 LDFLAGS ?= -ldflags '-s -w'

--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -232,7 +232,7 @@ spec:
     spec:
       serviceAccountName: machine-controller
       containers:
-        - image: kubermatic/machine-controller:latest
+        - image: quay.io/kubermatic/machine-controller:latest
           imagePullPolicy: IfNotPresent
           name: machine-controller
           command:
@@ -278,7 +278,7 @@ spec:
     spec:
       serviceAccountName: machine-controller
       containers:
-        - image: kubermatic/machine-controller:latest
+        - image: quay.io/kubermatic/machine-controller:latest
           imagePullPolicy: IfNotPresent
           name: webhook
           command:

--- a/test/tools/integration/master_install_script.sh
+++ b/test/tools/integration/master_install_script.sh
@@ -139,7 +139,7 @@ if ! ls machine-controller-deployed; then
   mkdir "images"
   buildah push localhost/kubermatic/machine-controller oci-archive:./images/machine-controller.tar:localhost/kubermatic/machine-controller:latest
   ctr --debug --namespace=k8s.io images import --all-platforms --no-unpack images/machine-controller.tar
-  sed -i "s_- image: kubermatic/machine-controller:latest_- image: localhost/kubermatic/machine-controller:latest_g" examples/machine-controller.yaml
+  sed -i "s_- image: quay.io/kubermatic/machine-controller:latest_- image: localhost/kubermatic/machine-controller:latest_g" examples/machine-controller.yaml
   # The 10 minute window given by default for the node to appear is too short
   # when we upgrade the instance during the upgrade test
   if [[ ${LC_JOB_NAME:-} = "pull-machine-controller-e2e-ubuntu-upgrade" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
What it says on the title. Image publishing location is moved from `docker.io/kubermatic/machine-controller` to `quay.io/kubermatic/machine-controller` to not be affected by DockerHub pull rate limits anymore.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1266

**Special notes for your reviewer**:
- I checked the prow job and it already signs in with quay.io credentials, so it seems no further change is needed for that.
- The repo under quay.io/kubermatic already exists and it seems images were pushed there occasionally.

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Container images are now published to `quay.io/kubermatic/machine-controller`
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>