### PR TITLE
Block setting spec.ConfigSource for Kubernetes 1.24+

### DIFF
--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -140,7 +140,6 @@ func (ad *admissionData) defaultAndValidateMachineSpec(ctx context.Context, spec
 	}
 
 	// Do not allow 1.24+ to use config source (dynamic kubelet configuration)
-
 	constraint124, err := semver.NewConstraint(">= 1.24")
 	if err != nil {
 		return fmt.Errorf("failed to parse 1.24 constraint: %w", err)


### PR DESCRIPTION


**What this PR does / why we need it**:

We already removed the feature flag in kubelet, but in my opinion we should also block this from being set in a `MachineSpec`, as it mirrors to the `Node` object and I would expect that the `NodeSpec` fields are going to go away eventually as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Machine specs for Kubernetes 1.24 or higher are not allowed to set spec.ConfigSource (as the dynamic kubelet configuration feature has been removed)
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
