### PR TITLE
[release/v1.43] Fix logic for finding node by ProviderID

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -159,7 +159,7 @@ presubmits:
       preset-e2e-ssh: "true"
       preset-hetzner: "true"
       preset-openstack: "true"
-      preset-vsphere: "true"
+      preset-vsphere-legacy: "true"
       preset-kubevirt: "true"
       preset-alibaba: "true"
       preset-goproxy: "true"
@@ -550,7 +550,7 @@ presubmits:
     labels:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
-      preset-vsphere: "true"
+      preset-vsphere-legacy: "true"
       preset-rhel: "true"
       preset-goproxy: "true"
     spec:
@@ -568,7 +568,8 @@ presubmits:
   - name: pull-machine-controller-e2e-nutanix
     optional: true
     always_run: false
-    run_if_changed: "(pkg/cloudprovider/provider/nutanix/|pkg/userdata/|test/e2e/provisioning/)"
+    # TODO uncomment this when Nutanix is in a working condition
+    # run_if_changed: "(pkg/cloudprovider/provider/nutanix/|pkg/userdata/|test/e2e/provisioning/)"
     decorate: true
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
@@ -794,7 +795,7 @@ presubmits:
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     labels:
-      preset-vsphere: "true"
+      preset-vsphere-legacy: "true"
       preset-rhel: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
@@ -817,7 +818,7 @@ presubmits:
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     labels:
-      preset-vsphere: "true"
+      preset-vsphere-legacy: "true"
       preset-rhel: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"

