### PR TITLE
Anexia: extend disk configuration

### DIFF
--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -32,6 +32,10 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAnexiaProvisioningE2E"
+          env:
+            # OperatingSystemManager does not yet support Anexia
+            - name: OPERATING_SYSTEM_MANAGER
+              value: "false"
           securityContext:
             privileged: true
           resources:

--- a/examples/anexia-machinedeployment.yaml
+++ b/examples/anexia-machinedeployment.yaml
@@ -36,7 +36,15 @@ spec:
             locationID: "<< ANEXIA_LOCATION_ID >>"
             cpus: 2
             memory: 2048
-            diskSize: 60
+
+            # only a single disk is currently supported, but support for multiple disks is planned already
+            disks:
+            - size: 60
+              performanceType: ENT6
+
+            # You may have this old disk config attribute in your config - please migrate to the disks attribute.
+            # For now it is still recognized though.
+            #diskSize: 60
           # Flatcar is the only supported operating system
           operatingSystem: "flatcar"
           operatingSystemSpec:

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
-	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/utils"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -58,13 +57,13 @@ func TestAnexiaProvider(t *testing.T) {
 		testhelper.Mux.HandleFunc("/api/vsphere/v1/search/by_name.json", createSearchHandler(t, waitUntilVMIsFound))
 
 		providerStatus := anxtypes.ProviderStatus{}
-		ctx := utils.CreateReconcileContext(context.Background(), utils.ReconcileContext{
+		ctx := createReconcileContext(context.Background(), reconcileContext{
 			Machine: &v1alpha1.Machine{
 				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
 			},
 			Status:   &providerStatus,
 			UserData: "",
-			Config:   &anxtypes.Config{},
+			Config:   resolvedConfig{},
 
 			ProviderData: &cloudprovidertypes.ProviderData{
 				Update: func(m *clusterv1alpha1.Machine, mod ...cloudprovidertypes.MachineModifier) error {
@@ -150,19 +149,21 @@ func TestAnexiaProvider(t *testing.T) {
 		})
 
 		providerStatus := anxtypes.ProviderStatus{}
-		ctx := utils.CreateReconcileContext(context.Background(), utils.ReconcileContext{
+		ctx := createReconcileContext(context.Background(), reconcileContext{
 			Machine: &v1alpha1.Machine{
 				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
 			},
 			Status:   &providerStatus,
 			UserData: "",
-			Config: &anxtypes.Config{
+			Config: resolvedConfig{
 				VlanID:     "VLAN-ID",
 				LocationID: "LOCATION-ID",
 				TemplateID: "TEMPLATE-ID",
-				CPUs:       5,
-				Memory:     5,
-				DiskSize:   5,
+				RawConfig: anxtypes.RawConfig{
+					CPUs:     5,
+					Memory:   5,
+					DiskSize: 5,
+				},
 			},
 			ProviderData: &cloudprovidertypes.ProviderData{
 				Update: func(m *clusterv1alpha1.Machine, mods ...cloudprovidertypes.MachineModifier) error {
@@ -186,10 +187,10 @@ func TestAnexiaProvider(t *testing.T) {
 				},
 			},
 		}
-		ctx := utils.CreateReconcileContext(context.Background(), utils.ReconcileContext{
+		ctx := createReconcileContext(context.Background(), reconcileContext{
 			Status:       &providerStatus,
 			UserData:     "",
-			Config:       nil,
+			Config:       resolvedConfig{},
 			ProviderData: nil,
 		})
 
@@ -214,7 +215,7 @@ func TestAnexiaProvider(t *testing.T) {
 			ReservedIP: "",
 			IPState:    "",
 		}
-		ctx := utils.CreateReconcileContext(context.Background(), utils.ReconcileContext{Status: providerStatus})
+		ctx := createReconcileContext(context.Background(), reconcileContext{Status: providerStatus})
 
 		t.Run("with unbound reserved IP", func(t *testing.T) {
 			expectedIP := "8.8.8.8"
@@ -230,42 +231,61 @@ func TestAnexiaProvider(t *testing.T) {
 func TestValidate(t *testing.T) {
 	t.Parallel()
 
+	// this generates a full config and allows hooking into it to e.g. remove a value
+	hookableConfig := func(hook func(*anxtypes.RawConfig)) anxtypes.RawConfig {
+		config := anxtypes.RawConfig{
+			CPUs: 1,
+
+			// let's assume those are gigabytes, the actual values don't actually matter
+			Memory:   2,
+			DiskSize: 20,
+
+			Token:      newConfigVarString("test-token"),
+			VlanID:     newConfigVarString("test-vlan"),
+			LocationID: newConfigVarString("test-location"),
+			TemplateID: newConfigVarString("test-template"),
+		}
+
+		if hook != nil {
+			hook(&config)
+		}
+
+		return config
+	}
+
 	var configCases []ConfigTestCase
 	configCases = append(configCases,
 		ConfigTestCase{
-			Config: anxtypes.RawConfig{},
+			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.Token.Value = "" }),
 			Error:  errors.New("token is missing"),
 		},
 		ConfigTestCase{
-			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN")},
+			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.CPUs = 0 }),
 			Error:  errors.New("cpu count is missing"),
 		},
 		ConfigTestCase{
-			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1},
+			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.DiskSize = 0 }),
 			Error:  errors.New("disk size is missing"),
 		},
 		ConfigTestCase{
-			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5},
+			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.Memory = 0 }),
 			Error:  errors.New("memory size is missing"),
 		},
 		ConfigTestCase{
-			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5},
+			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.LocationID.Value = "" }),
 			Error:  errors.New("location id is missing"),
 		},
 		ConfigTestCase{
-			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5,
-				LocationID: newConfigVarString("TLID")},
-			Error: errors.New("template id is missing"),
+			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.TemplateID.Value = "" }),
+			Error:  errors.New("template id is missing"),
 		},
 		ConfigTestCase{
-			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5,
-				LocationID: newConfigVarString("LID"), TemplateID: newConfigVarString("TID")},
-			Error: errors.New("vlan id is missing"),
+			Config: hookableConfig(func(c *anxtypes.RawConfig) { c.VlanID.Value = "" }),
+			Error:  errors.New("vlan id is missing"),
 		},
 		ConfigTestCase{
-			Config: anxtypes.RawConfig{Token: newConfigVarString("TEST-TOKEN"), CPUs: 1, DiskSize: 5, Memory: 5,
-				LocationID: newConfigVarString("LID"), TemplateID: newConfigVarString("TID"), VlanID: newConfigVarString("VLAN")},
-			Error: nil,
+			Config: hookableConfig(nil),
+			Error:  nil,
 		},
 	)
 

