### PR TITLE
remove check for dualstack unsupported zones in GCP

### DIFF
--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"cloud.google.com/go/logging"
 	monitoring "cloud.google.com/go/monitoring/apiv3"
@@ -49,7 +48,6 @@ const (
 	errOperatingSystem       = "Invalid or not supported operating system specified %q: %v"
 	errConnect               = "Failed to connect: %v"
 	errInvalidServiceAccount = "Service account is missing"
-	errIPv6UnsupportedZone   = "IPv6 is not supported in zone: %s"
 	errInvalidZone           = "Zone is missing"
 	errInvalidMachineType    = "Machine type is missing"
 	errInvalidDiskSize       = "Disk size must be a positive number"
@@ -122,9 +120,6 @@ func (p *Provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 	case util.IPv6:
 		return newError(common.InvalidConfigurationMachineError, util.ErrIPv6OnlyUnsupported)
 	case util.DualStack:
-		if !isIPv6Supported(cfg.zone) {
-			return newError(common.InvalidConfigurationMachineError, errIPv6UnsupportedZone, cfg.zone)
-		}
 	default:
 		return newError(common.InvalidConfigurationMachineError, util.ErrUnknownNetworkFamily, cfg.providerConfig.Network.GetIPFamily())
 	}
@@ -143,24 +138,6 @@ func (p *Provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 		return newError(common.InvalidConfigurationMachineError, errOperatingSystem, cfg.providerConfig.OperatingSystem, err)
 	}
 	return nil
-}
-
-func isIPv6Supported(zone string) bool {
-	supportedRegions := []string{
-		"asia-east1",
-		"asia-south1",
-		"europe-west2",
-		"us-west2",
-	}
-
-	for _, region := range supportedRegions {
-		// this is fine since zones are constructed from region + zone suffix
-		if strings.HasPrefix(zone, region) {
-			return true
-		}
-	}
-
-	return false
 }
 
 // Get retrieves a node instance that is associated with the given machine.

--- a/pkg/cloudprovider/provider/gce/provider_test.go
+++ b/pkg/cloudprovider/provider/gce/provider_test.go
@@ -157,20 +157,6 @@ func TestValidate(t *testing.T) {
 			},
 			false,
 		},
-		{
-			"with unsupported zone",
-			v1alpha1.MachineSpec{
-				ProviderSpec: v1alpha1.ProviderSpec{
-					Value: &runtime.RawExtension{
-						Raw: rawBytes(testMap(testProviderSpec()).
-							with("network.ipFamily", "IPv4+IPv6").
-							with("cloudProviderSpec.zone", "europe-west3-a"),
-						),
-					},
-				},
-			},
-			true,
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:
We are removing this check because GCP now supports dual stack in all  the regions. 

This is not directly documented. But the docs that had listed restrictions are gone and 
@rastislavs was able to create dual stack subnets anywhere. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Partial fulfillment of https://github.com/kubermatic/kubermatic/pull/9751


**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
