### PR TITLE
vcd: ipAllocationMode should be an optional field

### DIFF
--- a/pkg/cloudprovider/provider/vmwareclouddirector/types/types.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/types/types.go
@@ -46,7 +46,7 @@ type RawConfig struct {
 
 	// Network configuration.
 	Network          providerconfigtypes.ConfigVarString `json:"network"`
-	IPAllocationMode IPAllocationMode                    `json:"ipAllocationMode"`
+	IPAllocationMode IPAllocationMode                    `json:"ipAllocationMode,omitempty"`
 
 	// Compute configuration.
 	CPUs         int64   `json:"cpus"`


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
For VMware Cloud Director, `ipAllocationMode` should be an optional field since we are already [defaulting it to DHCP](https://github.com/kubermatic/machine-controller/blob/master/pkg/cloudprovider/provider/vmwareclouddirector/provider.go#L139). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMware Cloud Director: `ipAllocationMode` is an marked as optional field
```