--- a/pkg/cloudprovider/instance/instance.go
+++ b/pkg/cloudprovider/instance/instance.go
@@ -24,6 +24,8 @@ type Instance interface {
 	Name() string
 	// ID returns the instance identifier.
 	ID() string
+	// ProviderID returns the expected providerID for the instance
+	ProviderID() string
 	// Addresses returns a list of addresses associated with the instance.
 	Addresses() map[string]v1.NodeAddressType
 	// Status returns the instance status.

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -86,6 +86,11 @@ func (a *alibabaInstance) ID() string {
 	return a.instance.InstanceId
 }
 
+// TODO: Implement once we start supporting Alibaba CCM.
+func (a *alibabaInstance) ProviderID() string {
+	return ""
+}
+
 func (a *alibabaInstance) Addresses() map[string]v1.NodeAddressType {
 	primaryIPAddresses := map[string]v1.NodeAddressType{}
 	for _, networkInterface := range a.instance.NetworkInterfaces.NetworkInterface {

--- a/pkg/cloudprovider/provider/anexia/instance.go
+++ b/pkg/cloudprovider/provider/anexia/instance.go
@@ -45,6 +45,11 @@ func (ai *anexiaInstance) ID() string {
 	return ai.info.Identifier
 }
 
+// TODO(xmudrii): Implement this.
+func (ai *anexiaInstance) ProviderID() string {
+	return ""
+}
+
 func (ai *anexiaInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -987,6 +987,17 @@ func (d *awsInstance) ID() string {
 	return aws.StringValue(d.instance.InstanceId)
 }
 
+func (d *awsInstance) ProviderID() string {
+	if d.instance.InstanceId == nil {
+		return ""
+	}
+	if d.instance.Placement.AvailabilityZone == nil {
+		return "aws:///" + *d.instance.InstanceId
+	}
+
+	return "aws:///" + *d.instance.Placement.AvailabilityZone + "/" + *d.instance.InstanceId
+}
+
 func (d *awsInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{
 		aws.StringValue(d.instance.PublicIpAddress):  v1.NodeExternalIP,

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -122,6 +122,14 @@ func (vm *azureVM) Name() string {
 	return *vm.vm.Name
 }
 
+func (vm *azureVM) ProviderID() string {
+	if vm.vm.ID == nil {
+		return ""
+	}
+
+	return "azure://" + *vm.vm.ID
+}
+
 func (vm *azureVM) Status() instance.Status {
 	return vm.status
 }

--- a/pkg/cloudprovider/provider/baremetal/provider.go
+++ b/pkg/cloudprovider/provider/baremetal/provider.go
@@ -53,6 +53,11 @@ func (b bareMetalServer) ID() string {
 	return b.server.GetID()
 }
 
+// TODO: Tinkerbell doesn't have a CCM.
+func (b bareMetalServer) ProviderID() string {
+	return ""
+}
+
 func (b bareMetalServer) Addresses() map[string]corev1.NodeAddressType {
 	return map[string]corev1.NodeAddressType{
 		b.server.GetIPAddress(): corev1.NodeInternalIP,

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -497,6 +497,10 @@ func (d *doInstance) ID() string {
 	return strconv.Itoa(d.droplet.ID)
 }
 
+func (d *doInstance) ProviderID() string {
+	return fmt.Sprintf("digitalocean://%d", d.droplet.ID)
+}
+
 func (d *doInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 	for _, n := range d.droplet.Networks.V4 {

--- a/pkg/cloudprovider/provider/equinixmetal/provider.go
+++ b/pkg/cloudprovider/provider/equinixmetal/provider.go
@@ -372,6 +372,10 @@ func (s *metalDevice) ID() string {
 	return s.device.ID
 }
 
+func (s *metalDevice) ProviderID() string {
+	return "equinixmetal://" + s.device.ID
+}
+
 func (s *metalDevice) Addresses() map[string]v1.NodeAddressType {
 	// returns addresses in CIDR format
 	addresses := map[string]v1.NodeAddressType{}

--- a/pkg/cloudprovider/provider/fake/provider.go
+++ b/pkg/cloudprovider/provider/fake/provider.go
@@ -47,6 +47,10 @@ func (f CloudProviderInstance) ID() string {
 	return ""
 }
 
+func (f CloudProviderInstance) ProviderID() string {
+	return ""
+}
+
 func (f CloudProviderInstance) Addresses() map[string]v1.NodeAddressType {
 	return nil
 }

--- a/pkg/cloudprovider/provider/gce/instance.go
+++ b/pkg/cloudprovider/provider/gce/instance.go
@@ -60,6 +60,10 @@ func (gi *googleInstance) ID() string {
 	return strconv.FormatUint(gi.ci.Id, 10)
 }
 
+func (gi *googleInstance) ProviderID() string {
+	return fmt.Sprintf("gce://%s/%s/%s", gi.projectID, gi.zone, gi.ci.Name)
+}
+
 // Addresses implements instance.Instance.
 func (gi *googleInstance) Addresses() map[string]v1.NodeAddressType {
 	addrs := map[string]v1.NodeAddressType{}

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -538,6 +538,10 @@ func (s *hetznerServer) ID() string {
 	return strconv.Itoa(s.server.ID)
 }
 
+func (s *hetznerServer) ProviderID() string {
+	return fmt.Sprintf("hcloud://%d", s.server.ID)
+}
+
 func (s *hetznerServer) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 	for _, fips := range s.server.PublicNet.FloatingIPs {

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -98,6 +98,10 @@ func (k *kubeVirtServer) ID() string {
 	return string(k.vmi.UID)
 }
 
+func (k *kubeVirtServer) ProviderID() string {
+	return "kubevirt://" + k.vmi.Name
+}
+
 func (k *kubeVirtServer) Addresses() map[string]corev1.NodeAddressType {
 	addresses := map[string]corev1.NodeAddressType{}
 	for _, kvInterface := range k.vmi.Status.Interfaces {

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -411,6 +411,11 @@ func (d *linodeInstance) ID() string {
 	return strconv.Itoa(d.linode.ID)
 }
 
+// TODO: Implement once we start supporting Linode CCM.
+func (d *linodeInstance) ProviderID() string {
+	return ""
+}
+
 func (d *linodeInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 	for _, n := range d.linode.IPv4 {

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -85,6 +85,11 @@ func (nutanixServer Server) ID() string {
 	return nutanixServer.id
 }
 
+// NB: Nutanix doesn't have a CCM.
+func (nutanixServer Server) ProviderID() string {
+	return ""
+}
+
 func (nutanixServer Server) Addresses() map[string]corev1.NodeAddressType {
 	return nutanixServer.addresses
 }

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -931,6 +931,10 @@ func (d *osInstance) ID() string {
 	return d.server.ID
 }
 
+func (d *osInstance) ProviderID() string {
+	return "openstack:///" + d.server.ID
+}
+
 func (d *osInstance) Addresses() map[string]corev1.NodeAddressType {
 	addresses := map[string]corev1.NodeAddressType{}
 	for _, networkAddresses := range d.server.Addresses {

--- a/pkg/cloudprovider/provider/scaleway/provider.go
+++ b/pkg/cloudprovider/provider/scaleway/provider.go
@@ -382,6 +382,11 @@ func (s *scwServer) ID() string {
 	return s.server.ID
 }
 
+// TODO: Implement once we start supporting Scaleway CCM.
+func (s *scwServer) ProviderID() string {
+	return ""
+}
+
 func (s *scwServer) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 	if s.server.PrivateIP != nil {

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -82,6 +82,7 @@ var _ instance.Instance = &Server{}
 type Server struct {
 	name      string
 	id        string
+	uuid      string
 	status    instance.Status
 	addresses map[string]corev1.NodeAddressType
 }
@@ -92,6 +93,10 @@ func (vsphereServer Server) Name() string {
 
 func (vsphereServer Server) ID() string {
 	return vsphereServer.id
+}
+
+func (vsphereServer Server) ProviderID() string {
+	return "vsphere://" + vsphereServer.uuid
 }
 
 func (vsphereServer Server) Addresses() map[string]corev1.NodeAddressType {
@@ -351,7 +356,7 @@ func (p *provider) create(machine *v1alpha1.Machine, userdata string) (instance.
 		return nil, fmt.Errorf("error when waiting for vm powerOn task: %v", err)
 	}
 
-	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value}, nil
+	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, id: virtualMachine.Reference().Value, uuid: virtualMachine.UUID(ctx)}, nil
 }
 
 func (p *provider) Cleanup(machine *v1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
@@ -482,7 +487,7 @@ func (p *provider) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.Provi
 		}
 		// We must return here because the vendored code for determining if the guest
 		// utils are running yields an NPD when using with an instance that is not running
-		return Server{name: virtualMachine.Name(), status: instance.StatusUnknown}, nil
+		return Server{name: virtualMachine.Name(), status: instance.StatusUnknown, uuid: virtualMachine.UUID(ctx)}, nil
 	}
 
 	// virtualMachine.IsToolsRunning panics when executed on a VM that is not powered on
@@ -510,7 +515,7 @@ func (p *provider) Get(machine *v1alpha1.Machine, data *cloudprovidertypes.Provi
 		klog.V(3).Infof("Can't fetch the IP addresses for machine %s, the VMware guest utils are not running yet. This might take a few minutes", machine.Spec.Name)
 	}
 
-	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, addresses: addresses, id: virtualMachine.Reference().Value}, nil
+	return Server{name: virtualMachine.Name(), status: instance.StatusRunning, addresses: addresses, id: virtualMachine.Reference().Value, uuid: virtualMachine.UUID(ctx)}, nil
 }
 
 func (p *provider) MigrateUID(machine *v1alpha1.Machine, new ktypes.UID) error {

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -205,6 +205,20 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< MAX_PRICE >>=%s", "0.03"))
 	}
 
+	if strings.Contains(cloudProvider, string(providerconfigtypes.CloudProviderEquinixMetal)) {
+		switch testCase.osName {
+		case string(providerconfigtypes.OperatingSystemCentOS):
+			scenarioParams = append(scenarioParams, fmt.Sprintf("<< INSTANCE_TYPE >>=%s", "m3.small.x86"))
+			scenarioParams = append(scenarioParams, fmt.Sprintf("<< FACILITY_CODE >>=%s", "am6"))
+		case string(providerconfigtypes.OperatingSystemFlatcar):
+			scenarioParams = append(scenarioParams, fmt.Sprintf("<< INSTANCE_TYPE >>=%s", "c3.small.x86"))
+			scenarioParams = append(scenarioParams, fmt.Sprintf("<< FACILITY_CODE >>=%s", "ny5"))
+		case string(providerconfigtypes.OperatingSystemUbuntu):
+			scenarioParams = append(scenarioParams, fmt.Sprintf("<< INSTANCE_TYPE >>=%s", "m3.small.x86"))
+			scenarioParams = append(scenarioParams, fmt.Sprintf("<< FACILITY_CODE >>=%s", "am6"))
+		}
+	}
+
 	// only used by assume role scenario, otherwise empty (disabled)
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< AWS_ASSUME_ROLE_ARN >>=%s", os.Getenv("AWS_ASSUME_ROLE_ARN")))
 	scenarioParams = append(scenarioParams, fmt.Sprintf("<< AWS_ASSUME_ROLE_EXTERNAL_ID >>=%s", os.Getenv("AWS_ASSUME_ROLE_EXTERNAL_ID")))

--- a/test/e2e/provisioning/testdata/machinedeployment-equinixmetal.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-equinixmetal.yaml
@@ -26,9 +26,9 @@ spec:
           cloudProviderSpec:
             token: << METAL_AUTH_TOKEN >>
             projectID: << METAL_PROJECT_ID >>
-            instanceType: "c1.small.x86"
+            instanceType: "<< INSTANCE_TYPE >>"
             facilities:
-            - "am6"
+            - "<< FACILITY_CODE >>"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-equinixmetal.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-equinixmetal.yaml
@@ -28,7 +28,7 @@ spec:
             projectID: << METAL_PROJECT_ID >>
             instanceType: "c1.small.x86"
             facilities:
-            - "ams1"
+            - "am6"
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
@@ -28,7 +28,7 @@ spec:
           cloudProviderSpec:
             storageClassName: longhorn
             pvcSize: "10Gi"
-            sourceURL: http://10.244.1.19/<< OS_NAME >>.img
+            sourceURL: http://image-repo.kube-system.svc.cluster.local/images/<< OS_NAME >>.img
             cpus: "1"
             memory: "4096M"
             dnsPolicy: "None"


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual cherry-pick of #1351 to the `release/v1.43` branch, which is used on the KubeOne 1.4 release branch.

**Optional Release Note**:
```release-note
Fix finding nodes by providerID for clusters with CCM or in-tree cloud provider
```

/assign @moadqassem @ahmedwaleedmalik 