### PR TITLE
Fix IPv6 ExternalIP in machine object to align with hetzner ccm

### DIFF
--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -546,7 +546,12 @@ func (s *hetznerServer) Addresses() map[string]v1.NodeAddressType {
 		addresses[privateNetwork.IP.String()] = v1.NodeInternalIP
 	}
 	addresses[s.server.PublicNet.IPv4.IP.String()] = v1.NodeExternalIP
-	addresses[s.server.PublicNet.IPv6.IP.String()] = v1.NodeExternalIP
+	// For a given IPv6 network of 2001:db8:1234::/64, the instance address is 2001:db8:1234::1
+	// Reference: https://github.com/hetznercloud/hcloud-cloud-controller-manager/blob/v1.12.1/hcloud/instances.go#L165-167
+	if !s.server.PublicNet.IPv6.IP.IsUnspecified() {
+		s.server.PublicNet.IPv6.IP[len(s.server.PublicNet.IPv6.IP)-1] |= 0x01
+		addresses[s.server.PublicNet.IPv6.IP.String()] = v1.NodeExternalIP
+	}
 	return addresses
 }
 


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
In KKP, "kubectl logs" fail on dual-stack user cluster with Hetzner cloud provider with Konnectivity enabled (see #[10534](https://github.com/kubermatic/kubermatic/issues/10534)).
The External IPv6 address format in the machine object is not aligned properly according to the Hetzner node. Due to this
csr approval fails in machine-controller and in turn certificate validation fails when kubectl logs command is executed.
This PR fixes this by assigning the IPv6 address in proper format to align with Hetzner ccm.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Partially: #[10534](https://github.com/kubermatic/kubermatic/issues/10534)

**Special notes for your reviewer**:
This fixes only the Konnectivity enabled case of the issue. 
Konnectivity disabled case needs a fix in hcloud-cloud-controller-manager

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
