### PR TITLE
Upgrade to Go 1.18.2

### DIFF
--- a/.prow/e2e-features.yaml
+++ b/.prow/e2e-features.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -55,7 +55,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -77,7 +77,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -98,7 +98,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.12-1
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.13-4
           command:
             - /bin/bash
             - -c
@@ -54,7 +54,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.12-1
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.13-4
           command:
             - "./hack/ci-upload-gocache.sh"
           resources:

--- a/.prow/provider-alibaba.yaml
+++ b/.prow/provider-alibaba.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -48,7 +48,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -70,7 +70,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -92,7 +92,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -115,7 +115,7 @@ presubmits:
       preset-rhel: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -137,7 +137,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -159,7 +159,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -181,7 +181,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -203,7 +203,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -49,7 +49,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -73,7 +73,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-equinix-metal.yaml
+++ b/.prow/provider-equinix-metal.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -24,7 +24,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-linode.yaml
+++ b/.prow/provider-linode.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -49,7 +49,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-scaleway.yaml
+++ b/.prow/provider-scaleway.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -49,7 +49,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - "./hack/ci-e2e-test.sh"
           args:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - make
           args:
@@ -39,7 +39,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - make
           args:
@@ -149,7 +149,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.18.1
+        - image: golang:1.18.2
           command:
             - make
           args:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.18.1
+ARG GO_VERSION=1.18.2
 FROM golang:${GO_VERSION} AS builder
 WORKDIR /go/src/github.com/kubermatic/machine-controller
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 SHELL = /bin/bash -eu -o pipefail
 
-GO_VERSION ?= 1.18.1
+GO_VERSION ?= 1.18.2
 
 GOOS ?= $(shell go env GOOS)
 

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.18.1 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=golang:1.18.2 containerize ./hack/update-fixtures.sh
 
 go test ./... -v -update || go test ./...
 


### PR DESCRIPTION


**What this PR does / why we need it**:

What it says at the top. Bumps Go in prow jobs to 1.18.2 and respectively updated `kubermatic/build` images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Go to 1.18.2
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
