### PR TITLE
Dualstack support with AWS CCM

### DIFF
--- a/pkg/cloudprovider/provider/aws/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/aws/types/cloudconfig.go
@@ -37,6 +37,9 @@ KubernetesClusterID={{ .Global.KubernetesClusterID | iniEscape }}
 DisableSecurityGroupIngress={{ .Global.DisableSecurityGroupIngress }}
 ElbSecurityGroup={{ .Global.ElbSecurityGroup | iniEscape }}
 DisableStrictZoneCheck={{ .Global.DisableStrictZoneCheck }}
+{{- range .Global.NodeIPFamilies }}
+NodeIPFamilies={{ . | iniEscape}}
+{{- end }}
 `
 )
 
@@ -55,6 +58,7 @@ type GlobalOpts struct {
 	ElbSecurityGroup            string
 	DisableSecurityGroupIngress bool
 	DisableStrictZoneCheck      bool
+	NodeIPFamilies              []string
 }
 
 func CloudConfigToString(c *CloudConfig) (string, error) {

--- a/pkg/cloudprovider/provider/aws/types/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/aws/types/cloudconfig_test.go
@@ -46,6 +46,7 @@ func TestCloudConfigToString(t *testing.T) {
 					KubernetesClusterTag:        "some-tag",
 					RoleARN:                     "some-arn",
 					RouteTableID:                "some-rt",
+					NodeIPFamilies:              []string{"ipv4", "ipv6"},
 				},
 			},
 		},

--- a/pkg/cloudprovider/provider/aws/types/testdata/simple-config.golden
+++ b/pkg/cloudprovider/provider/aws/types/testdata/simple-config.golden
@@ -8,3 +8,5 @@ KubernetesClusterID="some-tag"
 DisableSecurityGroupIngress=true
 ElbSecurityGroup="some-sg"
 DisableStrictZoneCheck=true
+NodeIPFamilies="ipv4"
+NodeIPFamilies="ipv6"


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
 This PR adds NodeIPFamilies to GlobalOpts struct. This is required in Kubermatic repo for adding dual stack support with AWS CCM which is enabled with control plane version 1.24 onwards.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
This is only a struct change, the actual logic will be added in Kubermatic repo.
**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
