### PR TITLE
[release/v1.43] Cherry-pick recent RHEL changes

### DIFF
--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -229,6 +229,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     {{ if eq .CloudProviderName "vsphere" }}
     systemctl enable --now vmtoolsd.service
     {{ end -}}

--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -235,6 +235,7 @@ write_files:
     {{ end -}}
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -316,5 +317,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/amzn2/testdata/containerd-kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/containerd-kubelet-v1.20-aws.yaml
@@ -171,6 +171,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/containerd-kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/containerd-kubelet-v1.20-aws.yaml
@@ -174,6 +174,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -436,4 +437,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.20-aws.yaml
@@ -168,6 +168,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.20-aws.yaml
@@ -171,6 +171,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -416,4 +417,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
@@ -168,6 +168,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws-external.yaml
@@ -171,6 +171,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -416,4 +417,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
@@ -168,6 +168,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-aws.yaml
@@ -171,6 +171,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -416,4 +417,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -186,6 +186,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -181,6 +181,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -186,6 +186,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -181,6 +181,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
@@ -173,6 +173,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.21-vsphere.yaml
@@ -178,6 +178,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -424,4 +425,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
@@ -168,6 +168,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.22-aws.yaml
@@ -171,6 +171,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -416,4 +417,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
@@ -171,6 +171,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -414,4 +415,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
@@ -168,6 +168,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -243,6 +243,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     {{ if eq .CloudProviderName "vsphere" }}
     systemctl enable --now vmtoolsd.service
     {{ end -}}

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -249,6 +249,7 @@ write_files:
     {{ end -}}
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -330,5 +331,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -179,6 +179,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -441,4 +442,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -176,6 +176,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.20-aws.yaml
@@ -177,6 +177,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.20-aws.yaml
@@ -180,6 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -425,4 +426,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
@@ -177,6 +177,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws-external.yaml
@@ -180,6 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -425,4 +426,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
@@ -177,6 +177,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-aws.yaml
@@ -180,6 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -425,4 +426,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-nutanix.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-nutanix.yaml
@@ -187,6 +187,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-nutanix.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-nutanix.yaml
@@ -184,6 +184,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -190,6 +190,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-mirrors.yaml
@@ -195,6 +195,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -442,4 +443,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -190,6 +190,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere-proxy.yaml
@@ -195,6 +195,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -442,4 +443,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
@@ -182,6 +182,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.21-vsphere.yaml
@@ -187,6 +187,7 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
@@ -177,6 +177,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.22-aws.yaml
@@ -180,6 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -425,4 +426,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
@@ -177,6 +177,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
@@ -180,6 +180,7 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -423,4 +424,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -240,14 +240,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
-    {{ if eq .CloudProviderName "azure" }}
-    firewall-cmd --permanent --zone=trusted --add-source={{ .PodCIDR }}
-    firewall-cmd --permanent --add-port=8472/udp
-    firewall-cmd --permanent --add-port={{ .NodePortRange }}/tcp
-    firewall-cmd --permanent --add-port={{ .NodePortRange }}/udp
-    firewall-cmd --reload
-    systemctl restart firewalld
-    {{ end -}}
+    systemctl disable --now firewalld || true
     {{ if eq .CloudProviderName "vsphere" }}
     systemctl enable --now vmtoolsd.service
     {{ end -}}

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -247,6 +247,8 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -368,6 +370,6 @@ rh_subscription:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service
 `

--- a/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -172,6 +172,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-containerd-v1.20-aws.yaml
@@ -175,6 +175,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -470,5 +472,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
@@ -173,6 +173,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.20-aws.yaml
@@ -176,6 +176,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -454,5 +456,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -173,6 +173,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.21-aws.yaml
@@ -176,6 +176,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -454,5 +456,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -173,6 +173,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-aws.yaml
@@ -176,6 +176,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -454,5 +456,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
@@ -184,6 +184,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -463,5 +465,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.22-nutanix.yaml
@@ -181,6 +181,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -173,6 +173,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
 

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -176,6 +176,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -452,5 +454,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
@@ -176,6 +176,8 @@ write_files:
     systemctl disable --now firewalld || true
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -452,5 +454,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -192,6 +192,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -470,5 +472,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -187,6 +187,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -192,6 +192,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -470,5 +472,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -187,6 +187,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -179,6 +179,7 @@ write_files:
     mkdir -p /etc/systemd/system/kubelet.service.d/
     /opt/bin/setup_net_env.sh
 
+    systemctl disable --now firewalld || true
 
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -184,6 +184,8 @@ write_files:
     systemctl enable --now vmtoolsd.service
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
+    systemctl disable disable-nm-cloud-setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -461,5 +463,5 @@ rh_subscription:
     auto-attach: false
 
 runcmd:
-- systemctl start setup.service
-- systemctl start disable-nm-cloud-setup.service
+- systemctl enable --now setup.service
+- systemctl enable --now disable-nm-cloud-setup.service

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -2,6 +2,9 @@
 bootcmd:
 - modprobe ip_tables
 
+hostname: node1
+fqdn: node1
+
 
 ssh_pwauth: false
 
@@ -40,6 +43,7 @@ write_files:
     net.ipv4.ip_forward = 1
     vm.overcommit_memory = 1
     fs.inotify.max_user_watches = 1048576
+    fs.inotify.max_user_instances = 8192
 
 
 - path: /etc/selinux/config
@@ -68,6 +72,10 @@ write_files:
     sed -i.orig '/.*swap.*/d' /etc/fstab
     swapoff -a
 
+    hostnamectl set-hostname node1
+
+
+    yum update -y --disablerepo='*' --enablerepo='*microsoft*'
 
     yum install -y \
       device-mapper-persistent-data \
@@ -145,7 +153,7 @@ write_files:
     rm -f "$cri_tools_filename"
     ln -sf "$opt_bin/crictl" "$usr_local_bin"/crictl || echo "symbolic link is skipped"
     cd -
-    KUBE_VERSION="${KUBE_VERSION:-v1.23.0}"
+    KUBE_VERSION="${KUBE_VERSION:-v1.22.2}"
     kube_dir="$opt_bin/kubernetes-$KUBE_VERSION"
     kube_base_url="https://storage.googleapis.com/kubernetes-release/release/$KUBE_VERSION/bin/linux/$arch"
     kube_sum_file="$kube_dir/sha256"
@@ -213,12 +221,15 @@ write_files:
       --config=/etc/kubernetes/kubelet.conf \
       --network-plugin=cni \
       --cert-dir=/etc/kubernetes/pki \
-      --cloud-provider=aws \
+      --cloud-provider=azure \
       --cloud-config=/etc/kubernetes/cloud-config \
+      --hostname-override=node1 \
       --exit-on-lock-contention \
       --lock-file=/tmp/kubelet.lock \
       --container-runtime=docker \
       --container-runtime-endpoint=unix:///var/run/dockershim.sock \
+      --dynamic-config-dir=/etc/kubernetes/dynamic-config-dir \
+      --feature-gates=DynamicKubeletConfig=true \
       --node-ip ${KUBELET_NODE_IP}
 
     [Install]
@@ -227,7 +238,7 @@ write_files:
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |
-    {aws-config:true}
+    {config:true}
 
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -199,6 +199,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -296,5 +297,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -138,6 +138,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -408,4 +409,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -406,4 +407,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -408,4 +409,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -138,6 +138,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -408,4 +409,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -410,4 +411,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -410,4 +411,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/version-1.20.14.yaml
+++ b/pkg/userdata/sles/testdata/version-1.20.14.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -406,4 +407,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/version-1.21.8.yaml
+++ b/pkg/userdata/sles/testdata/version-1.21.8.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -406,4 +407,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/version-1.22.5.yaml
+++ b/pkg/userdata/sles/testdata/version-1.22.5.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -406,4 +407,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/version-1.23.0.yaml
+++ b/pkg/userdata/sles/testdata/version-1.23.0.yaml
@@ -136,6 +136,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -404,4 +405,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -146,6 +146,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -421,4 +422,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -146,6 +146,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -421,4 +422,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -137,6 +137,7 @@ write_files:
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
     systemctl enable --now --no-block docker-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -411,4 +412,4 @@ write_files:
     EnvironmentFile=-/etc/environment
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -243,6 +243,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -329,5 +330,5 @@ write_files:
 {{- end }}
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service
 `

