### PR TITLE
Bump Kubernetes versions used for E2E tests to 1.22.14, 1.23.11 and 1.24.5 respectively

### DIFF
--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -80,7 +80,7 @@ const (
 	nutanixManifest                   = "./testdata/machinedeployment-nutanix.yaml"
 )
 
-const defaultKubernetesVersion = "1.23.5"
+const defaultKubernetesVersion = "1.23.11"
 
 var testRunIdentifier = flag.String("identifier", "local", "The unique identifier for this test run")
 

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -33,9 +33,9 @@ var (
 	scenarios = buildScenarios()
 
 	versions = []*semver.Version{
-		semver.MustParse("v1.22.7"),
-		semver.MustParse("v1.23.5"),
-		semver.MustParse("v1.24.0"),
+		semver.MustParse("v1.22.14"),
+		semver.MustParse("v1.23.11"),
+		semver.MustParse("v1.24.5"),
 	}
 
 	operatingSystems = []providerconfigtypes.OperatingSystem{

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
@@ -35,6 +35,7 @@ spec:
             cpus: 2
             MemoryMB: 2048
             diskSizeGB: << DISK_SIZE >>
+            allowInsecure: true
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
@@ -35,6 +35,7 @@ spec:
             cpus: 2
             MemoryMB: 2048
             diskSizeGB: << DISK_SIZE >>
+            allowInsecure: true
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -32,9 +32,9 @@ spec:
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
             datastore: alpha1
-            allowInsecure: true
             cpus: 2
             MemoryMB: 2048
+            allowInsecure: true
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -35,6 +35,7 @@ spec:
             cpus: 2
             MemoryMB: 4096
             diskSizeGB: << DISK_SIZE >>
+            allowInsecure: true
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