--- a/pkg/cloudprovider/provider/anexia/reconcile_context.go
+++ b/pkg/cloudprovider/provider/anexia/reconcile_context.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package anexia
 
 import (
 	"context"
@@ -26,24 +26,25 @@ import (
 
 type contextKey byte
 
-const MachineReconcileContextKey contextKey = 0
+const machineReconcileContextKey contextKey = 0
 
-type ReconcileContext struct {
+type reconcileContext struct {
 	Machine      *v1alpha1.Machine
 	Status       *anxtypes.ProviderStatus
 	UserData     string
-	Config       *anxtypes.Config
+	Config       resolvedConfig
 	ProviderData *cloudprovidertypes.ProviderData
 }
 
-func CreateReconcileContext(ctx context.Context, cc ReconcileContext) context.Context {
-	return context.WithValue(ctx, MachineReconcileContextKey, cc)
+func createReconcileContext(ctx context.Context, cc reconcileContext) context.Context {
+	return context.WithValue(ctx, machineReconcileContextKey, cc)
 }
 
-func GetReconcileContext(ctx context.Context) ReconcileContext {
-	rawContext := ctx.Value(MachineReconcileContextKey)
-	if recContext, ok := rawContext.(ReconcileContext); ok {
+func getReconcileContext(ctx context.Context) reconcileContext {
+	rawContext := ctx.Value(machineReconcileContextKey)
+	if recContext, ok := rawContext.(reconcileContext); ok {
 		return recContext
 	}
-	return ReconcileContext{}
+
+	return reconcileContext{}
 }

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -46,6 +46,12 @@ var StatusUpdateFailed = cloudprovidererrors.TerminalError{
 	Message: "Unable to update the machine status",
 }
 
+// RawDisk specifies a single disk, with some values maybe being fetched from secrets.
+type RawDisk struct {
+	Size            int                                 `json:"size"`
+	PerformanceType providerconfigtypes.ConfigVarString `json:"performanceType"`
+}
+
 // RawConfig contains all the configuration values for VMs to create, with some values maybe being fetched from secrets.
 type RawConfig struct {
 	Token      providerconfigtypes.ConfigVarString `json:"token,omitempty"`
@@ -53,9 +59,13 @@ type RawConfig struct {
 	LocationID providerconfigtypes.ConfigVarString `json:"locationID"`
 	TemplateID providerconfigtypes.ConfigVarString `json:"templateID"`
 
-	CPUs     int `json:"cpus"`
-	Memory   int `json:"memory"`
+	CPUs   int `json:"cpus"`
+	Memory int `json:"memory"`
+
+	// Deprecated, use Disks instead.
 	DiskSize int `json:"diskSize"`
+
+	Disks []RawDisk `json:"disks"`
 }
 
 type ProviderStatus struct {

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -46,14 +46,16 @@ var StatusUpdateFailed = cloudprovidererrors.TerminalError{
 	Message: "Unable to update the machine status",
 }
 
+// RawConfig contains all the configuration values for VMs to create, with some values maybe being fetched from secrets.
 type RawConfig struct {
 	Token      providerconfigtypes.ConfigVarString `json:"token,omitempty"`
 	VlanID     providerconfigtypes.ConfigVarString `json:"vlanID"`
 	LocationID providerconfigtypes.ConfigVarString `json:"locationID"`
 	TemplateID providerconfigtypes.ConfigVarString `json:"templateID"`
-	CPUs       int                                 `json:"cpus"`
-	Memory     int                                 `json:"memory"`
-	DiskSize   int                                 `json:"diskSize"`
+
+	CPUs     int `json:"cpus"`
+	Memory   int `json:"memory"`
+	DiskSize int `json:"diskSize"`
 }
 
 type ProviderStatus struct {
@@ -63,16 +65,6 @@ type ProviderStatus struct {
 	ReservedIP       string         `json:"reservedIP"`
 	IPState          string         `json:"ipState"`
 	Conditions       []v1.Condition `json:"conditions,omitempty"`
-}
-
-type Config struct {
-	Token      string
-	VlanID     string
-	LocationID string
-	TemplateID string
-	CPUs       int
-	Memory     int
-	DiskSize   int
 }
 
 func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This extends the configuration for disks in provider Anexia. The important bit is the now-configurable disk performance type, but the config was revamped a bit to allow configuring multiple disks in the future.

As a side-effect, this PR also fixes CI for Anexia by disabling OperatingSystemManager for now as it is not yet supported.

**Special notes for your reviewer**:

In the first commit I did some cleanup of the config structs. This inflates the PR diff a bit, but it's separate commits at least.

The API changes are currently backwards compatible, so no "action required" needed for now.

**Optional Release Note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow configuring the disk performance type for provider Anexia
```