--- a/pkg/userdata/ubuntu/testdata/containerd.yaml
+++ b/pkg/userdata/ubuntu/testdata/containerd.yaml
@@ -182,6 +182,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -460,4 +461,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -182,6 +182,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -431,4 +432,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -182,6 +182,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -433,4 +434,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/nutanix.yaml
+++ b/pkg/userdata/ubuntu/testdata/nutanix.yaml
@@ -183,6 +183,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -438,4 +439,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -435,4 +436,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -435,4 +436,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.20.14.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.20.14.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -431,4 +432,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.21.8.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.21.8.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -431,4 +432,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.22.5.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.22.5.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -431,4 +432,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/version-1.23.0.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.23.0.yaml
@@ -180,6 +180,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -429,4 +430,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -190,6 +190,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -446,4 +447,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -190,6 +190,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -446,4 +447,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -181,6 +181,7 @@ write_files:
 
     systemctl enable --now kubelet
     systemctl enable --now --no-block kubelet-healthcheck.service
+    systemctl disable setup.service
 
 - path: "/opt/bin/supervise.sh"
   permissions: "0755"
@@ -436,4 +437,4 @@ write_files:
 
 
 runcmd:
-- systemctl start setup.service
+- systemctl enable --now setup.service

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -27,8 +27,8 @@ spec:
             templateVMName: '<< OS_NAME >>-template'
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
-            datacenter: 'Customer-A'
-            folder: '/Customer-A/vm/e2e-tests'
+            datacenter: 'dc-1'
+            folder: '/dc-1/vm/e2e-tests'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
             cluster: '<< VSPHERE_CLUSTER >>'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a manual cherry-pick of #1226 and #1316 to make upgrading Canal in KubeOne clusters possible. I assume that Canal doesn't work well along with `firewalld` and disabling it seems to fix an issue with the network connectivity being broken after upgrading Canal from v3.22 to v3.23.

**Which issue(s) this PR fixes**:
xref https://github.com/kubermatic/kubeone/issues/2325

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Disable firewalld on supported OSes
- Fix a bug where cloud-init "package_reboot_if_required" fails and prevents the setup of the node
```

**Documentation**:
```documentation
NONE
```

/hold
To be manually tested once again.