### PR TITLE
Implement Vultr cloud provider

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -23,6 +23,7 @@ allowlist:
   - BSD-2-Clause-FreeBSD
   - BSD-3-Clause
   - ISC
+  - MPL-2.0
 
 exceptions:
   - github.com/hashicorp/golang-lru # MPL-2.0

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ REGISTRY_NAMESPACE ?= kubermatic
 
 LDFLAGS ?= -ldflags '-s -w'
 
-IMAGE_TAG = \
+IMAGE_TAG ?= \
 		$(shell echo $$(git rev-parse HEAD && if [[ -n $$(git status --porcelain) ]]; then echo '-dirty'; fi)|tr -d ' ')
 IMAGE_NAME ?= $(REGISTRY)/$(REGISTRY_NAMESPACE)/machine-controller:$(IMAGE_TAG)
 

--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -321,3 +321,34 @@ memory: "2048M"
 ## vSphere
 
 Refer to the [VSphere](./vsphere.md#provider-configuration) specific documentation.
+
+## Vultr
+
+### machine.spec.providerConfig.cloudProviderSpec
+
+```yaml
+token:
+  secretKeyRef:
+    namespace: kube-system
+    name: machine-controller-vultr
+    key: token
+
+# required
+# possible values: bare-metal, cloud-instance
+machineType: "cloud-instance"
+
+# required
+# https://api.vultr.com/v2/regions
+region: "ams"
+
+# required
+# https://api.vultr.com/v2/regions/{region-id}/availability for cloud-instance
+# https://www.vultr.com/api/#operation/list-metal-plans for bare-metal
+plan: "vbm-4c-32gb"
+
+# optional
+tags:
+  - your
+  - tags
+  - here
+```

--- a/examples/vultr-machinedeployment.yaml
+++ b/examples/vultr-machinedeployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  # If you change the namespace/name, you must also
+  # adjust the rbac rules
+  name: machine-controller-vultr
+  namespace: kube-system
+type: Opaque
+stringData:
+  token: << VULTR_TOKEN >>
+---
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: vultr-machinedeployment
+  namespace: kube-system
+spec:
+  paused: false
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  minReadySeconds: 0
+  selector:
+    matchLabels:
+      foo: bar
+  template:
+    metadata:
+      labels:
+        foo: bar
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProvider: "vultr"
+          cloudProviderSpec:
+            token:
+              secretKeyRef:
+                namespace: kube-system
+                name: machine-controller-vultr
+                key: token
+
+            machineType: "cloud-instance"
+            region: "ams"
+            plan: "vbm-4c-32gb"
+            tags:
+              - your
+              - tags
+              - here
+
+          operatingSystem: "ubuntu"
+          operatingSystemSpec:
+            distUpgradeOnBoot: true
+      versions:
+        kubelet: 1.22.5

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/tinkerbell/tink v0.0.0-20210315140655-1b178daeaeda
 	github.com/vmware/go-vcloud-director/v2 v2.15.0
 	github.com/vmware/govmomi v0.28.0
+	github.com/vultr/govultr/v2 v2.17.2
 	go.anx.io/go-anxcloud v0.4.4
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb
@@ -112,6 +113,8 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -538,9 +538,15 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
+github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -941,6 +947,8 @@ github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPi
 github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/vmware/govmomi v0.28.0 h1:VgeQ/Rvz79U9G8QIKLdgpsN9AndHJL+5iMJLgYIrBGI=
 github.com/vmware/govmomi v0.28.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
+github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
+github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/scaleway"
 	vcd "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vmwareclouddirector"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vultr"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -107,6 +108,9 @@ var (
 		},
 		providerconfigtypes.CloudProviderVMwareCloudDirector: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
 			return vcd.New(cvr)
+		},
+		providerconfigtypes.CloudProviderVultr: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
+			return vultr.New(cvr)
 		},
 	}
 )

--- a/pkg/cloudprovider/provider/vultr/provider.go
+++ b/pkg/cloudprovider/provider/vultr/provider.go
@@ -21,7 +21,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"strings"
+	"time"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -35,6 +37,7 @@ import (
 	"golang.org/x/oauth2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 )
 
 type provider struct {
@@ -298,6 +301,32 @@ func (p *provider) Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine
 				Message: err.Error(),
 			}
 		}
