### PR TITLE
Enable setup.service and disable it after first run

### DIFF
--- a/.prow/provider-vcloud-director.yaml
+++ b/.prow/provider-vcloud-director.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   - name: pull-machine-controller-e2e-vmware-cloud-director
-    always_run: true
+    always_run: false
     decorate: true
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"

--- a/.prow/provider-vcloud-director.yaml
+++ b/.prow/provider-vcloud-director.yaml
@@ -17,7 +17,8 @@ presubmits:
     always_run: true
     decorate: true
     error_on_eviction: true
-    clone_uri: "(pkg/cloudprovider/provider/vcloud-director/|pkg/userdata)"
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    run_if_changed: "(pkg/cloudprovider/provider/vcloud-director/|pkg/userdata)"
     labels:
       preset-vcloud-director: "true"
       preset-hetzner: "true"

--- a/.prow/provider-vcloud-director.yaml
+++ b/.prow/provider-vcloud-director.yaml
@@ -14,24 +14,28 @@
 
 presubmits:
   - name: pull-machine-controller-e2e-vmware-cloud-director
-    always_run: false
-    run_if_changed: "(pkg/cloudprovider/provider/vcloud-director/|pkg/userdata)"
+    always_run: true
     decorate: true
     error_on_eviction: true
-    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    clone_uri: "(pkg/cloudprovider/provider/vcloud-director/|pkg/userdata)"
     labels:
+      preset-vcloud-director: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
-      preset-vcloud-director: "true"
       preset-rhel: "true"
       preset-goproxy: "true"
+      preset-kind-volume-mounts: "true"
+      preset-docker-mirror: "true"
+      preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: golang:1.18.2
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-5
           command:
-            - "./hack/ci-e2e-test.sh"
+            - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestVMwareCloudDirectorProvisioningE2E"
+          securityContext:
+            privileged: true
           resources:
             requests:
               memory: 1Gi

