### PR TITLE
Anexia: increase HTTP client timeout

### DIFF
--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -484,7 +484,7 @@ func (p *provider) SetMetricsForMachines(_ clusterv1alpha1.MachineList) error {
 
 func getClient(token string) (anxclient.Client, error) {
 	tokenOpt := anxclient.TokenFromString(token)
-	client := anxclient.HTTPClient(&http.Client{Timeout: 30 * time.Second})
+	client := anxclient.HTTPClient(&http.Client{Timeout: 120 * time.Second})
 	return anxclient.New(tokenOpt, client)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We found the current HTTP timeout of 30s is a bit short under some circumstances, so we change it to 120s.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anexia: change HTTP client timeout from 30s to 120s
```
