### PR TITLE
Only attempt resource deletion in azure provider if finalizer is set

### DIFF
--- a/pkg/cloudprovider/provider/azure/create_delete_resources.go
+++ b/pkg/cloudprovider/provider/azure/create_delete_resources.go
@@ -115,7 +115,8 @@ func deleteVMsByMachineUID(ctx context.Context, c *config, machineUID types.UID)
 		return err
 	}
 
-	list, err := vmClient.ListAll(ctx, "", "")
+	list, err := vmClient.List(ctx, c.ResourceGroup, "")
+
 	if err != nil {
 		return err
 	}

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -730,45 +730,53 @@ func (p *provider) Cleanup(machine *clusterv1alpha1.Machine, data *cloudprovider
 		return false, fmt.Errorf("failed to parse MachineSpec: %v", err)
 	}
 
-	klog.Infof("deleting VM %q", machine.Name)
-	if err = deleteVMsByMachineUID(context.TODO(), config, machine.UID); err != nil {
-		return false, fmt.Errorf("failed to delete instance for machine %q: %v", machine.Name, err)
+	if kuberneteshelper.HasFinalizer(machine, finalizerVM) {
+		klog.Infof("deleting VM %q", machine.Name)
+		if err = deleteVMsByMachineUID(context.TODO(), config, machine.UID); err != nil {
+			return false, fmt.Errorf("failed to delete instance for  machine %q: %v", machine.Name, err)
+		}
+
+		if err := data.Update(machine, func(updatedMachine *clusterv1alpha1.Machine) {
+			updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerVM)
+		}); err != nil {
+			return false, err
+		}
 	}
 
-	if err := data.Update(machine, func(updatedMachine *clusterv1alpha1.Machine) {
-		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerVM)
-	}); err != nil {
-		return false, err
+	if kuberneteshelper.HasFinalizer(machine, finalizerDisks) {
+		klog.Infof("deleting disks of VM %q", machine.Name)
+		if err := deleteDisksByMachineUID(context.TODO(), config, machine.UID); err != nil {
+			return false, fmt.Errorf("failed to remove disks of machine %q: %v", machine.Name, err)
+		}
+		if err := data.Update(machine, func(updatedMachine *clusterv1alpha1.Machine) {
+			updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerDisks)
+		}); err != nil {
+			return false, err
+		}
 	}
 
-	klog.Infof("deleting disks of VM %q", machine.Name)
-	if err := deleteDisksByMachineUID(context.TODO(), config, machine.UID); err != nil {
-		return false, fmt.Errorf("failed to remove disks of machine %q: %v", machine.Name, err)
-	}
-	if err := data.Update(machine, func(updatedMachine *clusterv1alpha1.Machine) {
-		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerDisks)
-	}); err != nil {
-		return false, err
-	}
-
-	klog.Infof("deleting network interfaces of VM %q", machine.Name)
-	if err := deleteInterfacesByMachineUID(context.TODO(), config, machine.UID); err != nil {
-		return false, fmt.Errorf("failed to remove network interfaces of machine %q: %v", machine.Name, err)
-	}
-	if err := data.Update(machine, func(updatedMachine *clusterv1alpha1.Machine) {
-		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerNIC)
-	}); err != nil {
-		return false, err
+	if kuberneteshelper.HasFinalizer(machine, finalizerNIC) {
+		klog.Infof("deleting network interfaces of VM %q", machine.Name)
+		if err := deleteInterfacesByMachineUID(context.TODO(), config, machine.UID); err != nil {
+			return false, fmt.Errorf("failed to remove network interfaces of machine %q: %v", machine.Name, err)
+		}
+		if err := data.Update(machine, func(updatedMachine *clusterv1alpha1.Machine) {
+			updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerNIC)
+		}); err != nil {
+			return false, err
+		}
 	}
 
-	klog.Infof("deleting public IP addresses of VM %q", machine.Name)
-	if err := deleteIPAddressesByMachineUID(context.TODO(), config, machine.UID); err != nil {
-		return false, fmt.Errorf("failed to remove public IP addresses of machine %q: %v", machine.Name, err)
-	}
-	if err := data.Update(machine, func(updatedMachine *clusterv1alpha1.Machine) {
-		updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerPublicIP)
-	}); err != nil {
-		return false, err
+	if kuberneteshelper.HasFinalizer(machine, finalizerPublicIP) {
+		klog.Infof("deleting public IP addresses of VM %q", machine.Name)
+		if err := deleteIPAddressesByMachineUID(context.TODO(), config, machine.UID); err != nil {
+			return false, fmt.Errorf("failed to remove public IP addresses of machine %q: %v", machine.Name, err)
+		}
+		if err := data.Update(machine, func(updatedMachine *clusterv1alpha1.Machine) {
+			updatedMachine.Finalizers = kuberneteshelper.RemoveFinalizer(updatedMachine.Finalizers, finalizerPublicIP)
+		}); err != nil {
+			return false, err
+		}
 	}
 
 	return true, nil
@@ -780,7 +788,7 @@ func getVMByUID(ctx context.Context, c *config, uid types.UID) (*compute.Virtual
 		return nil, err
 	}
 
-	list, err := vmClient.ListAll(ctx, "", "")
+	list, err := vmClient.List(ctx, c.ResourceGroup, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1019,9 +1027,9 @@ func (p *provider) Validate(spec clusterv1alpha1.MachineSpec) error {
 		return fmt.Errorf("failed to (create) vm client: %v", err.Error())
 	}
 
-	_, err = vmClient.ListAll(context.TODO(), "", "")
+	_, err = vmClient.List(context.TODO(), c.ResourceGroup, "")
 	if err != nil {
-		return fmt.Errorf("failed to list all: %v", err.Error())
+		return fmt.Errorf("failed to list virtual machines: %v", err.Error())
 	}
 
 	if _, err := getVirtualNetwork(context.TODO(), c); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
We set finalizers for different resources created by the azure provider, but the cleanup logic effectively ignored their presence (except for removing them) and always tried to delete all resources. When cleanup is only partially successful, subsequent attempts should be faster because there is no reason to try deleting the VM again if we were able to delete it before.

Also replaces a bunch of `ListAll` calls for VMs because we know the resource group to query, so let's not list _all_ VMs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Azure resources are ignored during machine cleanup if resource-specific finalizers are not set
```
