### PR TITLE
Rework OSM integration into generic external bootstrap "interface"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,8 +48,6 @@ require (
 	google.golang.org/grpc v1.45.0
 	gopkg.in/gcfg.v1 v1.2.3
 	gopkg.in/yaml.v3 v3.0.1
-	// Please ensure that you update the image tags in `examples/operating-system-manager.yaml` as well.
-	k8c.io/operating-system-manager v1.0.0
 	k8s.io/api v0.25.0
 	k8s.io/apiextensions-apiserver v0.24.2
 	k8s.io/apimachinery v0.25.0
@@ -95,10 +93,9 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/emicklei/go-restful/v3 v3.8.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
-	github.com/flatcar-linux/container-linux-config-transpiler v0.9.3 // indirect
-	github.com/flatcar-linux/ignition v0.36.1 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -107,7 +107,6 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/ajeddeloh/go-json v0.0.0-20160803184958-73d058cf8437/go.mod h1:otnto4/Icqn88WCcM4bhIJNSgsh9VLBuspyyCfvof9c=
 github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559 h1:4SPQljF/GJ8Q+QlCWMWxRBepub4DresnOm4eI2ebFGc=
 github.com/ajeddeloh/go-json v0.0.0-20200220154158-5ae607161559/go.mod h1:otnto4/Icqn88WCcM4bhIJNSgsh9VLBuspyyCfvof9c=
 github.com/ajeddeloh/yaml v0.0.0-20170912190910-6b94386aeefd h1:NlKlOv3aVJ5ODMC0JWPvddw05KENkL3cZttIuu8kJRo=
@@ -118,7 +117,6 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.1645 h1:IEL/Da0Dtg9j/36UnzyxD84n0eDj0JIoTKTKobN2eks=
@@ -138,7 +136,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
-github.com/aws/aws-sdk-go v1.8.39/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.16.12 h1:wbMYa2PlFysFx2GLIQojr6FJV5+OWCM/BwyHXARxETA=
@@ -168,7 +165,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.16.15/go.mod h1:Y+BUV19q3OmQVqNUlbZ4
 github.com/aws/smithy-go v1.13.0 h1:YfyEmSJLo7fAv8FbuDK4R8F9aAmi9DZ88Zb/KJJmUl0=
 github.com/aws/smithy-go v1.13.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -215,12 +211,10 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
-github.com/coreos/go-semver v0.1.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
 github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -288,10 +282,6 @@ github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGjnw8=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/flatcar-linux/container-linux-config-transpiler v0.9.3 h1:0Leh4HX8Wpe/PYuNidytk6v+2mIFHybK50DWipiCnng=
-github.com/flatcar-linux/container-linux-config-transpiler v0.9.3/go.mod h1:AGVTulMzeIKwurV9ExYH3UiokET1Ur65g+EIeRDMwzM=
-github.com/flatcar-linux/ignition v0.36.1 h1:yNvS9sQvm9HJ8VgxXskx88DsF73qdF35ALJkbTwcYhY=
-github.com/flatcar-linux/ignition v0.36.1/go.mod h1:0jS5n4AopgOdwgi7QDo5MFgkMx/fQUDYjuxlGJC1Txg=
 github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -312,7 +302,6 @@ github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aev
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgOZ7o=
@@ -332,6 +321,7 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
+github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
@@ -366,7 +356,6 @@ github.com/gobuffalo/logger v1.0.1/go.mod h1:2zbswyIUa45I+c+FLXuWl9zSWEiVuthsk8z
 github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b36chA3Q=
 github.com/gobuffalo/packr/v2 v2.7.1/go.mod h1:qYEvAazPaVxy7Y7KR0W8qYEE+RymX74kETFqjFoFlOc=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-github.com/godbus/dbus v0.0.0-20181025153459-66d97aec3384/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godror/godror v0.13.3/go.mod h1:2ouUT4kdhUBk7TAkHWD4SN0CdI0pgEQbo8FVHhbSKWg=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
@@ -545,7 +534,6 @@ github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jedib0t/go-pretty v4.3.0+incompatible/go.mod h1:XemHduiw8R651AF9Pt4FwCTKeG3oo7hrHJAoznj9nag=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -715,7 +703,6 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
-github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -727,7 +714,6 @@ github.com/peterhellberg/link v1.1.0 h1:s2+RH8EGuI/mI4QwrWGSYQCRz7uNgip9BaM04HKu
 github.com/peterhellberg/link v1.1.0/go.mod h1:gtSlOT4jmkY8P47hbTc8PTgiDDWpdPbFYl75keYyBB8=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
-github.com/pin/tftp v2.1.0+incompatible/go.mod h1:xVpZOMCXTy+A5QMjEVN0Glwa1sUvaJhFXbr/aAxuxGY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -806,8 +792,6 @@ github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/sigma/bdoor v0.0.0-20160202064022-babf2a4017b0/go.mod h1:WBu7REWbxC/s/J06jsk//d+9DOz9BbsmcIrimuGRFbs=
-github.com/sigma/vmw-guestinfo v0.0.0-20160204083807-95dd4126d6e8/go.mod h1:JrRFFC0veyh0cibh0DAhriSY7/gV3kDdNaVUOmfx01U=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -815,9 +799,7 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
-github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
@@ -876,8 +858,6 @@ github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPi
 github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/vmware/govmomi v0.28.0 h1:VgeQ/Rvz79U9G8QIKLdgpsN9AndHJL+5iMJLgYIrBGI=
 github.com/vmware/govmomi v0.28.0/go.mod h1:F7adsVewLNHsW/IIm7ziFURaXDaHEwcc+ym4r3INMdY=
-github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
-github.com/vmware/vmw-ovflib v0.0.0-20170608004843-1f217b9dc714/go.mod h1:jiPk45kn7klhByRvUq5i2vo1RtHKBHj+iWGFpxbXuuI=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
@@ -956,7 +936,6 @@ go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
 go.uber.org/zap v1.21.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
-go4.org v0.0.0-20160314031811-03efcb870d84/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 go4.org v0.0.0-20201209231011-d4a079459e60 h1:iqAGo78tVOJXELHQFRjR6TMwItrvXH4hrGJ32I/NFF8=
 go4.org v0.0.0-20201209231011-d4a079459e60/go.mod h1:CIiUVy99QCPfoE13bO4EZaz5GZMZXMSBGhxRdsvzbkg=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -1031,7 +1010,6 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190320064053-1272bf9dcd53/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -1215,7 +1193,6 @@ golang.org/x/term v0.0.0-20220526004731-065cf7ba2467/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.1-0.20190321115727-fe223c5a2583/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -1546,8 +1523,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-k8c.io/operating-system-manager v1.0.0 h1:E1dCaLHypgaaLNgm50jcT3uwk3vok3xWYOnFcspXJ38=
-k8c.io/operating-system-manager v1.0.0/go.mod h1:8Q1xpjJomTG9X6lfx/y3+yGHCackHtqxuYEk0TIPMfA=
 k8s.io/api v0.23.3/go.mod h1:w258XdGyvCmnBj/vGzQMj6kzdufJZVUwEM1U2fRJwSQ=
 k8s.io/api v0.24.2/go.mod h1:AHqbSkTm6YrQ0ObxjO3Pmp/ubFF/KuM7jU+3khoBsOg=
 k8s.io/api v0.25.0 h1:H+Q4ma2U/ww0iGB78ijZx6DRByPz6/733jIuFpX70e0=

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -42,37 +42,37 @@ import (
 )
 
 type admissionData struct {
-	client          ctrlruntimeclient.Client
-	workerClient    ctrlruntimeclient.Client
-	userDataManager *userdatamanager.Manager
-	nodeSettings    machinecontroller.NodeSettings
-	useOSM          bool
-	namespace       string
-	constraints     *semver.Constraints
+	client               ctrlruntimeclient.Client
+	workerClient         ctrlruntimeclient.Client
+	userDataManager      *userdatamanager.Manager
+	nodeSettings         machinecontroller.NodeSettings
+	useExternalBootstrap bool
+	namespace            string
+	constraints          *semver.Constraints
 }
 
 var jsonPatch = admissionv1.PatchTypeJSONPatch
 
 type Builder struct {
-	ListenAddress      string
-	Client             ctrlruntimeclient.Client
-	WorkerClient       ctrlruntimeclient.Client
-	UserdataManager    *userdatamanager.Manager
-	NodeFlags          *node.Flags
-	UseOSM             bool
-	Namespace          string
-	VersionConstraints *semver.Constraints
+	ListenAddress        string
+	Client               ctrlruntimeclient.Client
+	WorkerClient         ctrlruntimeclient.Client
+	UserdataManager      *userdatamanager.Manager
+	UseExternalBootstrap bool
+	NodeFlags            *node.Flags
+	Namespace            string
+	VersionConstraints   *semver.Constraints
 }
 
 func (build Builder) Build() (*http.Server, error) {
 	mux := http.NewServeMux()
 	ad := &admissionData{
-		client:          build.Client,
-		workerClient:    build.WorkerClient,
-		userDataManager: build.UserdataManager,
-		useOSM:          build.UseOSM,
-		namespace:       build.Namespace,
-		constraints:     build.VersionConstraints,
+		client:               build.Client,
+		workerClient:         build.WorkerClient,
+		userDataManager:      build.UserdataManager,
+		useExternalBootstrap: build.UseExternalBootstrap,
+		namespace:            build.Namespace,
+		constraints:          build.VersionConstraints,
 	}
 
 	if err := build.NodeFlags.UpdateNodeSettings(&ad.nodeSettings); err != nil {

--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider"
+	controllerutil "github.com/kubermatic/machine-controller/pkg/controller/util"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
@@ -95,6 +96,17 @@ func (ad *admissionData) mutateMachines(ctx context.Context, ar admissionv1.Admi
 			return nil, err
 		}
 		common.SetOSLabel(&machine.Spec, string(providerConfig.OperatingSystem))
+	}
+
+	if machine.Labels == nil {
+		machine.Labels = make(map[string]string)
+	}
+
+	// Set LegacyMachineControllerUserDataLabel to false if external bootstrapping is expected for managing the machine configuration.
+	if ad.useExternalBootstrap {
+		machine.Labels[controllerutil.LegacyMachineControllerUserDataLabel] = "false"
+	} else {
+		machine.Labels[controllerutil.LegacyMachineControllerUserDataLabel] = "true"
 	}
 
 	return createAdmissionResponse(machineOriginal, &machine)

--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -27,7 +27,6 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/common"
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider"
-	controllerutil "github.com/kubermatic/machine-controller/pkg/controller/util"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
@@ -98,14 +97,6 @@ func (ad *admissionData) mutateMachines(ctx context.Context, ar admissionv1.Admi
 		common.SetOSLabel(&machine.Spec, string(providerConfig.OperatingSystem))
 	}
 
-	// Set LegacyMachineControllerUserDataLabel to false if OSM was used for managing the machine configuration.
-	if ad.useOSM {
-		if machine.Labels == nil {
-			machine.Labels = make(map[string]string)
-		}
-		machine.Labels[controllerutil.LegacyMachineControllerUserDataLabel] = "false"
-	}
-
 	return createAdmissionResponse(machineOriginal, &machine)
 }
 
@@ -169,7 +160,7 @@ func (ad *admissionData) defaultAndValidateMachineSpec(ctx context.Context, spec
 		providerConfig.OperatingSystem,
 		providerConfig.CloudProvider,
 		providerConfig.OperatingSystemSpec,
-		ad.useOSM,
+		ad.useExternalBootstrap,
 	)
 	if err != nil {
 		return err

--- a/pkg/bootstrap/doc.go
+++ b/pkg/bootstrap/doc.go
@@ -19,9 +19,21 @@ package bootstrap contains the necessary type definitions to implement the exter
 mechanism that machine-controller can use instead of generating instance user-data itself.
 
 Any external bootstrap provider needs to implement the logic as laid out in this documentation.
-This package can be imported to ensure the correct values are used.
+This package can be imported to ensure the correct values and patterns are used.
 
-machine-controller will expect two Secret objects in the namespace defined by `bootstrap.CloudInitSettingsNamespace`.
+machine-controller will expect a Secret object in the namespace defined by `CloudInitSettingsNamespace`,
+using `CloudConfigSecretNamePattern` as a pattern to determine the Secret name. This secret must provide
+valid user-data that will be passed to the cloud provider instance on creation.
+
+Example code that determines the secret name for a specific Machine:
+
+```
+bootstrapSecretName := fmt.Sprintf(bootstrap.CloudConfigSecretNamePattern,
+	referencedMachineDeployment,
+	machine.Namespace,
+	bootstrap.BootstrapCloudConfig)
+```
+
 */
 
 package bootstrap

--- a/pkg/bootstrap/doc.go
+++ b/pkg/bootstrap/doc.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+package bootstrap contains the necessary type definitions to implement the external bootstrap
+mechanism that machine-controller can use instead of generating instance user-data itself.
+
+Any external bootstrap provider needs to implement the logic as laid out in this documentation.
+This package can be imported to ensure the correct values are used.
+
+machine-controller will expect two Secret objects in the namespace defined by `bootstrap.CloudInitSettingsNamespace`.
+*/
+
+package bootstrap

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package bootstrap
 
 /*
-Do not update existing consts in this file as they are used by external bootstrap providers. Instead,
+Do NOT update existing consts in this file as they are used by external bootstrap providers. Instead,
 introduce new consts (e.g. `CloudConfigSecretNamePatternV2`) and ensure that machine-controller still
 supports the old "interface" (the existing consts) for a few releases, in addition to any new interfaces
 you are introducing.
@@ -26,8 +26,7 @@ you are introducing.
 type CloudConfigSecret string
 
 const (
-	ProvisioningCloudConfig CloudConfigSecret = "provisioning"
-	BootstrapCloudConfig    CloudConfigSecret = "bootstrap"
+	BootstrapCloudConfig CloudConfigSecret = "bootstrap"
 
 	CloudConfigSecretNamePattern = "%s-%s-%s-config"
 

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -30,7 +30,7 @@ const (
 
 	CloudConfigSecretNamePattern = "%s-%s-%s-config"
 
-	// CloudInitSettingsNamespace is the namespace in which bootstrap secrets are created by an external mechanism
+	// CloudInitSettingsNamespace is the namespace in which bootstrap secrets are created by an external mechanism.
 	CloudInitSettingsNamespace = "cloud-init-settings"
 	// MachineDeploymentRevision is the revision for Machine Deployment.
 	MachineDeploymentRevision = "k8c.io/machine-deployment-revision"

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bootstrap
+
+type CloudConfigSecret string
+
+const (
+	ProvisioningCloudConfig CloudConfigSecret = "provisioning"
+	BootstrapCloudConfig    CloudConfigSecret = "bootstrap"
+
+	CloudConfigSecretNamePattern = "%s-%s-%s-config"
+
+	// CloudInitSettingsNamespace is the namespace in which bootstrap secrets are created by an external mechanism
+	CloudInitSettingsNamespace = "cloud-init-settings"
+	// MachineDeploymentRevision is the revision for Machine Deployment.
+	MachineDeploymentRevision = "k8c.io/machine-deployment-revision"
+)

--- a/pkg/bootstrap/types.go
+++ b/pkg/bootstrap/types.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package bootstrap
 
+/*
+Do not update existing consts in this file as they are used by external bootstrap providers. Instead,
+introduce new consts (e.g. `CloudConfigSecretNamePatternV2`) and ensure that machine-controller still
+supports the old "interface" (the existing consts) for a few releases, in addition to any new interfaces
+you are introducing.
+*/
+
 type CloudConfigSecret string
 
 const (

--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -820,27 +820,6 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 					return nil, fmt.Errorf("failed to find machine's MachineDployment: %w", err)
 				}
 
-				// We need to ensure that both provisoning and bootstrapping secrets have been created. And that the revision
-				// matches with the machine deployment revision
-				provisioningSecretName := fmt.Sprintf(bootstrap.CloudConfigSecretNamePattern,
-					referencedMachineDeployment,
-					machine.Namespace,
-					bootstrap.ProvisioningCloudConfig)
-
-				// Ensure that the provisioning secret exists
-				provisioningSecret := &corev1.Secret{}
-				if err := r.client.Get(ctx,
-					types.NamespacedName{Name: provisioningSecretName, Namespace: util.CloudInitNamespace},
-					provisioningSecret); err != nil {
-					klog.Errorf(CloudInitNotReadyError, bootstrap.ProvisioningCloudConfig, machine.Name)
-					return nil, err
-				}
-
-				provisioningSecretRevision := provisioningSecret.Annotations[bootstrap.MachineDeploymentRevision]
-				if provisioningSecretRevision != machineDeploymentRevision {
-					return nil, fmt.Errorf(CloudInitNotReadyError, bootstrap.ProvisioningCloudConfig, machine.Name)
-				}
-
 				bootstrapSecretName := fmt.Sprintf(bootstrap.CloudConfigSecretNamePattern,
 					referencedMachineDeployment,
 					machine.Namespace,

--- a/pkg/providerconfig/types.go
+++ b/pkg/providerconfig/types.go
@@ -184,7 +184,7 @@ func DefaultOperatingSystemSpec(
 	osys providerconfigtypes.OperatingSystem,
 	cloudProvider providerconfigtypes.CloudProvider,
 	operatingSystemSpec runtime.RawExtension,
-	operatingSystemManagerEnabled bool,
+	externalBootstrapEnabled bool,
 ) (runtime.RawExtension, error) {
 	switch osys {
 	case providerconfigtypes.OperatingSystemAmazonLinux2:
@@ -192,7 +192,7 @@ func DefaultOperatingSystemSpec(
 	case providerconfigtypes.OperatingSystemCentOS:
 		return centos.DefaultConfig(operatingSystemSpec), nil
 	case providerconfigtypes.OperatingSystemFlatcar:
-		return flatcar.DefaultConfigForCloud(operatingSystemSpec, cloudProvider, operatingSystemManagerEnabled), nil
+		return flatcar.DefaultConfigForCloud(operatingSystemSpec, cloudProvider, externalBootstrapEnabled), nil
 	case providerconfigtypes.OperatingSystemRHEL:
 		return rhel.DefaultConfig(operatingSystemSpec), nil
 	case providerconfigtypes.OperatingSystemSLES:

--- a/pkg/userdata/flatcar/flatcar.go
+++ b/pkg/userdata/flatcar/flatcar.go
@@ -49,7 +49,7 @@ func DefaultConfig(operatingSystemSpec runtime.RawExtension) runtime.RawExtensio
 	return DefaultConfigForCloud(operatingSystemSpec, "", true)
 }
 
-func DefaultConfigForCloud(operatingSystemSpec runtime.RawExtension, cloudProvider types.CloudProvider, operatingSystemManagerEnabled bool) runtime.RawExtension {
+func DefaultConfigForCloud(operatingSystemSpec runtime.RawExtension, cloudProvider types.CloudProvider, externalBootstrapEnabled bool) runtime.RawExtension {
 	// If userdata is being used from machine-controller and selected cloud provider is AWS then we
 	// force cloud-init. Because AWS has a very low cap for the maximum size of user-data. In case of ignition,
 	// we always exceed that limit which prevents new ec2 instances from being created.
@@ -58,7 +58,7 @@ func DefaultConfigForCloud(operatingSystemSpec runtime.RawExtension, cloudProvid
 		_ = json.Unmarshal(operatingSystemSpec.Raw, &osSpec)
 	}
 	// In case of OSM this is not required.
-	if cloudProvider == types.CloudProviderAWS && !operatingSystemManagerEnabled {
+	if cloudProvider == types.CloudProviderAWS && !externalBootstrapEnabled {
 		osSpec.ProvisioningUtility = CloudInit
 	}
 

--- a/test/e2e/provisioning/testdata/machinedeployment-alibaba.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-alibaba.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-anexia.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-anexia.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:
@@ -21,7 +23,7 @@ spec:
       providerSpec:
         value:
           sshPublicKeys:
-          - "<< YOUR_PUBLIC_KEY >>"
+            - "<< YOUR_PUBLIC_KEY >>"
           cloudProvider: anexia
           cloudProviderSpec:
             token: "<< ANEXIA_TOKEN >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-ebs-encryption-enabled.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-ebs-encryption-enabled.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:
@@ -35,7 +37,7 @@ spec:
             diskType: "gp2"
             ebsVolumeEncrypted: true
             securityGroupIDs:
-            - "sg-a2c195ca"
+              - "sg-a2c195ca"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:
@@ -40,7 +42,7 @@ spec:
               maxPrice: "<< MAX_PRICE >>"
               persistentRequest: false
             securityGroupIDs:
-            - "sg-a2c195ca"
+              - "sg-a2c195ca"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:
@@ -38,7 +40,7 @@ spec:
             ebsVolumeEncrypted: false
             ami: "<< AMI >>"
             securityGroupIDs:
-            - "sg-a2c195ca"
+              - "sg-a2c195ca"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-azure-custom-image-reference.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure-custom-image-reference.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-azure-redhat-satellite.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure-redhat-satellite.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-baremetal-tinkerbell.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-baremetal-tinkerbell.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-digitalocean.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-digitalocean.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-equinixmetal.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-equinixmetal.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-gce.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-gce.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:
@@ -36,7 +38,7 @@ spec:
             # Can be 'pd-standard' or 'pd-ssd'
             diskType: "pd-standard"
             labels:
-                "kubernetes_cluster": "gce-test-cluster"
+              "kubernetes_cluster": "gce-test-cluster"
             assignPublicIPAddress: true
             customImage: "<< CUSTOM-IMAGE >>"
             disableMachineServiceAccount: false

--- a/test/e2e/provisioning/testdata/machinedeployment-hetzner.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-hetzner.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   paused: false
   replicas: 1
@@ -48,7 +50,7 @@ spec:
                 type: "" # Allowed values: "", "soft", "hard"
                 key: "foo"
                 values:
-                - bar
+                  - bar
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-linode.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-linode.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-nutanix.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-nutanix.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack-project-auth.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack-project-auth.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack-upgrade.yml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-openstack.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-scaleway.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-scaleway.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-vmware-cloud-director.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vmware-cloud-director.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   paused: false
   replicas: 1

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:
@@ -41,11 +43,11 @@ spec:
             disableAutoUpdate: true
             rhsmOfflineToken: "<< REDHAT_SUBSCRIPTIONS_OFFLINE_TOKEN >>"
           network:
-           cidr: "192.168.44.<< IP_OCTET >>/20"
-           gateway: "192.168.32.1"
-           dns:
-             servers:
-              - "192.168.32.1"
-              - "8.8.8.8"
+            cidr: "192.168.44.<< IP_OCTET >>/20"
+            gateway: "192.168.32.1"
+            dns:
+              servers:
+                - "192.168.32.1"
+                - "8.8.8.8"
       versions:
         kubelet: "<< KUBERNETES_VERSION >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -3,6 +3,8 @@ kind: MachineDeployment
 metadata:
   name: << MACHINE_NAME >>
   namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
 spec:
   replicas: 1
   strategy:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is essentially both proposal and code change in one go. Let me explain the reasoning behind this PR first:

Essentially, we have a consumer/producer relationship between MC (as consumer) and OSM (as producer) when it comes to the user-data passed to new machines. However, I believe the consumer/producer relationship bits are a bit all over the place. Some logic exists in MC, some in OSM. The consumer/producer relationship here is very similar to Go interfaces, and a rule of thumb there is that interfaces should not be aware of types that implement them.

The same, IMHO, goes for the MC-OSM relationship: MC should support a standard (or interface, if you want; `pkg/bootstrap` defines this in this PR) that any producer of bootstrapping user-data can "slot" into. But MC should not be aware of the producer component in any way, other than the defined interface (which, in this PR, is a `Secret` created under a certain naming pattern). Theoretically, you should be able to create bootstrapping user-data manually.

The point of all this is that MC should not be aware of OSM or depend on it. If this is accepted, I plan to follow up in OSM with adding some of the logic removed here back into it.

In addition, the current MC code does a referential integrity check on an OSP resource - with all the previous explanation this does not make sense anymore anyway (as it's implementation-specific for OSP), but we do not apply referential integrity checks anywhere else for a specific reason: It's against Kubernetes design principles (you won't find this in HPAs referencing a non-existing Deployment, or RBAC role bindings referencing non-existing roles). So, I propose that the check for OSP is removed and replaced with events on `MachineDeployments`, highlighting that the referenced OSP does not (yet) exist. But that is for the follow-up PR in OSM.

TL;DR: This PR does the following things:

- Remove the code dependency on OSM to stop the dependency loop we have between MC and OSM.
- Remove OSM-specific validation and mutation.
- Document "external bootstrap" mechanism in `pkg/bootstrap` that relies on some third-party component (such as OSM) creating a user-data bootstrap secret (following the same pattern that OSM applies right now).

Note: The OSP annotation magic should move to KKP, I'll follow up on that as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove dependency on operating-system-manager (OSM) and instead rely on generic external bootstrap secret "interface" (which can be fulfilled by any provider)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
