### PR TITLE
Switch to Ubuntu 22.04 LTS for e2e tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION=1.18.2
-FROM golang:${GO_VERSION} AS builder
+FROM docker.io/golang:${GO_VERSION} AS builder
 WORKDIR /go/src/github.com/kubermatic/machine-controller
 COPY . .
 RUN make all

--- a/test/tools/integration/hetzner.tf
+++ b/test/tools/integration/hetzner.tf
@@ -14,7 +14,7 @@ resource "hcloud_network" "net" {
 
 resource "hcloud_server" "machine-controller-test" {
   name        = var.hcloud_test_server_name
-  image       = "ubuntu-20.04"
+  image       = "ubuntu-22.04"
   server_type = "cx21"
   ssh_keys    = [hcloud_ssh_key.default.id]
   location    = "nbg1"

--- a/test/tools/integration/master_install_script.sh
+++ b/test/tools/integration/master_install_script.sh
@@ -27,9 +27,6 @@ systemctl mask swap.target
 swapoff -a
 
 if ! which buildah; then
-  sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/testing/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:testing.list"
-  wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:testing/xUbuntu_20.04/Release.key -O Release.key
-  apt-key add - < Release.key
   apt-get update
   apt-get -y install buildah
 fi

--- a/test/tools/integration/master_install_script.sh
+++ b/test/tools/integration/master_install_script.sh
@@ -22,6 +22,8 @@ echo "$LC_E2E_SSH_PUBKEY" >> .ssh/authorized_keys
 echo "GatewayPorts clientspecified" >> /etc/ssh/sshd_config
 systemctl restart sshd.service
 
+export DEBIAN_FRONTEND=noninteractive
+
 # Hetzner's Ubuntu Bionic comes with swap pre-configured, so we force it off.
 systemctl mask swap.target
 swapoff -a

--- a/test/tools/integration/master_install_script.sh
+++ b/test/tools/integration/master_install_script.sh
@@ -51,7 +51,7 @@ EOF
   EnvironmentFile=-/etc/environment
 EOF
 
-  DEBIAN_FRONTEND=noninteractive apt-get install -y  containerd.io=1.4*
+  DEBIAN_FRONTEND=noninteractive apt-get install -y  containerd.io=1.5*
   apt-mark hold containerd.io
 
   mkdir -p /etc/containerd/ && touch /etc/containerd/config.toml


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
We were previously using `kubic` packages from SUSE for the installation of buildah. Although they have been discontinued.

The alternative that I chose is to upgrade to `Ubuntu 22.04` in this case. Although eventually, we'll remove all of this in favor of KIND cluster and docker for building image with https://github.com/kubermatic/machine-controller/pull/1304

```
"NOTE: Kubic packages have been discontinued for Ubuntu 22.04 LTS. Current users of the Kubic repos for Ubuntu are highly recommended to uninstall the packages from the Kubic repos before upgrading to Ubuntu 22.04 LTS."
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
