### PR TITLE
Add an option to enable guest os features at GCP

### DIFF
--- a/examples/gce-machinedeployment.yaml
+++ b/examples/gce-machinedeployment.yaml
@@ -71,6 +71,9 @@ spec:
             disableMachineServiceAccount: false
             enableNestedVirtualization: false
             minCPUPlatform: "Intel Haswell"
+            guestOSFeatures:
+              - "VIRTIO_SCSI_MULTIQUEUE"
+              - "GVNIC"
           # Can be 'ubuntu' or 'rhel'
           operatingSystem: "ubuntu"
           operatingSystemSpec:

--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -114,6 +114,7 @@ type config struct {
 	disableMachineServiceAccount bool
 	enableNestedVirtualization   bool
 	minCPUPlatform               string
+	guestOSFeatures              []string
 }
 
 // newConfig creates a Provider configuration out of the passed resolver and spec.
@@ -126,10 +127,11 @@ func newConfig(resolver *providerconfig.ConfigVarResolver, spec v1alpha1.Provide
 
 	// Setup configuration.
 	cfg := &config{
-		providerConfig: providerConfig,
-		labels:         cpSpec.Labels,
-		tags:           cpSpec.Tags,
-		diskSize:       cpSpec.DiskSize,
+		providerConfig:  providerConfig,
+		labels:          cpSpec.Labels,
+		tags:            cpSpec.Tags,
+		diskSize:        cpSpec.DiskSize,
+		guestOSFeatures: cpSpec.GuestOSFeatures,
 	}
 
 	cfg.serviceAccount, err = resolver.GetConfigVarStringValueOrEnv(cpSpec.ServiceAccount, envGoogleServiceAccount)

--- a/pkg/cloudprovider/provider/gce/provider_test.go
+++ b/pkg/cloudprovider/provider/gce/provider_test.go
@@ -57,6 +57,10 @@ func testProviderSpec() map[string]interface{} {
 			"disableMachineServiceAccount": false,
 			"enableNestedVirtualization":   true,
 			"minCPUPlatform":               "Intel Haswell",
+			"guestOSFeatures": []string{
+				"VIRTIO_SCSI_MULTIQUEUE",
+				"GVNIC",
+			},
 		},
 		"operatingSystem": "ubuntu",
 		"operatingSystemSpec": map[string]interface{}{

--- a/pkg/cloudprovider/provider/gce/service.go
+++ b/pkg/cloudprovider/provider/gce/service.go
@@ -125,6 +125,11 @@ func (svc *service) attachedDisks(cfg *config) ([]*compute.AttachedDisk, error) 
 			SourceImage: sourceImage,
 		},
 	}
+	for _, v := range cfg.guestOSFeatures {
+		bootDisk.GuestOsFeatures = append(bootDisk.GuestOsFeatures, &compute.GuestOsFeature{
+			Type: v,
+		})
+	}
 	return []*compute.AttachedDisk{bootDisk}, nil
 }
 

--- a/pkg/cloudprovider/provider/gce/types/types.go
+++ b/pkg/cloudprovider/provider/gce/types/types.go
@@ -49,7 +49,8 @@ type CloudProviderSpec struct {
 	CustomImage                  providerconfigtypes.ConfigVarString  `json:"customImage,omitempty"`
 	DisableMachineServiceAccount providerconfigtypes.ConfigVarBool    `json:"disableMachineServiceAccount,omitempty"`
 	EnableNestedVirtualization   providerconfigtypes.ConfigVarBool    `json:"enableNestedVirtualization,omitempty"`
-	MinCPUPlatform               providerconfigtypes.ConfigVarString  `json:"MinCPUPlatform,omitempty"`
+	MinCPUPlatform               providerconfigtypes.ConfigVarString  `json:"minCPUPlatform,omitempty"`
+	GuestOSFeatures              []string                             `json:"guestOSFeatures,omitempty"`
 }
 
 // UpdateProviderSpec updates the given provider spec with changed


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables guest os features for GCP compute instance
https://cloud.google.com/compute/docs/images/create-custom#guest-os-features

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable Guest OS Features for GCP cloud provider
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
