### PR TITLE
Fix logic for finding node by ProviderID

### DIFF
--- a/pkg/cloudprovider/instance/instance.go
+++ b/pkg/cloudprovider/instance/instance.go
@@ -24,6 +24,8 @@ type Instance interface {
 	Name() string
 	// ID returns the instance identifier.
 	ID() string
+	// ProviderID returns the expected providerID for the instance
+	ProviderID() string
 	// Addresses returns a list of addresses associated with the instance.
 	Addresses() map[string]v1.NodeAddressType
 	// Status returns the instance status.

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -86,6 +86,7 @@ func (a *alibabaInstance) ID() string {
 	return a.instance.InstanceId
 }
 
+// TODO: Implement once we start supporting Alibaba CCM
 func (a *alibabaInstance) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -86,7 +86,7 @@ func (a *alibabaInstance) ID() string {
 	return a.instance.InstanceId
 }
 
-// TODO: Implement once we start supporting Alibaba CCM
+// TODO: Implement once we start supporting Alibaba CCM.
 func (a *alibabaInstance) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -86,6 +86,10 @@ func (a *alibabaInstance) ID() string {
 	return a.instance.InstanceId
 }
 
+func (a *alibabaInstance) ProviderID() string {
+	return ""
+}
+
 func (a *alibabaInstance) Addresses() map[string]v1.NodeAddressType {
 	primaryIPAddresses := map[string]v1.NodeAddressType{}
 	for _, networkInterface := range a.instance.NetworkInterfaces.NetworkInterface {

--- a/pkg/cloudprovider/provider/anexia/instance.go
+++ b/pkg/cloudprovider/provider/anexia/instance.go
@@ -45,6 +45,10 @@ func (ai *anexiaInstance) ID() string {
 	return ai.info.Identifier
 }
 
+func (ai *anexiaInstance) ProviderID() string {
+	return ""
+}
+
 func (ai *anexiaInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 

--- a/pkg/cloudprovider/provider/anexia/instance.go
+++ b/pkg/cloudprovider/provider/anexia/instance.go
@@ -45,6 +45,7 @@ func (ai *anexiaInstance) ID() string {
 	return ai.info.Identifier
 }
 
+// TODO(xmudrii): Implement this.
 func (ai *anexiaInstance) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -1005,7 +1005,14 @@ func (d *awsInstance) ID() string {
 }
 
 func (d *awsInstance) ProviderID() string {
-	return ""
+	if d.instance.InstanceId == nil {
+		return ""
+	}
+	if d.instance.Placement.AvailabilityZone == nil {
+		return "aws:///" + *d.instance.InstanceId
+	}
+
+	return "aws:///" + *d.instance.Placement.AvailabilityZone + "/" + *d.instance.InstanceId
 }
 
 func (d *awsInstance) Addresses() map[string]v1.NodeAddressType {

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -1004,6 +1004,10 @@ func (d *awsInstance) ID() string {
 	return aws.StringValue(d.instance.InstanceId)
 }
 
+func (d *awsInstance) ProviderID() string {
+	return ""
+}
+
 func (d *awsInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{
 		aws.StringValue(d.instance.PublicIpAddress):  v1.NodeExternalIP,

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -125,7 +125,11 @@ func (vm *azureVM) Name() string {
 }
 
 func (vm *azureVM) ProviderID() string {
-	return ""
+	if vm.vm.ID == nil {
+		return ""
+	}
+
+	return "azure://" + *vm.vm.ID
 }
 
 func (vm *azureVM) Status() instance.Status {

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -124,6 +124,10 @@ func (vm *azureVM) Name() string {
 	return *vm.vm.Name
 }
 
+func (vm *azureVM) ProviderID() string {
+	return ""
+}
+
 func (vm *azureVM) Status() instance.Status {
 	return vm.status
 }

--- a/pkg/cloudprovider/provider/baremetal/provider.go
+++ b/pkg/cloudprovider/provider/baremetal/provider.go
@@ -53,7 +53,7 @@ func (b bareMetalServer) ID() string {
 	return b.server.GetID()
 }
 
-// TODO: Implement once we start supporting vCloud Director CCM
+// TODO: Tinkerbell doesn't have a CCM.
 func (b bareMetalServer) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/baremetal/provider.go
+++ b/pkg/cloudprovider/provider/baremetal/provider.go
@@ -53,6 +53,10 @@ func (b bareMetalServer) ID() string {
 	return b.server.GetID()
 }
 
+func (b bareMetalServer) ProviderID() string {
+	return ""
+}
+
 func (b bareMetalServer) Addresses() map[string]corev1.NodeAddressType {
 	return map[string]corev1.NodeAddressType{
 		b.server.GetIPAddress(): corev1.NodeInternalIP,

--- a/pkg/cloudprovider/provider/baremetal/provider.go
+++ b/pkg/cloudprovider/provider/baremetal/provider.go
@@ -53,6 +53,7 @@ func (b bareMetalServer) ID() string {
 	return b.server.GetID()
 }
 
+// TODO: Implement once we start supporting vCloud Director CCM
 func (b bareMetalServer) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -503,6 +503,10 @@ func (d *doInstance) ID() string {
 	return strconv.Itoa(d.droplet.ID)
 }
 
+func (d *doInstance) ProviderID() string {
+	return ""
+}
+
 func (d *doInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 	for _, n := range d.droplet.Networks.V4 {

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -504,7 +504,7 @@ func (d *doInstance) ID() string {
 }
 
 func (d *doInstance) ProviderID() string {
-	return ""
+	return fmt.Sprintf("digitalocean://%d", d.droplet.ID)
 }
 
 func (d *doInstance) Addresses() map[string]v1.NodeAddressType {

--- a/pkg/cloudprovider/provider/equinixmetal/provider.go
+++ b/pkg/cloudprovider/provider/equinixmetal/provider.go
@@ -400,7 +400,7 @@ func (s *metalDevice) ID() string {
 }
 
 func (s *metalDevice) ProviderID() string {
-	return ""
+	return "equinixmetal://" + s.device.ID
 }
 
 func (s *metalDevice) Addresses() map[string]v1.NodeAddressType {

--- a/pkg/cloudprovider/provider/equinixmetal/provider.go
+++ b/pkg/cloudprovider/provider/equinixmetal/provider.go
@@ -399,6 +399,10 @@ func (s *metalDevice) ID() string {
 	return s.device.ID
 }
 
+func (s *metalDevice) ProviderID() string {
+	return ""
+}
+
 func (s *metalDevice) Addresses() map[string]v1.NodeAddressType {
 	// returns addresses in CIDR format
 	addresses := map[string]v1.NodeAddressType{}

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -48,6 +48,10 @@ func (f CloudProviderInstance) ID() string {
 	return ""
 }
 
+func (f CloudProviderInstance) ProviderID() string {
+	return ""
+}
+
 func (f CloudProviderInstance) Addresses() map[string]corev1.NodeAddressType {
 	return nil
 }

--- a/pkg/cloudprovider/provider/gce/instance.go
+++ b/pkg/cloudprovider/provider/gce/instance.go
@@ -60,6 +60,10 @@ func (gi *googleInstance) ID() string {
 	return strconv.FormatUint(gi.ci.Id, 10)
 }
 
+func (gi *googleInstance) ProviderID() string {
+	return ""
+}
+
 // Addresses implements instance.Instance.
 func (gi *googleInstance) Addresses() map[string]v1.NodeAddressType {
 	addrs := map[string]v1.NodeAddressType{}

--- a/pkg/cloudprovider/provider/gce/instance.go
+++ b/pkg/cloudprovider/provider/gce/instance.go
@@ -61,7 +61,7 @@ func (gi *googleInstance) ID() string {
 }
 
 func (gi *googleInstance) ProviderID() string {
-	return ""
+	return fmt.Sprintf("gce://%s/%s/%s", gi.projectID, gi.zone, gi.ci.Name)
 }
 
 // Addresses implements instance.Instance.

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -534,7 +534,7 @@ func (s *hetznerServer) ID() string {
 }
 
 func (s *hetznerServer) ProviderID() string {
-	return ""
+	return fmt.Sprintf("hcloud://%d", s.server.ID)
 }
 
 func (s *hetznerServer) Addresses() map[string]v1.NodeAddressType {

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -533,6 +533,10 @@ func (s *hetznerServer) ID() string {
 	return strconv.Itoa(s.server.ID)
 }
 
+func (s *hetznerServer) ProviderID() string {
+	return ""
+}
+
 func (s *hetznerServer) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 	for _, fips := range s.server.PublicNet.FloatingIPs {

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -162,7 +162,7 @@ func (k *kubeVirtServer) ID() string {
 }
 
 func (k *kubeVirtServer) ProviderID() string {
-	return ""
+	return "kubevirt://" + k.vmi.Name
 }
 
 func (k *kubeVirtServer) Addresses() map[string]corev1.NodeAddressType {

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -161,6 +161,10 @@ func (k *kubeVirtServer) ID() string {
 	return string(k.vmi.UID)
 }
 
+func (k *kubeVirtServer) ProviderID() string {
+	return ""
+}
+
 func (k *kubeVirtServer) Addresses() map[string]corev1.NodeAddressType {
 	addresses := map[string]corev1.NodeAddressType{}
 	for _, kvInterface := range k.vmi.Status.Interfaces {

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -403,6 +403,7 @@ func (d *linodeInstance) ID() string {
 	return strconv.Itoa(d.linode.ID)
 }
 
+// TODO: Implement once we start supporting Linode CCM
 func (d *linodeInstance) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -403,6 +403,10 @@ func (d *linodeInstance) ID() string {
 	return strconv.Itoa(d.linode.ID)
 }
 
+func (d *linodeInstance) ProviderID() string {
+	return ""
+}
+
 func (d *linodeInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 	for _, n := range d.linode.IPv4 {

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -403,7 +403,7 @@ func (d *linodeInstance) ID() string {
 	return strconv.Itoa(d.linode.ID)
 }
 
-// TODO: Implement once we start supporting Linode CCM
+// TODO: Implement once we start supporting Linode CCM.
 func (d *linodeInstance) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -85,6 +85,10 @@ func (nutanixServer Server) ID() string {
 	return nutanixServer.id
 }
 
+func (nutanixServer Server) ProviderID() string {
+	return ""
+}
+
 func (nutanixServer Server) Addresses() map[string]corev1.NodeAddressType {
 	return nutanixServer.addresses
 }

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -85,6 +85,7 @@ func (nutanixServer Server) ID() string {
 	return nutanixServer.id
 }
 
+// NB: Nutanix doesn't have a CCM
 func (nutanixServer Server) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -85,7 +85,7 @@ func (nutanixServer Server) ID() string {
 	return nutanixServer.id
 }
 
-// NB: Nutanix doesn't have a CCM
+// NB: Nutanix doesn't have a CCM.
 func (nutanixServer Server) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -934,6 +934,10 @@ func (d *osInstance) ID() string {
 	return d.server.ID
 }
 
+func (d *osInstance) ProviderID() string {
+	return ""
+}
+
 func (d *osInstance) Addresses() map[string]corev1.NodeAddressType {
 	addresses := map[string]corev1.NodeAddressType{}
 	for _, networkAddresses := range d.server.Addresses {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -935,7 +935,7 @@ func (d *osInstance) ID() string {
 }
 
 func (d *osInstance) ProviderID() string {
-	return ""
+	return "openstack:///" + d.server.ID
 }
 
 func (d *osInstance) Addresses() map[string]corev1.NodeAddressType {

--- a/pkg/cloudprovider/provider/scaleway/provider.go
+++ b/pkg/cloudprovider/provider/scaleway/provider.go
@@ -379,6 +379,10 @@ func (s *scwServer) ID() string {
 	return s.server.ID
 }
 
+func (s *scwServer) ProviderID() string {
+	return ""
+}
+
 func (s *scwServer) Addresses() map[string]corev1.NodeAddressType {
 	addresses := map[string]corev1.NodeAddressType{}
 	if s.server.PrivateIP != nil {

--- a/pkg/cloudprovider/provider/scaleway/provider.go
+++ b/pkg/cloudprovider/provider/scaleway/provider.go
@@ -379,6 +379,7 @@ func (s *scwServer) ID() string {
 	return s.server.ID
 }
 
+// TODO: Implement once we start supporting Scaleway CCM
 func (s *scwServer) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/scaleway/provider.go
+++ b/pkg/cloudprovider/provider/scaleway/provider.go
@@ -379,7 +379,7 @@ func (s *scwServer) ID() string {
 	return s.server.ID
 }
 
-// TODO: Implement once we start supporting Scaleway CCM
+// TODO: Implement once we start supporting Scaleway CCM.
 func (s *scwServer) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
@@ -120,6 +120,7 @@ func (s Server) ID() string {
 	return s.id
 }
 
+// TODO: Implement once we start supporting vCloud Director CCM
 func (s Server) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
@@ -120,7 +120,7 @@ func (s Server) ID() string {
 	return s.id
 }
 
-// TODO: Implement once we start supporting vCloud Director CCM
+// TODO: Implement once we start supporting vCloud Director CCM.
 func (s Server) ProviderID() string {
 	return ""
 }

--- a/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
@@ -120,6 +120,10 @@ func (s Server) ID() string {
 	return s.id
 }
 
+func (s Server) ProviderID() string {
+	return ""
+}
+
 func (s Server) Addresses() map[string]corev1.NodeAddressType {
 	return s.addresses
 }

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -82,6 +82,7 @@ var _ instance.Instance = &Server{}
 type Server struct {
 	name      string
 	id        string
+	uuid      string
 	status    instance.Status
 	addresses map[string]corev1.NodeAddressType
 }
@@ -95,7 +96,7 @@ func (vsphereServer Server) ID() string {
 }
 
 func (vsphereServer Server) ProviderID() string {
-	return ""
+	return "vsphere://" + vsphereServer.uuid
 }
 
 func (vsphereServer Server) Addresses() map[string]corev1.NodeAddressType {
@@ -376,7 +377,7 @@ func (p *provider) create(ctx context.Context, machine *clusterv1alpha1.Machine,
 		return nil, fmt.Errorf("error when waiting for vm powerOn task: %w", err)
 	}
 
-	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value}, nil
+	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value, uuid: virtualMachine.UUID(ctx)}, nil
 }
 
 func (p *provider) Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
@@ -506,7 +507,7 @@ func (p *provider) Get(ctx context.Context, machine *clusterv1alpha1.Machine, da
 		}
 		// We must return here because the vendored code for determining if the guest
 		// utils are running yields an NPD when using with an instance that is not running
-		return Server{name: virtualMachine.Name(), status: instance.StatusUnknown}, nil
+		return Server{name: virtualMachine.Name(), status: instance.StatusUnknown, uuid: virtualMachine.UUID(ctx)}, nil
 	}
 
 	// virtualMachine.IsToolsRunning panics when executed on a VM that is not powered on
@@ -534,7 +535,7 @@ func (p *provider) Get(ctx context.Context, machine *clusterv1alpha1.Machine, da
 		klog.V(3).Infof("Can't fetch the IP addresses for machine %s, the VMware guest utils are not running yet. This might take a few minutes", machine.Spec.Name)
 	}
 
-	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, addresses: addresses, id: virtualMachine.Reference().Value}, nil
+	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, addresses: addresses, id: virtualMachine.Reference().Value, uuid: virtualMachine.UUID(ctx)}, nil
 }
 
 func (p *provider) MigrateUID(_ context.Context, _ *clusterv1alpha1.Machine, _ ktypes.UID) error {

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -94,6 +94,10 @@ func (vsphereServer Server) ID() string {
 	return vsphereServer.id
 }
 
+func (vsphereServer Server) ProviderID() string {
+	return ""
+}
+
 func (vsphereServer Server) Addresses() map[string]corev1.NodeAddressType {
 	return vsphereServer.addresses
 }

--- a/pkg/controller/machine/machine_test.go
+++ b/pkg/controller/machine/machine_test.go
@@ -62,6 +62,10 @@ func (i *fakeInstance) ID() string {
 	return i.id
 }
 
+func (i *fakeInstance) ProviderID() string {
+	return ""
+}
+
 func (i *fakeInstance) Status() instance.Status {
 	return i.status
 }

--- a/pkg/controller/machine/machine_test.go
+++ b/pkg/controller/machine/machine_test.go
@@ -48,10 +48,11 @@ func init() {
 }
 
 type fakeInstance struct {
-	name      string
-	id        string
-	addresses map[string]corev1.NodeAddressType
-	status    instance.Status
+	name       string
+	id         string
+	providerID string
+	addresses  map[string]corev1.NodeAddressType
+	status     instance.Status
 }
 
 func (i *fakeInstance) Name() string {
@@ -63,7 +64,7 @@ func (i *fakeInstance) ID() string {
 }
 
 func (i *fakeInstance) ProviderID() string {
-	return ""
+	return i.providerID
 }
 
 func (i *fakeInstance) Status() instance.Status {
@@ -74,11 +75,7 @@ func (i *fakeInstance) Addresses() map[string]corev1.NodeAddressType {
 	return i.addresses
 }
 
-func getTestNode(id, provider string) corev1.Node {
-	providerID := ""
-	if provider != "" {
-		providerID = fmt.Sprintf("%s:///%s", provider, id)
-	}
+func getTestNode(id, providerID string) corev1.Node {
 	return corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("node%s", id),
@@ -102,10 +99,10 @@ func getTestNode(id, provider string) corev1.Node {
 }
 
 func TestController_GetNode(t *testing.T) {
-	node1 := getTestNode("1", "aws")
-	node2 := getTestNode("2", "openstack")
+	node1 := getTestNode("1", "aws:///i-1")
+	node2 := getTestNode("2", "openstack:///test")
 	node3 := getTestNode("3", "")
-	node4 := getTestNode("4", "hetzner")
+	node4 := getTestNode("4", "hcloud://123")
 	nodeList := []*corev1.Node{&node1, &node2, &node3, &node4}
 
 	tests := []struct {
@@ -138,7 +135,7 @@ func TestController_GetNode(t *testing.T) {
 			resNode:  &node1,
 			exists:   true,
 			err:      nil,
-			instance: &fakeInstance{id: "1", addresses: map[string]corev1.NodeAddressType{"": ""}},
+			instance: &fakeInstance{id: "1", addresses: map[string]corev1.NodeAddressType{"": ""}, providerID: "aws:///i-1"},
 		},
 		{
 			name:     "node found by internal ip",
@@ -186,7 +183,7 @@ func TestController_GetNode(t *testing.T) {
 			resNode:  &node4,
 			exists:   true,
 			err:      nil,
-			instance: &fakeInstance{id: "4", addresses: map[string]corev1.NodeAddressType{"": ""}},
+			instance: &fakeInstance{id: "4", addresses: map[string]corev1.NodeAddressType{"": ""}, providerID: "hcloud://123"},
 		},
 	}
 
@@ -647,6 +644,56 @@ func TestControllerDeleteNodeForMachine(t *testing.T) {
 				if len(test.nodes) != len(nodes.Items) {
 					t.Errorf("expected %d nodes, but got %d", len(test.nodes), len(nodes.Items))
 				}
+			}
+		})
+	}
+}
+
+func TestControllerFindNodeByProviderID(t *testing.T) {
+	tests := []struct {
+		name         string
+		instance     instance.Instance
+		provider     providerconfigtypes.CloudProvider
+		nodes        []corev1.Node
+		expectedNode bool
+	}{
+		{
+			name:     "aws providerID type 1",
+			instance: &fakeInstance{id: "99", providerID: "aws:///some-zone/i-99"},
+			provider: providerconfigtypes.CloudProviderAWS,
+			nodes: []corev1.Node{
+				getTestNode("1", "random"),
+				getTestNode("2", "aws:///some-zone/i-99"),
+			},
+			expectedNode: true,
+		},
+		{
+			name:     "aws providerID type 2",
+			instance: &fakeInstance{id: "99", providerID: "aws:///i-99"},
+			provider: providerconfigtypes.CloudProviderAWS,
+			nodes: []corev1.Node{
+				getTestNode("1", "aws:///i-99"),
+				getTestNode("2", "random"),
+			},
+			expectedNode: true,
+		},
+		{
+			name:     "azure providerID",
+			instance: &fakeInstance{id: "99", providerID: "azure:///test/test"},
+			provider: providerconfigtypes.CloudProviderAWS,
+			nodes: []corev1.Node{
+				getTestNode("1", "random"),
+				getTestNode("2", "azure:///test/test"),
+			},
+			expectedNode: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			node := findNodeByProviderID(test.instance, test.provider, test.nodes)
+			if (node != nil) != test.expectedNode {
+				t.Errorf("expected %t, but got %t", test.expectedNode, (node != nil))
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`machine_controller` is matching Machine object with respective Node object by:

* matching expected ProviderID with actual ProviderID of the Node object
* matching IP addresses of Machine object with IP addresses of the Node object

Matching Machines and Nodes by ProviderID currently works only for some providers such as AWS and Azure. It doesn't work for GCP, vSphere, and some other providers. This is because we expect all providers to format ProviderID like `<provider-name>:///<instance-id>` but that's not the case. Instead:

* some providers use double-slash instead of triple-slash, e.g. `<provider-name>://<instance-id>`
* some providers use something other than `<instance-id>`, e.g. `<provider-name>:///<availability-zone>/<instance-id>`

That said, the issue is that we're generating incorrect expected ProviderID for some providers. This PR fixes this problem by extending the `Instance` interface with the `ProviderID()` function which returns the expected ProviderID based on how CCM generates ProviderID for that provider. We use this function in place of the old expected ProviderID generation.

The reason for extending the `Instance` interface instead of going with another approach is:

* we anyways need to implement the `ProviderID()` function for each provider because formats are different
* this approach doesn't require modifying signature of the `getNode()` function which might be more complicated
* in the majority of cases, the information needed to generate the expected ProviderID is private and not available to `machine_controller` (e.g. availability zone, project ID, UUID...)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1353

**Optional Release Note**:
```release-note
Fix finding nodes by providerID for clusters with CCM or in-tree cloud provider
```