### PR TITLE
Support configuring MaxPods for Machines

### DIFF
--- a/pkg/apis/cluster/common/consts.go
+++ b/pkg/apis/cluster/common/consts.go
@@ -140,6 +140,7 @@ const (
 	EvictionHardKubeletConfig         = "EvictionHard"
 	ContainerLogMaxSizeKubeletConfig  = "ContainerLogMaxSize"
 	ContainerLogMaxFilesKubeletConfig = "ContainerLogMaxFiles"
+	MaxPodsKubeletConfig              = "MaxPods"
 )
 
 const (

--- a/pkg/userdata/helper/kubelet.go
+++ b/pkg/userdata/helper/kubelet.go
@@ -247,6 +247,16 @@ func kubeletConfiguration(clusterDomain string, clusterDNS []net.IP, featureGate
 		}
 	}
 
+	if maxPods, ok := kubeletConfigs[common.MaxPodsKubeletConfig]; ok {
+		mp, err := strconv.ParseInt(maxPods, 10, 32)
+		if err != nil {
+			// Instead of breaking the workflow, just print a warning and skip the configuration
+			klog.Warningf("Skipping invalid MaxPods value %v for Kubelet configuration", maxPods)
+		} else {
+			cfg.MaxPods = int32(mp)
+		}
+	}
+
 	if containerLogMaxSize, ok := kubeletConfigs[common.ContainerLogMaxSizeKubeletConfig]; ok {
 		cfg.ContainerLogMaxSize = containerLogMaxSize
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for configuring the maximum number of pods per node.

The maximum number of pods can be adjusted by applying the following annotation on the Machine object:

```yaml
...
metadata:
  annotations:
    v1.kubelet-config.machine-controller.kubermatic.io/MaxPods: "<maxpods>"
...
```

If you're using MachineDeployment to manage Machines, you can apply this annotation by adding it to `spec.template.metadata.annotations` on MachineDeployment:

```yaml
...
...
spec:
  template:
    metadata:
      annotations:
        v1.kubelet-config.machine-controller.kubermatic.io/MaxPods: "<maxpods>"
...
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
xref https://github.com/kubermatic/kubeone/issues/2071

**Optional Release Note**:
```release-note
Support configuring the maximum number of pods per node
```