### PR TITLE
Add enableBootDiagnostics field to Azure cloud spec

### DIFF
--- a/pkg/cloudprovider/provider/azure/types/types.go
+++ b/pkg/cloudprovider/provider/azure/types/types.go
@@ -43,6 +43,7 @@ type RawConfig struct {
 	ImagePlan                   *ImagePlan                          `json:"imagePlan,omitempty"`
 	ImageReference              *ImageReference                     `json:"imageReference,omitempty"`
 	EnableAcceleratedNetworking *bool                               `json:"enableAcceleratedNetworking"`
+	EnableBootDiagnostics       *bool                               `json:"enableBootDiagnostics,omitempty"`
 
 	ImageID        providerconfigtypes.ConfigVarString `json:"imageID"`
 	OSDiskSize     int32                               `json:"osDiskSize"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Boot diagnostics are nice because you can see the console logs if things go wrong and you cannot SSH into your VM for whatever reason. That can be useful for our development, but I imagine users who face stability issues with their Azure VMs might also want to enable this setting.

Azure [enables this setting by default on VMs created via the portal](https://learn.microsoft.com/en-us/azure/virtual-machines/boot-diagnostics#enable-managed-boot-diagnostics-using-the-azure-portal), so it seems a good idea to at least provide a setting for this.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1291

**What type of PR is this?**
/kind feature
/kind api-change

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `enableBootDiagnostics` field to Azure cloud spec to enable boot diagnostics on managed storage account
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
