### PR TITLE
Update package repo path for Buildah

### DIFF
--- a/test/tools/integration/master_install_script.sh
+++ b/test/tools/integration/master_install_script.sh
@@ -27,8 +27,8 @@ systemctl mask swap.target
 swapoff -a
 
 if ! which buildah; then
-  sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-  wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/xUbuntu_20.04/Release.key -O Release.key
+  sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list"
+  wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:testing/xUbuntu_20.04/Release.key -O Release.key
   apt-key add - < Release.key
   apt-get update
   apt-get -y install buildah


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
`Buildah` was removed from `http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/` and moved to `http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_20.04/`. 

The reason is still not well known. From ubuntu 20.10 and 21.x, this package is included in the OS default APT repositories. Maybe this is removed to `testing` repository because it isn't going to be actively maintained for 20.04 and 18.04, just an assumption.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
