### PR TITLE
Refactor handling of Kubeconfig for KubeVirt

### DIFF
--- a/examples/kubevirt-machinedeployment.yaml
+++ b/examples/kubevirt-machinedeployment.yaml
@@ -28,7 +28,9 @@ spec:
           cloudProviderSpec:
             auth:
               kubeconfig:
-                value: '<< KUBECONFIG >>'
+                # Can also be set via the env var 'KUBEVIRT_KUBECONFIG' on the machine-controller
+                # If specified directly, this value should be a base64 encoded kubeconfig in either yaml or json format.
+                value: "<< KUBECONFIG >>"
             virtualMachine:
               template:
                 cpus: "1"
@@ -44,7 +46,7 @@ spec:
                 type: "" # Allowed values: "", "soft", "hard"
                 key: "foo"
                 values:
-                - bar
+                  - bar
           # Can also be `centos`, must align with he configured registryImage above
           operatingSystem: "ubuntu"
           operatingSystemSpec:

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -281,7 +281,7 @@ func addCAToDeployment(ctx context.Context, client ctrlruntimeclient.Client, nam
 func TestKubevirtProvisioningE2E(t *testing.T) {
 	t.Parallel()
 
-	kubevirtKubeconfig := os.Getenv("KUBEVIRT_E2E_TESTS_KUBECONFIG_JSON")
+	kubevirtKubeconfig := os.Getenv("KUBEVIRT_E2E_TESTS_KUBECONFIG")
 
 	if kubevirtKubeconfig == "" {
 		t.Fatalf("Unable to run kubevirt tests, KUBEVIRT_E2E_TESTS_KUBECONFIG must be set")


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
This PR intends to make the handling of Kubeconfig for KubeVirt consistent between KKP and machine-controller. 
* When Kubeconfig is specified directly in the CR then it should be base64 encoded.
* If referred using a secret or environment variable. Then it can either be an unencoded string or base64 encoded.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve handling of Kubeconfig for KubeVirt
```
