### PR TITLE
[release/v1.43] Update containerd to v1.5 for all Kubernetes versions

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Machine Controller Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Contains commonly used functions for the other scripts.
+
+# Required for signal propagation to work so
+# the cleanup trap gets executed when a script
+# receives a SIGINT
+set -o monitor
+
+containerize() {
+  local cmd="$1"
+  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.0.0}"
+  local gocache="${CONTAINERIZE_GOCACHE:-/tmp/.gocache}"
+  local gomodcache="${CONTAINERIZE_GOMODCACHE:-/tmp/.gomodcache}"
+  local skip="${NO_CONTAINERIZE:-}"
+
+  # short-circuit containerize when in some cases it needs to be avoided
+  [ -n "$skip" ] && return
+
+  if ! [ -f /.dockerenv ]; then
+    echodate "Running $cmd in a Docker container using $image..."
+    mkdir -p "$gocache"
+    mkdir -p "$gomodcache"
+
+    exec docker run \
+      -v "$PWD":/go/src/k8c.io/kubermatic \
+      -v "$gocache":"$gocache" \
+      -v "$gomodcache":"$gomodcache" \
+      -w /go/src/k8c.io/kubermatic \
+      -e "GOCACHE=$gocache" \
+      -e "GOMODCACHE=$gomodcache" \
+      -u "$(id -u):$(id -g)" \
+      --entrypoint="$cmd" \
+      --rm \
+      -it \
+      $image $@
+
+    exit $?
+  fi
+}
+
+echodate() {
+  # do not use -Is to keep this compatible with macOS
+  echo "[$(date +%Y-%m-%dT%H:%M:%S%:z)]" "$@"
+}

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -14,6 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -euo pipefail
+
+cd $(dirname $0)/..
+source hack/lib.sh
+
+CONTAINERIZE_IMAGE=golang:1.17.1 containerize ./hack/update-fixtures.sh
+
 go test ./... -v -update || go test ./...
 
 if [[ $? -eq 0 ]]; then echo "Successfully updated fixtures"; else "Failed to update fixtures"; fi

--- a/pkg/containerruntime/containerd.go
+++ b/pkg/containerruntime/containerd.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	DefaultContainerdVersion = "1.4"
+	LegacyContainerdVersion  = "1.4"
+	DefaultContainerdVersion = "1.5"
 )
 
 type Containerd struct {
@@ -59,6 +60,8 @@ func (eng *Containerd) ScriptFor(os types.OperatingSystem) (string, error) {
 
 	switch os {
 	case types.OperatingSystemAmazonLinux2:
+		// Amazon Linux 2 does not have containerd 1.5
+		args.ContainerdVersion = LegacyContainerdVersion
 		err := containerdAmzn2Template.Execute(&buf, args)
 		return buf.String(), err
 	case types.OperatingSystemCentOS, types.OperatingSystemRHEL:

--- a/pkg/containerruntime/docker.go
+++ b/pkg/containerruntime/docker.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	DefaultDockerVersion = "19.03"
-	LegacyDockerVersion  = "18.09"
+	DefaultDockerContainerdVersion = "1.4"
+	DefaultDockerVersion           = "19.03"
+	LegacyDockerVersion            = "18.09"
 )
 
 type Docker struct {
@@ -60,7 +61,7 @@ func (eng *Docker) ScriptFor(os types.OperatingSystem) (string, error) {
 		ContainerdVersion string
 	}{
 		DockerVersion:     DefaultDockerVersion,
-		ContainerdVersion: DefaultContainerdVersion,
+		ContainerdVersion: DefaultDockerContainerdVersion,
 	}
 
 	switch os {

--- a/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -100,7 +100,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    yum install -y containerd.io-1.4* yum-plugin-versionlock
+    yum install -y containerd.io-1.5* yum-plugin-versionlock
     yum versionlock add containerd.io
 
     systemctl daemon-reload

--- a/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -97,7 +97,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    yum install -y containerd.io-1.4* yum-plugin-versionlock
+    yum install -y containerd.io-1.5* yum-plugin-versionlock
     yum versionlock add containerd.io
 
     systemctl daemon-reload

--- a/pkg/userdata/ubuntu/testdata/containerd.yaml
+++ b/pkg/userdata/ubuntu/testdata/containerd.yaml
@@ -105,7 +105,7 @@ write_files:
     EnvironmentFile=-/etc/environment
     EOF
 
-    apt-get install -y --allow-downgrades containerd.io=1.4*
+    apt-get install -y --allow-downgrades containerd.io=1.5*
     apt-mark hold containerd.io
 
     systemctl daemon-reload


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates containerd to v1.5 for all Kubernetes versions because v1.4 has reached EOL.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
xref https://github.com/kubermatic/kubeone/issues/2215

**Optional Release Note**:
```release-note
Update containerd to v1.5 for all Kubernetes versions
```