### PR TITLE
Update containerd to 1.5 for all Kubernetes versions

### DIFF
--- a/pkg/containerruntime/containerd.go
+++ b/pkg/containerruntime/containerd.go
@@ -63,13 +63,10 @@ func (eng *Containerd) ScriptFor(os types.OperatingSystem) (string, error) {
 		args.ContainerdVersion = eng.version
 	}
 
-	// Amazon Linux 2 does not have containerd 1.5
-	if eng.version == "" && os == types.OperatingSystemAmazonLinux2 {
-		args.ContainerdVersion = LegacyContainerdVersion
-	}
-
 	switch os {
 	case types.OperatingSystemAmazonLinux2:
+		// Amazon Linux 2 does not have containerd 1.5
+		args.ContainerdVersion = LegacyContainerdVersion
 		err := containerdAmzn2Template.Execute(&buf, args)
 		return buf.String(), err
 	case types.OperatingSystemCentOS, types.OperatingSystemRHEL, types.OperatingSystemRockyLinux:

--- a/pkg/containerruntime/containerruntime.go
+++ b/pkg/containerruntime/containerruntime.go
@@ -117,13 +117,11 @@ func (cfg Config) Engine(kubeletVersion *semver.Version) Engine {
 	moreThan124, _ := semver.NewConstraint(">= 1.24")
 
 	switch {
-	case moreThan124.Check(kubeletVersion):
+	case moreThan124.Check(kubeletVersion) || cfg.Containerd != nil:
+		// docker support has been removed in Kubernetes 1.24
 		return containerd
 	case cfg.Docker != nil:
 		return docker
-	case cfg.Containerd != nil:
-		containerd.version = LegacyContainerdVersion
-		return containerd
 	}
 
 	return docker

--- a/pkg/userdata/ubuntu/testdata/containerd.yaml
+++ b/pkg/userdata/ubuntu/testdata/containerd.yaml
@@ -103,7 +103,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y --allow-downgrades containerd.io=1.4*
+    apt-get install -y --allow-downgrades containerd.io=1.5*
     apt-mark hold containerd.io
 
     systemctl daemon-reload


### PR DESCRIPTION
**What this PR does / why we need it**:
As discussed, this PR changes logic introduced with #1272 to only use containerd 1.5 in Kubernetes 1.24+. containerd 1.5 is now used for all Kubernetes versions still supported by `machine-controller`. Amazon Linux 2 is the exception as it does not have containerd 1.5 available.

Note: containerd installed with docker remains on 1.4 right now due to docker 19.03 only mentioning containerd 1.3 in its release notes. Maybe 1.5 works fine too, but let's investigate that in a separate PR which also bumps docker to 20.10.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update containerd to 1.5 when using it as container runtime (Amazon Linux 2 remains on 1.4 until newer versions are available)
```
