### PR TITLE
Add `publicIPSKU` field to Azure provider

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,7 +58,7 @@ issues:
     - "cyclomatic complexity 31 of func `main` is high"
     - 'cyclomatic complexity 34 of func `\(\*provider\)\.getConfig` is high'
     - 'cyclomatic complexity 31 of func `\(\*provider\)\.Validate` is high'
-    - 'cyclomatic complexity 31 of func `\(\*provider\)\.Create` is high'
+    - 'cyclomatic complexity 32 of func `\(\*provider\)\.Create` is high'
     # SA1019: node.Spec.ConfigSource is deprecated: Previously used to specify the source of the node's configuration for the DynamicKubeletConfig feature.
     # This feature is removed from Kubelets as of 1.24 and will be fully removed in 1.26. +optional
     # We still support setting dynamic kubelet config feature in machine-controller. Hence, ignoring this error.

--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -50,6 +50,7 @@ type RawConfig struct {
 	DataDiskSize   int32                               `json:"dataDiskSize"`
 	DataDiskSKU    *string                             `json:"dataDiskSKU,omitempty"`
 	AssignPublicIP providerconfigtypes.ConfigVarBool   `json:"assignPublicIP"`
+	PublicIPSKU    *string                             `json:"publicIPSKU,omitempty"`
 	Tags           map[string]string                   `json:"tags,omitempty"`
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The public IP address SKU wasn't configurable before. This adds it, plus some validation around the field.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged)*:
Fixes #1395

**Special notes for your reviewer**:

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add new field `publicIPSKU` for Azure provider that configures the public IP address SKU (can be either `basic` or `standard`)
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
