### PR TITLE
switch to kubermati-ci folder in e2e tests

### DIFF
--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
@@ -28,7 +28,7 @@ spec:
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
             datacenter: 'Hamburg'
-            folder: '/Hamburg/vm/Kubermatic-dev'
+            folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
             datastoreCluster: 'dsc-1'

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
@@ -28,7 +28,7 @@ spec:
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
             datacenter: 'Hamburg'
-            folder: '/Hamburg/vm/Kubermatic-dev'
+            folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             datastoreCluster: 'dsc-1'
             resourcePool: 'e2e-resource-pool'

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -28,7 +28,7 @@ spec:
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
             datacenter: 'Hamburg'
-            folder: '/Hamburg/vm/Kubermatic-dev'
+            folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
             datastore: alpha1

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -28,7 +28,7 @@ spec:
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
             datacenter: 'Hamburg'
-            folder: '/Hamburg/vm/Kubermatic-dev'
+            folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
             datastore: alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:

Switches the folder for vsphere e2e tests to ci

/kind cleanup

```release-note
NONE
```

```documentation
NONE
```