+
+		// After Delete(), Vultr API doesn't list the instance anymore, but the instance is still online for a while,
+		// causing the control-plane to reconnect with the instance, leaving the node on NotReady state
+		// This guarantees that the Node is gone
+		nodeIsOnline := true
+		var ipAddress string
+
+		switch vultrInstance := instance.(type) {
+		case *vultrBareMetalInstance:
+			ipAddress = vultrInstance.instance.MainIP
+		}
+
+		if ipAddress == "" {
+			return false, nil
+		}
+
+		for nodeIsOnline {
+			_, err := net.DialTimeout("tcp", fmt.Sprint(ipAddress, ":22"), 5*time.Second)
+			if err != nil {
+				nodeIsOnline = false
+			}
+			klog.Infof("trying to delete node %s, still responding on port 22", instance.Name())
+			time.Sleep(2 * time.Second)
+		}
+
+		klog.Infof("deleting %s, node stopped responding on port 22", instance.Name())
 
 		return false, nil
 	} else if c.MachineType == string(vultrtypes.CloudInstance) {

--- a/pkg/cloudprovider/provider/vultr/provider.go
+++ b/pkg/cloudprovider/provider/vultr/provider.go
@@ -1,0 +1,520 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vultr
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/instance"
+	vultrtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vultr/types"
+	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig"
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"github.com/vultr/govultr/v2"
+	"golang.org/x/oauth2"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type provider struct {
+	configVarResolver *providerconfig.ConfigVarResolver
+}
+
+func New(configVarResolver *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
+	return &provider{configVarResolver: configVarResolver}
+}
+
+type Config struct {
+	Token       string
+	MachineType string
+	Region      string
+	Plan        string
+	Tags        []string
+}
+
+func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *providerconfigtypes.Config, error) {
+	if provSpec.Value == nil {
+		return nil, nil, fmt.Errorf("machine.spec.providerconfig.value is nil")
+	}
+
+	pconfig, err := providerconfigtypes.GetConfig(provSpec)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if pconfig.OperatingSystemSpec.Raw == nil {
+		return nil, nil, errors.New("operatingSystemSpec in the MachineDeployment cannot be empty")
+	}
+
+	rawConfig, err := vultrtypes.GetConfig(*pconfig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c := Config{}
+
+	c.Token, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.Token, "VULTR_TOKEN")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get the value of \"token\" field, error = %w", err)
+	}
+
+	c.MachineType, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.MachineType)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c.Region, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Region)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c.Plan, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.Plan)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, tag := range rawConfig.Tags {
+		tagVal, err := p.configVarResolver.GetConfigVarStringValue(tag)
+		if err != nil {
+			return nil, nil, err
+		}
+		c.Tags = append(c.Tags, tagVal)
+	}
+
+	return &c, pconfig, err
+}
+
+func getClient(token string) *govultr.Client {
+	config := &oauth2.Config{}
+	ctx := context.Background()
+	ts := config.TokenSource(ctx, &oauth2.Token{AccessToken: token})
+
+	return govultr.NewClient(oauth2.NewClient(ctx, ts))
+}
+
+// getOdIs, vultr works with OS IDs (instead of names)
+// The IDs hardcoded here come from https://api.vultr.com/v2/os
+func getOsId(os providerconfigtypes.OperatingSystem) (int, error) {
+	switch os {
+	case providerconfigtypes.OperatingSystemUbuntu:
+		return 387, nil
+	}
+
+	return 0, providerconfigtypes.ErrOSNotSupported
+}
+
+func (p *provider) Validate(ctx context.Context, spec clusterv1alpha1.MachineSpec) error {
+	c, pc, err := p.getConfig(spec.ProviderSpec)
+	if err != nil {
+		return fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	if c.Token == "" {
+		return errors.New("token is missing")
+	}
+
+	if c.MachineType != string(vultrtypes.BareMetal) && c.MachineType != string(vultrtypes.CloudInstance) {
+		return fmt.Errorf("invalid machineType %q, valid values are %q, %q", c.MachineType, vultrtypes.BareMetal, vultrtypes.CloudInstance)
+	}
+
+	osId, err := getOsId(pc.OperatingSystem)
+	if err != nil {
+		return fmt.Errorf("invalid/not supported operating system specified %q: %w", pc.OperatingSystem, err)
+	}
+
+	client := getClient(c.Token)
+
+	var foundRegion bool
+	regions, _, err := client.Region.List(ctx, nil)
+	if err != nil {
+		return err
+	}
+	for _, r := range regions {
+		if r.ID == c.Region {
+			foundRegion = true
+			break
+		}
+	}
+	if !foundRegion {
+		return fmt.Errorf("region %q not found", c.Region)
+	}
+
+	var foundAvailablePlan bool
+	if c.MachineType == string(vultrtypes.CloudInstance) {
+		planAvailability, err := client.Region.Availability(ctx, c.Region, "all")
+		if err != nil {
+			return err
+		}
+		for _, p := range planAvailability.AvailablePlans {
+			if p == c.Plan {
+				foundAvailablePlan = true
+				break
+			}
+		}
+		if !foundAvailablePlan {
+			return fmt.Errorf("plan %q not available on region %q", c.Plan, c.Region)
+		}
+	} else if c.MachineType == string(vultrtypes.BareMetal) {
+		planAvailability, _, err := client.Plan.ListBareMetal(ctx, nil)
+		if err != nil {
+			return err
+		}
+
+		var foundPlanRegion bool
+		for _, p := range planAvailability {
+			if p.ID == c.Plan {
+				for _, r := range p.Locations {
+					if r == c.Region {
+						foundPlanRegion = true
+					}
+				}
+			}
+		}
+		if !foundPlanRegion {
+			return fmt.Errorf("plan %q not available on region %q", c.Plan, c.Region)
+		}
+	}
+
+	var foundOperatingSystem bool
+	oss, _, err := client.OS.List(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	for _, os := range oss {
+		if os.ID == osId {
+			foundOperatingSystem = true
+			break
+		}
+	}
+	if !foundOperatingSystem {
+		return fmt.Errorf("operating system with ID %q not found", osId)
+	}
+
+	return nil
+}
+
+func (p *provider) Create(ctx context.Context, machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData, userData string) (instance.Instance, error) {
+	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
+	if err != nil {
+		return nil, cloudprovidererrors.TerminalError{
+			Reason:  common.InvalidConfigurationMachineError,
+			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
+		}
+	}
+
+	client := getClient(c.Token)
+
+	osId, _ := getOsId(pc.OperatingSystem)
+
+	c.Tags = append(c.Tags, fmt.Sprintf("machineUid=%s", machine.UID))
+
+	if c.MachineType == string(vultrtypes.BareMetal) {
+		instanceOpts := govultr.BareMetalCreate{
+			Label:    machine.Spec.Name,
+			Region:   c.Region,
+			Plan:     c.Plan,
+			OsID:     osId,
+			Tags:     c.Tags,
+			UserData: base64.StdEncoding.EncodeToString([]byte(userData)),
+		}
+
+		instance, err := client.BareMetalServer.Create(ctx, &instanceOpts)
+		if err != nil {
+			return nil, fmt.Errorf("could not create bare-metal instance: %q", err)
+		}
+
+		return &vultrBareMetalInstance{instance: instance}, nil
+	} else if c.MachineType == string(vultrtypes.CloudInstance) {
+		instanceOpts := govultr.InstanceCreateReq{
+			Label:    machine.Spec.Name,
+			Region:   c.Region,
+			Plan:     c.Plan,
+			OsID:     osId,
+			Tags:     c.Tags,
+			UserData: base64.StdEncoding.EncodeToString([]byte(userData)),
+		}
+
+		instance, err := client.Instance.Create(ctx, &instanceOpts)
+		if err != nil {
+			return nil, fmt.Errorf("could not create cloud-instance instance: %q", err)
+		}
+
+		return &vultrCloudInstance{instance: instance}, nil
+	}
+
+	return nil, fmt.Errorf("could not create instance: %q", err)
+}
+
+func (p *provider) AddDefaults(spec clusterv1alpha1.MachineSpec) (clusterv1alpha1.MachineSpec, error) {
+	return spec, nil
+}
+
+func (p *provider) Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
+	instance, err := p.Get(ctx, machine, data)
+	if err != nil {
+		if errors.Is(err, cloudprovidererrors.ErrInstanceNotFound) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	if err != nil {
+		return false, cloudprovidererrors.TerminalError{
+			Reason:  common.InvalidConfigurationMachineError,
+			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
+		}
+	}
+
+	client := getClient(c.Token)
+
+	if c.MachineType == string(vultrtypes.BareMetal) {
+		err := client.BareMetalServer.Delete(ctx, instance.ID())
+		if err != nil {
+			return false, cloudprovidererrors.TerminalError{
+				Reason:  common.InvalidConfigurationMachineError,
+				Message: err.Error(),
+			}
+		}
+
+		return false, nil
+
+	} else if c.MachineType == string(vultrtypes.CloudInstance) {
+		err := client.Instance.Delete(ctx, instance.ID())
+		if err != nil {
+			return false, cloudprovidererrors.TerminalError{
+				Reason:  common.InvalidConfigurationMachineError,
+				Message: err.Error(),
+			}
+		}
+
+		return false, nil
+	}
+
+	return false, nil
+}
+
+func (p *provider) Get(ctx context.Context, machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	if err != nil {
+		return nil, cloudprovidererrors.TerminalError{
+			Reason:  common.InvalidConfigurationMachineError,
+			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
+		}
+	}
+
+	client := getClient(c.Token)
+
+	if c.MachineType == string(vultrtypes.BareMetal) {
+		instances, _, err := client.BareMetalServer.List(ctx, &govultr.ListOptions{Tag: fmt.Sprintf("machineUid=%s", machine.UID)})
+		if err != nil {
+			return nil, cloudprovidererrors.TerminalError{
+				Reason:  common.InvalidConfigurationMachineError,
+				Message: err.Error(),
+			}
+		}
+
+		for _, instance := range instances {
+			for _, tag := range instance.Tags {
+				if tag == fmt.Sprintf("machineUid=%s", machine.UID) {
+					return &vultrBareMetalInstance{instance: &instance}, nil
+				}
+			}
+		}
+	} else if c.MachineType == string(vultrtypes.CloudInstance) {
+		instances, _, err := client.Instance.List(ctx, nil)
+		if err != nil {
+			return nil, cloudprovidererrors.TerminalError{
+				Reason:  common.InvalidConfigurationMachineError,
+				Message: err.Error(),
+			}
+		}
+
+		for _, instance := range instances {
+			for _, tag := range instance.Tags {
+				if tag == fmt.Sprintf("machineUid=%s", machine.UID) {
+					return &vultrCloudInstance{instance: &instance}, nil
+				}
+			}
+		}
+	}
+
+	return nil, cloudprovidererrors.ErrInstanceNotFound
+}
+
+func (p *provider) MigrateUID(ctx context.Context, machine *clusterv1alpha1.Machine, newUID types.UID) error {
+	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	if err != nil {
+		return cloudprovidererrors.TerminalError{
+			Reason:  common.InvalidConfigurationMachineError,
+			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
+		}
+	}
+
+	instance, err := p.Get(ctx, machine, nil)
+	if err != nil {
+		if errors.Is(err, cloudprovidererrors.ErrInstanceNotFound) {
+			return err
+		}
+	}
+
+	client := getClient(c.Token)
+
+	if c.MachineType == string(vultrtypes.BareMetal) {
+		rawInstance, err := client.BareMetalServer.Get(ctx, instance.ID())
+		if err != nil {
+			return fmt.Errorf("could not get instance with id %q", instance.ID())
+		}
+
+		var tagFound bool
+		for i, t := range rawInstance.Tags {
+			if strings.HasPrefix(t, "machineUid") {
+				tagFound = true
+				rawInstance.Tags[i] = fmt.Sprintf("machineUid=%s", newUID)
+			}
+		}
+
+		if !tagFound {
+			return fmt.Errorf("could not find instance with old machineUid tag")
+		}
+
+		_, err = client.BareMetalServer.Update(ctx, instance.ID(), &govultr.BareMetalUpdate{Tags: rawInstance.Tags})
+		if err != nil {
+			return fmt.Errorf("failed to update instance with new UID: %w", err)
+		}
+	} else if c.MachineType == string(vultrtypes.CloudInstance) {
+		rawInstance, err := client.Instance.Get(ctx, instance.ID())
+		if err != nil {
+			return fmt.Errorf("could not get instance with id %q", instance.ID())
+		}
+
+		var tagFound bool
+		for i, t := range rawInstance.Tags {
+			if strings.HasPrefix(t, "machineUid") {
+				tagFound = true
+				rawInstance.Tags[i] = fmt.Sprintf("machineUid=%s", newUID)
+			}
+		}
+
+		if !tagFound {
+			return fmt.Errorf("could not find instance with old machineUid tag")
+		}
+
+		_, err = client.Instance.Update(ctx, instance.ID(), &govultr.InstanceUpdateReq{Tags: rawInstance.Tags})
+		if err != nil {
+			return fmt.Errorf("failed to update instance with new UID: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (p *provider) MachineMetricsLabels(machine *clusterv1alpha1.Machine) (map[string]string, error) {
+	labels := make(map[string]string)
+
+	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	if err == nil {
+		labels["region"] = c.Region
+		labels["plan"] = c.Plan
+	}
+
+	return labels, err
+}
+
+func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config string, name string, err error) {
+	return "", "", nil
+}
+
+func (p *provider) SetMetricsForMachines(machines clusterv1alpha1.MachineList) error {
+	return nil
+}
+
+type vultrBareMetalInstance struct {
+	instance *govultr.BareMetalServer
+}
+
+func (v *vultrBareMetalInstance) Name() string {
+	return string(v.instance.Label)
+}
+
+func (v *vultrBareMetalInstance) ID() string {
+	return v.instance.ID
+}
+
+func (v *vultrBareMetalInstance) ProviderID() string {
+	return fmt.Sprintf("vultr://%s", v.instance.ID)
+}
+
+func (v *vultrBareMetalInstance) Addresses() map[string]v1.NodeAddressType {
+	addresses := map[string]v1.NodeAddressType{}
+	addresses[v.instance.MainIP] = v1.NodeExternalIP
+
+	return addresses
+}
+
+func (v *vultrBareMetalInstance) Status() instance.Status {
+	switch v.instance.Status {
+	case "pending":
+		return instance.StatusCreating
+	case "active":
+		return instance.StatusRunning
+	default:
+		return instance.StatusUnknown
+	}
+}
+
+type vultrCloudInstance struct {
+	instance *govultr.Instance
+}
+
+func (v *vultrCloudInstance) Name() string {
+	return string(v.instance.Label)
+}
+
+func (v *vultrCloudInstance) ID() string {
+	return v.instance.ID
+}
+
+func (v *vultrCloudInstance) ProviderID() string {
+	return fmt.Sprintf("vultr://%s", v.instance.ID)
+}
+
+func (v *vultrCloudInstance) Addresses() map[string]v1.NodeAddressType {
+	addresses := map[string]v1.NodeAddressType{}
+	addresses[v.instance.MainIP] = v1.NodeExternalIP
+
+	return addresses
+}
+
+func (v *vultrCloudInstance) Status() instance.Status {
+	switch v.instance.Status {
+	case "pending":
+		return instance.StatusCreating
+	case "active":
+		return instance.StatusRunning
+	default:
+		return instance.StatusUnknown
+	}
+}

--- a/pkg/cloudprovider/provider/vultr/types/types.go
+++ b/pkg/cloudprovider/provider/vultr/types/types.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"github.com/kubermatic/machine-controller/pkg/jsonutil"
+	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+)
+
+type RawConfig struct {
+	Token       providerconfigtypes.ConfigVarString   `json:"token,omitempty"`
+	MachineType providerconfigtypes.ConfigVarString   `json:"machineType"`
+	Region      providerconfigtypes.ConfigVarString   `json:"region"`
+	Plan        providerconfigtypes.ConfigVarString   `json:"plan"`
+	Tags        []providerconfigtypes.ConfigVarString `json:"tags,omitempty"`
+}
+
+func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {
+	rawConfig := &RawConfig{}
+
+	return rawConfig, jsonutil.StrictUnmarshal(pconfig.CloudProviderSpec.Raw, rawConfig)
+}
+
+type MachineType string
+
+const (
+	BareMetal     MachineType = "bare-metal"
+	CloudInstance MachineType = "cloud-instance"
+)

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -66,6 +66,7 @@ const (
 	CloudProviderScaleway            CloudProvider = "scaleway"
 	CloudProviderBaremetal           CloudProvider = "baremetal"
 	CloudProviderExternal            CloudProvider = "external"
+	CloudProviderVultr               CloudProvider = "vultr"
 )
 
 var (

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -78,6 +78,8 @@ const (
 	alibabaManifest                   = "./testdata/machinedeployment-alibaba.yaml"
 	anexiaManifest                    = "./testdata/machinedeployment-anexia.yaml"
 	nutanixManifest                   = "./testdata/machinedeployment-nutanix.yaml"
+	vultrBareMetalManifest            = "./testdata/machinedeployment-vultr-bare-metal.yaml"
+	vultrCloudInstanceManifest        = "./testdata/machinedeployment-vultr-cloud-instance.yaml"
 )
 
 const defaultKubernetesVersion = "1.23.11"
@@ -742,6 +744,42 @@ func TestHetznerProvisioningE2E(t *testing.T) {
 	// act
 	params := []string{fmt.Sprintf("<< HETZNER_TOKEN >>=%s", hzToken)}
 	runScenarios(t, selector, params, HZManifest, fmt.Sprintf("hz-%s", *testRunIdentifier))
+}
+
+// TestVultrBareMetalProvisioning - a test suite that exercises Vultr provider with a bare metal instance
+// by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
+func TestVultrBareMetalProvisioningE2E(t *testing.T) {
+	t.Parallel()
+
+	// test data
+	vultrToken := os.Getenv("VULTR_E2E_TOKEN")
+	if len(vultrToken) == 0 {
+		t.Fatal("unable to run the test suite, VULTR_E2E_TOKEN environment variable cannot be empty")
+	}
+
+	selector := OsSelector("ubuntu")
+
+	// act
+	params := []string{fmt.Sprintf("<< VULTR_TOKEN >>=%s", vultrToken)}
+	runScenarios(t, selector, params, vultrBareMetalManifest, fmt.Sprintf("vultr-bare-metal-%s", *testRunIdentifier))
+}
+
+// TestVultrCloudInstanceProvisioning - a test suite that exercises Vultr provider with a cloud instance
+// by requesting nodes with different combination of container runtime type, container runtime version and the OS flavour.
+func TestVultrCloudInstanceProvisioningE2E(t *testing.T) {
+	t.Parallel()
+
+	// test data
+	vultrToken := os.Getenv("VULTR_E2E_TOKEN")
+	if len(vultrToken) == 0 {
+		t.Fatal("unable to run the test suite, VULTR_E2E_TOKEN environment variable cannot be empty")
+	}
+
+	selector := OsSelector("ubuntu")
+
+	// act
+	params := []string{fmt.Sprintf("<< VULTR_TOKEN >>=%s", vultrToken)}
+	runScenarios(t, selector, params, vultrCloudInstanceManifest, fmt.Sprintf("vultr-cloud-instance-%s", *testRunIdentifier))
 }
 
 // TestEquinixMetalProvisioningE2E - a test suite that exercises Equinix Metal provider

--- a/test/e2e/provisioning/testdata/machinedeployment-vultr-bare-metal.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vultr-bare-metal.yaml
@@ -1,0 +1,36 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: << MACHINE_NAME >>
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: << MACHINE_NAME >>
+  template:
+    metadata:
+      labels:
+        name: << MACHINE_NAME >>
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProvider: "vultr"
+          cloudProviderSpec:
+            token: << VULTR_TOKEN >>
+            machineType: "bare-metal"
+            region: "ams"
+            plan: "vbm-4c-32gb"
+          operatingSystem: "<< OS_NAME >>"
+          operatingSystemSpec:
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+      versions:
+        kubelet: "<< KUBERNETES_VERSION >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-vultr-cloud-instance.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vultr-cloud-instance.yaml
@@ -1,0 +1,36 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: << MACHINE_NAME >>
+  namespace: kube-system
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: << MACHINE_NAME >>
+  template:
+    metadata:
+      labels:
+        name: << MACHINE_NAME >>
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProvider: "vultr"
+          cloudProviderSpec:
+            token: << VULTR_TOKEN >>
+            machineType: "cloud-instance"
+            region: "ams"
+            plan: "vc2-8c-32gb"
+          operatingSystem: "<< OS_NAME >>"
+          operatingSystemSpec:
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+      versions:
+        kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to [Vultr](vultr.com/) cloud provider, for both their Bare Metal and Cloud Instance products. 

For now, is only supports `ubuntu`.

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:
- How does the automated E2E work? Who is responsible for the cloud provider token/billing?

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Add Vultr cloud provider
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
- Included in the `docs/` folder.
```
