### PR TITLE
Fix unmarshalling for `configvarstring` in cloudProviderSpec

### DIFF
--- a/pkg/providerconfig/types/types_test.go
+++ b/pkg/providerconfig/types/types_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 )
 
@@ -160,6 +160,7 @@ func TestConfigVarBoolMarshalling(t *testing.T) {
 func TestConfigVarStringMarshallingAndUnmarshalling(t *testing.T) {
 	testCases := []ConfigVarString{
 		{Value: "val"},
+		{Value: "spe<ialv&lue"},
 		{SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
 		{Value: "val", SecretKeyRef: GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
 		{ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"}},
@@ -169,6 +170,11 @@ func TestConfigVarStringMarshallingAndUnmarshalling(t *testing.T) {
 		},
 		{
 			Value:           "val",
+			ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+			SecretKeyRef:    GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
+		},
+		{
+			Value:           "spe<ialv&lue",
 			ConfigMapKeyRef: GlobalConfigMapKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
 			SecretKeyRef:    GlobalSecretKeySelector{ObjectReference: v1.ObjectReference{Namespace: "ns", Name: "name"}, Key: "key"},
 		},


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
To keep strings safe to embed inside HTML `json.Marshal()` encodes them using [HTMLEscape](https://github.com/golang/go/blob/go1.18.4/src/encoding/json/encode.go#L161). It replaces invalid bytes with the Unicode replacement rune. For example "<", ">" will be converted to "\u003c","\u003e", respectively. `json.Unmarshal` takes care of replacing these escape characters with the actual value. 

In general, this works fine for us but in the case of `ConfigVarString` we override the unmarshalling and marshalling behavior. And Unmarshalling [doesn't replace the escape characters](https://github.com/kubermatic/machine-controller/blob/master/pkg/providerconfig/types/types.go#L164).

This PR reworks the `ConfigVarString` unmashalling to rectify this issue.

Special thanks to @xmudrii for coming up with the fix. ⚡ 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix unmarshalling for `configvarstring` in cloudProviderSpec.
```
