### PR TITLE
Fix to mitigate race condition while configuring kubelet node ips

### DIFF
--- a/pkg/userdata/helper/helper.go
+++ b/pkg/userdata/helper/helper.go
@@ -160,6 +160,11 @@ func SetupNodeIPEnvScript(ipFamily util.IPFamily) string {
 	case util.DualStack:
 		defaultIfcIP = `DEFAULT_IFC_IP=$(ip -o route get  1 | grep -oP "src \K\S+")
 DEFAULT_IFC_IP6=$(ip -o -6 route get  1:: | grep -oP "src \K\S+")
+if [ -z "${DEFAULT_IFC_IP6}" ]
+then
+  echodate "Failed to get IPv6 address for the default route interface"
+  exit 1
+fi
 DEFAULT_IFC_IP=$DEFAULT_IFC_IP,$DEFAULT_IFC_IP6`
 	default:
 		defaultIfcIP = defaultIfcIPv4

--- a/pkg/userdata/ubuntu/testdata/digitalocean-dualstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/digitalocean-dualstack.yaml
@@ -259,6 +259,11 @@ write_files:
     # get the default interface IP address
     DEFAULT_IFC_IP=$(ip -o route get  1 | grep -oP "src \K\S+")
     DEFAULT_IFC_IP6=$(ip -o -6 route get  1:: | grep -oP "src \K\S+")
+    if [ -z "${DEFAULT_IFC_IP6}" ]
+    then
+      echodate "Failed to get IPv6 address for the default route interface"
+      exit 1
+    fi
     DEFAULT_IFC_IP=$DEFAULT_IFC_IP,$DEFAULT_IFC_IP6
 
     # get the full hostname

--- a/pkg/userdata/ubuntu/testdata/openstack-dualstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-dualstack.yaml
@@ -259,6 +259,11 @@ write_files:
     # get the default interface IP address
     DEFAULT_IFC_IP=$(ip -o route get  1 | grep -oP "src \K\S+")
     DEFAULT_IFC_IP6=$(ip -o -6 route get  1:: | grep -oP "src \K\S+")
+    if [ -z "${DEFAULT_IFC_IP6}" ]
+    then
+      echodate "Failed to get IPv6 address for the default route interface"
+      exit 1
+    fi
     DEFAULT_IFC_IP=$DEFAULT_IFC_IP,$DEFAULT_IFC_IP6
 
     # get the full hostname


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
In case of Dualstack, mitigate the timing issue between interface IPv6 assignment and kubelet service bringup.
This is achieved by adding a check for IPv6 address while configuring env variables for kubelet service. If the IPv6 is not yet assigned, return an error, which in-turn triggers the restart of setup and kubelet service.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #[10871](https://github.com/kubermatic/kubermatic/issues/10871)

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:
Verified for below combinations:

- Equinix - Rockylinux
- Hetzner - Ubuntu

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
