### PR TITLE
[release/v1.42] Enable setup.service and disable it after first run

### DIFF
--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -234,6 +234,7 @@ write_files:
     {{ end -}}
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -315,5 +316,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/amzn2/testdata/containerd-kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/containerd-kubelet-v1.20-aws.yaml
@@ -173,6 +173,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -435,4 +436,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.20-aws.yaml
@@ -170,6 +170,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -415,4 +416,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
@@ -170,6 +170,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -415,4 +416,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
@@ -170,6 +170,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -415,4 +416,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -185,6 +185,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -432,4 +433,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -185,6 +185,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -432,4 +433,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
@@ -177,6 +177,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -423,4 +424,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
@@ -170,6 +170,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -415,4 +416,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
@@ -170,6 +170,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -413,4 +414,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -248,6 +248,7 @@ write_files:
     {{ end -}}
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -329,5 +330,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -178,6 +178,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -440,4 +441,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.20-aws.yaml
@@ -179,6 +179,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -424,4 +425,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
@@ -179,6 +179,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -424,4 +425,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
@@ -179,6 +179,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -424,4 +425,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-nutanix.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-nutanix.yaml
@@ -186,6 +186,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -432,4 +433,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -194,6 +194,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -441,4 +442,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -194,6 +194,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -441,4 +442,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
@@ -186,6 +186,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -432,4 +433,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
@@ -179,6 +179,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -424,4 +425,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
@@ -179,6 +179,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -422,4 +423,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -254,6 +254,8 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -375,6 +377,6 @@ rh_subscription:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service
 `

--- a/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -174,6 +174,8 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -469,5 +471,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
@@ -175,6 +175,8 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -453,5 +455,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -175,6 +175,8 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -453,5 +455,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -175,6 +175,8 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -453,5 +455,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
@@ -183,6 +183,8 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -462,5 +464,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -175,6 +175,8 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -451,5 +453,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
@@ -175,6 +175,8 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -451,5 +453,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -191,6 +191,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -469,5 +471,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -191,6 +191,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -469,5 +471,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -183,6 +183,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -460,5 +462,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -199,6 +199,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -296,5 +297,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service
 `

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -138,6 +138,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -408,4 +409,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -406,4 +407,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -408,4 +409,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -138,6 +138,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -408,4 +409,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -410,4 +411,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -410,4 +411,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/version-1.20.14.yaml
+++ b/pkg/userdata/sles/testdata/version-1.20.14.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -406,4 +407,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/version-1.21.8.yaml
+++ b/pkg/userdata/sles/testdata/version-1.21.8.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -406,4 +407,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/version-1.22.5.yaml
+++ b/pkg/userdata/sles/testdata/version-1.22.5.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -406,4 +407,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/version-1.23.0.yaml
+++ b/pkg/userdata/sles/testdata/version-1.23.0.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -404,4 +405,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -146,6 +146,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -421,4 +422,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -146,6 +146,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -421,4 +422,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -137,6 +137,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -411,4 +412,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable setup.service

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -243,6 +243,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -329,5 +330,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/ubuntu/testdata/containerd.yaml
+++ b/pkg/userdata/ubuntu/testdata/containerd.yaml
@@ -182,6 +182,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -460,4 +461,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -182,6 +182,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -431,4 +432,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -182,6 +182,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/nutanix.yaml
+++ b/pkg/userdata/ubuntu/testdata/nutanix.yaml
@@ -183,6 +183,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -438,4 +439,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -435,4 +436,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -435,4 +436,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.20.14.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.20.14.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -431,4 +432,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.21.8.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.21.8.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -431,4 +432,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.22.5.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.22.5.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -431,4 +432,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.23.0.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.23.0.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -429,4 +430,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -190,6 +190,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -446,4 +447,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -190,6 +190,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -446,4 +447,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -181,6 +181,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -436,4 +437,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport for https://github.com/kubermatic/machine-controller/pull/1316. Required manual cherry-pick to resolve conflicts and avoid CI changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable setup.service and disable it after first run
```