--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -240,6 +240,7 @@ write_files:
     {{ end -}}
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -337,5 +338,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -240,7 +240,7 @@ write_files:
     {{ end -}}
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
@@ -170,6 +170,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -432,4 +433,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
@@ -170,7 +170,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
@@ -170,6 +170,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -432,4 +433,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
@@ -170,7 +170,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -185,6 +185,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -449,4 +450,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -185,7 +185,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -185,6 +185,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -449,4 +450,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -185,7 +185,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
@@ -177,6 +177,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -440,4 +441,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
@@ -177,7 +177,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
@@ -170,6 +170,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -432,4 +433,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
@@ -170,7 +170,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
@@ -170,6 +170,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -430,4 +431,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
@@ -170,7 +170,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.24-aws.yaml
@@ -173,6 +173,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -449,4 +450,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.24-aws.yaml
@@ -173,7 +173,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -258,6 +258,7 @@ write_files:
     {{- if eq .CloudProviderName "kubevirt" }}
     systemctl enable --now --no-block restart-kubelet.service
     {{ end }}
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -391,5 +392,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -258,7 +258,7 @@ write_files:
     {{- if eq .CloudProviderName "kubevirt" }}
     systemctl enable --now --no-block restart-kubelet.service
     {{ end }}
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
@@ -180,6 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -442,4 +443,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
@@ -180,7 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
@@ -180,6 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -442,4 +443,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
@@ -180,7 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -195,7 +195,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -195,6 +195,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -459,4 +460,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -195,7 +195,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -195,6 +195,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -459,4 +460,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
@@ -187,7 +187,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
@@ -187,6 +187,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -450,4 +451,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
@@ -180,6 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -442,4 +443,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
@@ -180,7 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
@@ -180,6 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -440,4 +441,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
@@ -180,7 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-nutanix.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-nutanix.yaml
@@ -187,7 +187,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-nutanix.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-nutanix.yaml
@@ -187,6 +187,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -448,4 +449,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.24-aws.yaml
@@ -179,6 +179,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -455,4 +456,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.24-aws.yaml
@@ -179,7 +179,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -258,8 +258,8 @@ write_files:
     {{- if eq .CloudProviderName "kubevirt" }}
     systemctl enable --now --no-block restart-kubelet.service
     {{ end }}
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -258,6 +258,8 @@ write_files:
     {{- if eq .CloudProviderName "kubevirt" }}
     systemctl enable --now --no-block restart-kubelet.service
     {{ end }}
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -431,6 +433,6 @@ rh_subscription:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service
 `

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -180,8 +180,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -180,6 +180,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -475,5 +477,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -180,8 +180,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -180,6 +180,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -475,5 +477,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
@@ -188,8 +188,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
@@ -188,6 +188,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -484,5 +486,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -180,8 +180,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -180,6 +180,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -473,5 +475,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
@@ -180,8 +180,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
@@ -180,6 +180,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -473,5 +475,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -196,8 +196,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -196,6 +196,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -491,5 +493,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -196,8 +196,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -196,6 +196,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -491,5 +493,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -188,6 +188,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -482,5 +484,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -188,8 +188,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
@@ -179,8 +179,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
@@ -179,6 +179,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -488,5 +490,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
@@ -179,8 +179,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
@@ -179,6 +179,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -488,5 +490,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -185,6 +185,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
+	systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -481,5 +483,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -185,8 +185,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
-	systemctl disable disable-nm-cloud-setup.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/provider.go
+++ b/pkg/userdata/rockylinux/provider.go
@@ -250,6 +250,7 @@ write_files:
     {{ end -}}
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -347,5 +348,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/rockylinux/provider.go
+++ b/pkg/userdata/rockylinux/provider.go
@@ -250,7 +250,7 @@ write_files:
     {{ end -}}
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-aws-external.yaml
@@ -175,6 +175,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -437,4 +438,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-aws-external.yaml
@@ -175,7 +175,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-aws.yaml
@@ -175,6 +175,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -437,4 +438,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-aws.yaml
@@ -175,7 +175,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -190,7 +190,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -190,6 +190,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -454,4 +455,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -190,7 +190,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -190,6 +190,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -454,4 +455,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere.yaml
@@ -182,6 +182,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -445,4 +446,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.21-vsphere.yaml
@@ -182,7 +182,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.22-aws.yaml
@@ -175,6 +175,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -437,4 +438,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.22-aws.yaml
@@ -175,7 +175,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-aws.yaml
@@ -175,7 +175,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-aws.yaml
@@ -175,6 +175,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -435,4 +436,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-nutanix.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-nutanix.yaml
@@ -182,6 +182,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -443,4 +444,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-nutanix.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-nutanix.yaml
@@ -182,7 +182,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.24-aws.yaml
@@ -174,6 +174,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+	systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -450,4 +451,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.24-aws.yaml
@@ -174,7 +174,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
-	systemctl disable setup.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -251,6 +251,7 @@ write_files:
     {{- if eq .CloudProviderName "kubevirt" }}
     systemctl enable --now --no-block restart-kubelet.service
     {{ end }}
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -387,5 +388,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/ubuntu/testdata/containerd.yaml
+++ b/pkg/userdata/ubuntu/testdata/containerd.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -473,4 +474,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -446,4 +447,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/docker.yaml
+++ b/pkg/userdata/ubuntu/testdata/docker.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -458,4 +459,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -178,6 +178,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -444,4 +445,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -178,6 +178,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -446,4 +447,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -446,4 +447,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/nutanix.yaml
+++ b/pkg/userdata/ubuntu/testdata/nutanix.yaml
@@ -181,6 +181,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -451,4 +452,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -178,6 +178,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -448,4 +449,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -178,6 +178,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -448,4 +449,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.21.10.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.21.10.yaml
@@ -178,6 +178,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -444,4 +445,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.22.7.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.22.7.yaml
@@ -178,6 +178,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -444,4 +445,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.23.5.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.23.5.yaml
@@ -178,6 +178,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -442,4 +443,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.24.0.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.24.0.yaml
@@ -178,6 +178,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -458,4 +459,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -188,6 +188,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -459,4 +460,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -188,6 +188,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -459,4 +460,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -179,6 +179,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -449,4 +450,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables the setup.service via systemd and disable it after it runs once. This ensures that the setup runs in case systemd cannot start the service immediately, due to a pending shutdown.


Fixes #https://github.com/kubermatic/kubermatic/issues/9724


```release-note
Fix a bug where cloud-init "package_reboot_if_required" fails and prevents the setup of the node
```
