### PR TITLE
enable DHCPv6 on RHEL

### DIFF
--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -236,7 +236,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -232,10 +232,11 @@ write_files:
     {{ end }}
 {{ .ContainerRuntimeScript | indent 4 }}
 {{ safeDownloadBinariesScript .KubeletVersion | indent 4 }}
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -232,6 +232,10 @@ write_files:
     {{ end }}
 {{ .ContainerRuntimeScript | indent 4 }}
 {{ safeDownloadBinariesScript .KubeletVersion | indent 4 }}
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -236,6 +236,7 @@ write_files:
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
     sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -172,7 +172,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -168,10 +168,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -168,6 +168,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -172,7 +172,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -168,10 +168,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -168,6 +168,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
@@ -176,10 +176,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
@@ -180,7 +180,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
@@ -176,6 +176,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -172,7 +172,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -168,10 +168,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -168,6 +168,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
@@ -172,7 +172,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
@@ -168,10 +168,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
@@ -168,6 +168,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -182,10 +182,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -186,7 +186,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -182,6 +182,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -182,10 +182,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -186,7 +186,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -182,6 +182,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -178,7 +178,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -174,6 +174,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -174,10 +174,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
@@ -167,6 +167,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
@@ -171,7 +171,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
@@ -167,10 +167,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
@@ -167,6 +167,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
@@ -171,7 +171,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
@@ -167,10 +167,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -175,6 +175,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
+    sudo ifdown eth0 && sudo ifup eth0
+
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -179,7 +179,7 @@ write_files:
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
     echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
     echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
-    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
+    ifdown $DEFAULT_IFC_NAME && ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -175,10 +175,11 @@ write_files:
         chmod +x /opt/bin/health-monitor.sh
     fi
 
+    DEFAULT_IFC_NAME=$(ip -o route get 1  | grep -oP "dev \K\S+")
     echo NETWORKING_IPV6=yes >> /etc/sysconfig/network
-    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-eth0
-    sudo ifdown eth0 && sudo ifup eth0
+    echo IPV6INIT=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    echo DHCPV6C=yes >> /etc/sysconfig/network-scripts/ifcfg-$DEFAULT_IFC_NAME
+    sudo ifdown eth0 && sudo ifup $DEFAULT_IFC_NAME
 
     # set kubelet nodeip environment variable
     mkdir -p /etc/systemd/system/kubelet.service.d/


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables DHCPv6 on RHEL machines. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Part of https://github.com/kubermatic/kubermatic/issues/9617

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
