### PR TITLE
Add label on machine to differentiate between the tool used for managing machine configurations

### DIFF
--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider"
+	controllerutil "github.com/kubermatic/machine-controller/pkg/controller/util"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
@@ -95,6 +96,14 @@ func (ad *admissionData) mutateMachines(ctx context.Context, ar admissionv1.Admi
 			return nil, err
 		}
 		common.SetOSLabel(&machine.Spec, string(providerConfig.OperatingSystem))
+	}
+
+	// Set LegacyMachineControllerUserDataLabel to false if OSM was used for managing the machine configuration.
+	if ad.useOSM {
+		if machine.Labels == nil {
+			machine.Labels = make(map[string]string)
+		}
+		machine.Labels[controllerutil.LegacyMachineControllerUserDataLabel] = "false"
 	}
 
 	return createAdmissionResponse(machineOriginal, &machine)

--- a/pkg/controller/util/machine.go
+++ b/pkg/controller/util/machine.go
@@ -26,6 +26,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// LegacyMachineControllerUserDataLabel is set to true when machine-controller is used for managing machine configuration.
+const LegacyMachineControllerUserDataLabel = "machine.clusters.k8s.io/legacy-machine-controller-user-data"
+
 func GetMachineDeploymentNameAndRevisionForMachine(ctx context.Context, machine *clusterv1alpha1.Machine, c client.Client) (string, string, error) {
 	var (
 		machineSetName        string


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Add label on machine to differentiate between the tool used for managing machine configurations.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
