### PR TITLE
Fix KubeVirt e2e Os images http server

### DIFF
--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
@@ -34,7 +34,7 @@ spec:
                 cpus: "1"
                 memory: "4096M"
                 primaryDisk:
-                  osImage: http://10.244.1.19/<< OS_NAME >>.img
+                  osImage: http://image-repo.kube-system.svc.cluster.local/images/<< OS_NAME >>.img
                   size: "25Gi"
                   storageClassName: longhorn
               dnsPolicy: "None"


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
- Created a service for os images instead of Pod Ip (subject to changes)
- OS images are now in /usr/share/nginx/html/images (mounted from a PVC), so not lost when the pod is restarted.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
