### PR TITLE
Populate default OSP annotation if an empty value is provided for the OSP key

### DIFF
--- a/pkg/admission/machinedeployments_validation.go
+++ b/pkg/admission/machinedeployments_validation.go
@@ -148,8 +148,9 @@ func mutationsForMachineDeployment(md *v1alpha1.MachineDeployment, useOSM bool) 
 }
 
 func ensureOSPAnnotation(md *v1alpha1.MachineDeployment, providerConfig providerconfigtypes.Config) error {
-	// Check for existing annotation
-	if _, ok := md.Annotations[osmresources.MachineDeploymentOSPAnnotation]; !ok {
+	// Check for existing annotation if it doesn't exist or if the value is empty
+	// inject the appropriate annotation.
+	if val, ok := md.Annotations[osmresources.MachineDeploymentOSPAnnotation]; !ok || val == "" {
 		if md.Annotations == nil {
 			md.Annotations = make(map[string]string)
 		}


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Populate default OSP annotation if an empty value is provided for the OSP key/

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
