### PR TITLE
Add IPFamily options in vSphere cloud config API

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -36,6 +36,7 @@ working-dir       = {{ .Global.WorkingDir | iniEscape }}
 datacenter        = {{ .Global.Datacenter | iniEscape }}
 datastore         = {{ .Global.DefaultDatastore | iniEscape }}
 server            = {{ .Global.VCenterIP | iniEscape }}
+ip-family         = {{ .Global.IPFamily | iniEscape }}
 
 [Disk]
 scsicontrollertype = {{ .Disk.SCSIControllerType | iniEscape }}
@@ -53,6 +54,7 @@ user = {{ $vc.User | iniEscape }}
 password = {{ $vc.Password | iniEscape }}
 port = {{ $vc.VCenterPort }}
 datacenters = {{ $vc.Datacenters | iniEscape }}
+ip-family = {{ $vc.IPFamily | iniEscape }}
 {{ end }}
 `
 )
@@ -79,6 +81,7 @@ type GlobalOpts struct {
 	DefaultDatastore string `gcfg:"datastore"`
 	VCenterIP        string `gcfg:"server"`
 	ClusterID        string `gcfg:"cluster-id"`
+	IPFamily         string `gcfg:"ip-family"`
 }
 
 type VirtualCenterConfig struct {
@@ -86,6 +89,7 @@ type VirtualCenterConfig struct {
 	Password    string `gcfg:"password"`
 	VCenterPort string `gcfg:"port"`
 	Datacenters string `gcfg:"datacenters"`
+	IPFamily    string `gcfg:"ip-family"`
 }
 
 // CloudConfig is used to read and store information from the cloud configuration file.

--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig_test.go
@@ -87,6 +87,36 @@ func TestCloudConfigToString(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "3-dual-stack",
+			config: &CloudConfig{
+				Global: GlobalOpts{
+					User:         "admin",
+					Password:     "password",
+					InsecureFlag: true,
+					IPFamily:     "ipv4,ipv6",
+				},
+				Workspace: WorkspaceOpts{
+					VCenterIP:        "https://127.0.0.1:8443",
+					ResourcePoolPath: "/some-resource-pool",
+					DefaultDatastore: "Datastore",
+					Folder:           "some-folder",
+					Datacenter:       "Datacenter",
+				},
+				Disk: DiskOpts{
+					SCSIControllerType: "pvscsi",
+				},
+				VirtualCenter: map[string]*VirtualCenterConfig{
+					"vc1": {
+						User:        "1-some-user",
+						Password:    "1-some-password",
+						VCenterPort: "443",
+						Datacenters: "1-foo",
+						IPFamily:    "ipv4,ipv6",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/cloudprovider/provider/vsphere/types/testdata/3-dual-stack.golden
+++ b/pkg/cloudprovider/provider/vsphere/types/testdata/3-dual-stack.golden
@@ -7,7 +7,7 @@ working-dir       = ""
 datacenter        = ""
 datastore         = ""
 server            = ""
-ip-family         = ""
+ip-family         = "ipv4,ipv6"
 
 [Disk]
 scsicontrollertype = "pvscsi"
@@ -25,12 +25,5 @@ user = "1-some-user"
 password = "1-some-password"
 port = 443
 datacenters = "1-foo"
-ip-family = ""
-
-[VirtualCenter "vc2"]
-user = "2-some-user"
-password = "2-some-password"
-port = 443
-datacenters = "2-foo"
-ip-family = ""
+ip-family = "ipv4,ipv6"
 

--- a/pkg/cloudprovider/provider/vsphere/types/testdata/simple-config.golden
+++ b/pkg/cloudprovider/provider/vsphere/types/testdata/simple-config.golden
@@ -7,6 +7,7 @@ working-dir       = ""
 datacenter        = ""
 datastore         = ""
 server            = ""
+ip-family         = ""
 
 [Disk]
 scsicontrollertype = "pvscsi"


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Adds options to configure ip-family on Global and VirtualCenter level in [vSphere cloudconfig](https://github.com/kubernetes/cloud-provider-vsphere/blob/release-1.24/docs/book/cloud_config.md).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
The ip-family options have been there at least since the [release 1.18](https://github.com/kubernetes/cloud-provider-vsphere/blob/release-1.18/docs/book/cloud_config.md) and they default to `ipv4`, so the change should not be breaking.

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add IPFamily options into in vSphere cloud config API.
```
