### PR TITLE
Implement ProviderID() for Anexia

### DIFF
--- a/pkg/cloudprovider/provider/anexia/instance.go
+++ b/pkg/cloudprovider/provider/anexia/instance.go
@@ -45,9 +45,8 @@ func (ai *anexiaInstance) ID() string {
 	return ai.info.Identifier
 }
 
-// TODO(xmudrii): Implement this.
 func (ai *anexiaInstance) ProviderID() string {
-	return ""
+	return ai.ID()
 }
 
 func (ai *anexiaInstance) Addresses() map[string]v1.NodeAddressType {


### PR DESCRIPTION
**What this PR does / why we need it**:

#1351 changed the mapping from Machine to Node, but left the `ProviderID()` method unimplemented for Anexia, this adds the implementation.

**Special notes for your reviewer**:

Our CCM currently does not set any prefix, which I guess could make problems when having a single cluster spanning multiple providers. At least they are fairly long and random, so chance for collision isn't too high .. still, if you need us to change that, I'll happily find a way for that.

Probably would make the most sense if @xmudrii takes a look at this, as I took that named TODO ^^'

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Implement ProviderID function for Anexia
```
