### PR TITLE
Anexia: return reserved IP when instance IPs are requested

### DIFF
--- a/pkg/cloudprovider/provider/anexia/instance.go
+++ b/pkg/cloudprovider/provider/anexia/instance.go
@@ -17,6 +17,8 @@ limitations under the License.
 package anexia
 
 import (
+	"net"
+
 	"go.anx.io/go-anxcloud/pkg/vsphere/info"
 
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
@@ -26,7 +28,8 @@ import (
 )
 
 type anexiaInstance struct {
-	info *info.Info
+	info              *info.Info
+	reservedAddresses []string
 }
 
 func (ai *anexiaInstance) Name() string {
@@ -52,19 +55,30 @@ func (ai *anexiaInstance) ProviderID() string {
 func (ai *anexiaInstance) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 
-	if ai.info == nil {
-		return addresses
+	if ai.reservedAddresses != nil {
+		for _, reservedIP := range ai.reservedAddresses {
+			addresses[reservedIP] = v1.NodeExternalIP
+		}
 	}
 
-	for _, network := range ai.info.Network {
-		for _, ip := range network.IPv4 {
-			addresses[ip] = v1.NodeExternalIP
+	if ai.info != nil {
+		for _, network := range ai.info.Network {
+			for _, ip := range network.IPv4 {
+				addresses[ip] = v1.NodeExternalIP
+			}
+			for _, ip := range network.IPv6 {
+				addresses[ip] = v1.NodeExternalIP
+			}
 		}
-		for _, ip := range network.IPv6 {
-			addresses[ip] = v1.NodeExternalIP
-		}
+	}
 
-		// TODO mark RFC1918 and RFC4193 addresses as internal
+	for ip := range addresses {
+		parsed := net.ParseIP(ip)
+		if parsed.IsPrivate() {
+			addresses[ip] = v1.NodeInternalIP
+		} else {
+			addresses[ip] = v1.NodeExternalIP
+		}
 	}
 
 	return addresses

--- a/pkg/cloudprovider/provider/anexia/instance_test.go
+++ b/pkg/cloudprovider/provider/anexia/instance_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anexia
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/testhelper"
+
+	"go.anx.io/go-anxcloud/pkg/vsphere/info"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestAnexiaInstance(t *testing.T) {
+	addressCheck := func(t *testing.T, testcase string, instance *anexiaInstance, expected map[string]v1.NodeAddressType) {
+		t.Run(testcase, func(t *testing.T) {
+			addresses := instance.Addresses()
+
+			testhelper.AssertDeepEquals(t, expected, addresses)
+		})
+	}
+
+	t.Run("empty instance", func(t *testing.T) {
+		instance := anexiaInstance{}
+		addressCheck(t, "no addresses", &instance, map[string]v1.NodeAddressType{})
+	})
+
+	t.Run("instance with only reservedAddresses set", func(t *testing.T) {
+		instance := anexiaInstance{
+			reservedAddresses: []string{"10.0.0.2", "fda0:23::2", "8.8.8.8", "2001:db8::2"},
+		}
+
+		addressCheck(t, "expected addresses", &instance, map[string]v1.NodeAddressType{
+			"10.0.0.2":    v1.NodeInternalIP,
+			"fda0:23::2":  v1.NodeInternalIP,
+			"8.8.8.8":     v1.NodeExternalIP,
+			"2001:db8::2": v1.NodeExternalIP,
+		})
+	})
+
+	t.Run("instance with only info set", func(t *testing.T) {
+		instance := anexiaInstance{
+			info: &info.Info{
+				Network: []info.Network{
+					{
+						IPv4: []string{"10.0.0.2"},
+						IPv6: []string{"fda0:23::2"},
+					},
+					{
+						IPv4: []string{"8.8.8.8"},
+						IPv6: []string{"2001:db8::2"},
+					},
+				},
+			},
+		}
+
+		addressCheck(t, "expected addresses", &instance, map[string]v1.NodeAddressType{
+			"10.0.0.2":    v1.NodeInternalIP,
+			"fda0:23::2":  v1.NodeInternalIP,
+			"8.8.8.8":     v1.NodeExternalIP,
+			"2001:db8::2": v1.NodeExternalIP,
+		})
+	})
+
+	t.Run("instance with both reservedAddresses and info set, full overlapping set", func(t *testing.T) {
+		instance := anexiaInstance{
+			reservedAddresses: []string{"10.0.0.2", "fda0:23::2", "8.8.8.8", "2001:db8::2"},
+			info: &info.Info{
+				Network: []info.Network{
+					{
+						IPv4: []string{"10.0.0.2"},
+						IPv6: []string{"fda0:23::2"},
+					},
+					{
+						IPv4: []string{"8.8.8.8"},
+						IPv6: []string{"2001:db8::2"},
+					},
+				},
+			},
+		}
+
+		addressCheck(t, "expected addresses", &instance, map[string]v1.NodeAddressType{
+			"10.0.0.2":    v1.NodeInternalIP,
+			"fda0:23::2":  v1.NodeInternalIP,
+			"8.8.8.8":     v1.NodeExternalIP,
+			"2001:db8::2": v1.NodeExternalIP,
+		})
+	})
+
+	t.Run("instance with both reservedAddresses and info set, some overlap, each adding some", func(t *testing.T) {
+		instance := anexiaInstance{
+			reservedAddresses: []string{"10.0.0.2", "8.8.8.8", "2001:db8::2"},
+			info: &info.Info{
+				Network: []info.Network{
+					{
+						IPv4: []string{"10.0.0.2"},
+						IPv6: []string{"fda0:23::2"},
+					},
+					{
+						IPv6: []string{"2001:db8::2"},
+					},
+				},
+			},
+		}
+
+		addressCheck(t, "expected addresses", &instance, map[string]v1.NodeAddressType{
+			"10.0.0.2":    v1.NodeInternalIP,
+			"fda0:23::2":  v1.NodeInternalIP,
+			"8.8.8.8":     v1.NodeExternalIP,
+			"2001:db8::2": v1.NodeExternalIP,
+		})
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When creating a machine at, we always first reserve an IP address for it. Later when retrieving the addresses of that machine, we rely on the vminfo API, which has some delay as it retrieves the IPs from the running VM.

This commit adds the reserved address to the list of addresses returned from an instance, which should reduce provisioning time a bit and make it more stable.

Also fixes a long-standing TODO comment: marking internal IPs as internal.

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

[As per this comment](https://github.com/kubermatic/machine-controller/pull/1405#issuecomment-1216429137)

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
