### PR TITLE
Remove use-osm flag from run-machine-controller script

### DIFF
--- a/hack/run-machine-controller.sh
+++ b/hack/run-machine-controller.sh
@@ -17,8 +17,11 @@
 set -e
 
 # Use a special env variable for machine-controller only
+# This kubeconfig should point to the cluster where machinedeployments, machines are installed.
 MC_KUBECONFIG=${MC_KUBECONFIG:-$(dirname $0)/../.kubeconfig}
 # If you want to use the default kubeconfig `export MC_KUBECONFIG=$KUBECONFIG`
+
+# `-use-osm` flag can be specified if https://github.com/kubermatic/operating-system-manager is used to manage user data.
 
 make -C $(dirname $0)/.. build-machine-controller
 $(dirname $0)/../machine-controller \
@@ -29,6 +32,5 @@ $(dirname $0)/../machine-controller \
   -cluster-dns=172.16.0.10 \
   -enable-profiling \
   -metrics-address=0.0.0.0:8080 \
-  -use-osm \
   -health-probe-address=0.0.0.0:8085 \
   -node-container-runtime=containerd


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
OSM is not GA yet, it's confusing for people who are trying to run machine-controller locally that it's enabled by default. Since you need to run OSM in parallel with machine-controller for everything to work in this case. We should disable it for now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
