### PR TITLE
Equinix: use m3.small.x86 for CentOS E2E tests

### DIFF
--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -205,7 +205,7 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 	if strings.Contains(cloudProvider, string(providerconfigtypes.CloudProviderEquinixMetal)) {
 		switch testCase.osName {
 		case string(providerconfigtypes.OperatingSystemCentOS):
-			scenarioParams = append(scenarioParams, fmt.Sprintf("<< INSTANCE_TYPE >>=%s", "c3.small.x86"))
+			scenarioParams = append(scenarioParams, fmt.Sprintf("<< INSTANCE_TYPE >>=%s", "m3.small.x86"))
 			scenarioParams = append(scenarioParams, fmt.Sprintf("<< METRO_CODE >>=%s", "AM"))
 		case string(providerconfigtypes.OperatingSystemFlatcar):
 			scenarioParams = append(scenarioParams, fmt.Sprintf("<< INSTANCE_TYPE >>=%s", "c3.small.x86"))


### PR DESCRIPTION
**What this PR does / why we need it**:

`c3.small.x86` is not available in AM metro, so let's use `m3.small.x86` for CentOS E2E tests. We already use that instance size for Ubuntu and Rocky Linux E2E tests.

**Optional Release Note**:
```release-note
NONE
```

/assign @moadqassem 