### PR TITLE
add optional additional subnets to Nutanix provider

### DIFF
--- a/examples/nutanix-machinedeployment.yaml
+++ b/examples/nutanix-machinedeployment.yaml
@@ -60,8 +60,10 @@ spec:
             projectName: project1
             # Sets the subnet that the VM is connected to. Must exist in the given Nutanix cluster
             subnetName: subnet1
-            # Optional: Sets the storage subnet that the VM is connected to. Must exist in the given Nutanix cluster
-            # storageSubnetName: subnet2
+            # Optional: Sets multiple additional subnets that the VM is connected to. Must exist in the given Nutanix cluster
+            # additionalSubnetNames:
+            #   - subnet2
+            #   - subnet3
             # Provides the image used to create the VM
             imageName: ubuntu-20.04
             # Sets the vCPU count for this VM

--- a/examples/nutanix-machinedeployment.yaml
+++ b/examples/nutanix-machinedeployment.yaml
@@ -60,6 +60,8 @@ spec:
             projectName: project1
             # Sets the subnet that the VM is connected to. Must exist in the given Nutanix cluster
             subnetName: subnet1
+            # Optional: Sets the storage subnet that the VM is connected to. Must exist in the given Nutanix cluster
+            # storageSubnetName: subnet2
             # Provides the image used to create the VM
             imageName: ubuntu-20.04
             # Sets the vCPU count for this VM

--- a/pkg/cloudprovider/provider/nutanix/client.go
+++ b/pkg/cloudprovider/provider/nutanix/client.go
@@ -113,18 +113,18 @@ func createVM(ctx context.Context, client *ClientSet, name string, conf Config, 
 		},
 	}
 
-	if strings.TrimSpace(conf.StorageSubnetName) != "" {
-		storageSubnet, err := getSubnetByName(ctx, client, conf.StorageSubnetName, *cluster.Metadata.UUID)
+	for _, subnet := range conf.AdditionalSubnetNames {
+		additionalSubnet, err := getSubnetByName(ctx, client, subnet, *cluster.Metadata.UUID)
 		if err != nil {
 			return nil, err
 		}
-		storageSubnetNic := &nutanixv3.VMNic{
+		additionalSubnetNic := &nutanixv3.VMNic{
 			SubnetReference: &nutanixv3.Reference{
 				Kind: pointer.String(nutanixtypes.SubnetKind),
-				UUID: storageSubnet.Metadata.UUID,
+				UUID: additionalSubnet.Metadata.UUID,
 			},
 		}
-		nicList = append(nicList, storageSubnetNic)
+		nicList = append(nicList, additionalSubnetNic)
 	}
 
 	image, err := getImageByName(ctx, client, conf.ImageName)

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -45,11 +45,11 @@ type Config struct {
 	AllowInsecure bool
 	ProxyURL      string
 
-	ClusterName       string
-	ProjectName       string
-	SubnetName        string
-	StorageSubnetName string
-	ImageName         string
+	ClusterName           string
+	ProjectName           string
+	SubnetName            string
+	AdditionalSubnetNames []string
+	ImageName             string
 
 	Categories map[string]string
 
@@ -181,12 +181,8 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	if rawConfig.StorageSubnetName != nil {
-		c.StorageSubnetName, err = p.configVarResolver.GetConfigVarStringValue(*rawConfig.StorageSubnetName)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-	}
+
+	c.AdditionalSubnetNames = append(c.AdditionalSubnetNames, rawConfig.AdditionalSubnetNames...)
 
 	c.ImageName, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.ImageName)
 	if err != nil {
@@ -234,8 +230,8 @@ func (p *provider) Validate(ctx context.Context, spec clusterv1alpha1.MachineSpe
 		return fmt.Errorf("failed to get subnet: %w", err)
 	}
 
-	if config.StorageSubnetName != "" {
-		if _, err := getSubnetByName(ctx, client, config.StorageSubnetName, *cluster.Metadata.UUID); err != nil {
+	for _, subnet := range config.AdditionalSubnetNames {
+		if _, err := getSubnetByName(ctx, client, subnet, *cluster.Metadata.UUID); err != nil {
 			return fmt.Errorf("failed to get subnet: %w", err)
 		}
 	}

--- a/pkg/cloudprovider/provider/nutanix/types/types.go
+++ b/pkg/cloudprovider/provider/nutanix/types/types.go
@@ -38,11 +38,11 @@ type RawConfig struct {
 	AllowInsecure providerconfigtypes.ConfigVarBool   `json:"allowInsecure"`
 	ProxyURL      providerconfigtypes.ConfigVarString `json:"proxyURL,omitempty"`
 
-	ClusterName       providerconfigtypes.ConfigVarString  `json:"clusterName"`
-	ProjectName       *providerconfigtypes.ConfigVarString `json:"projectName,omitempty"`
-	SubnetName        providerconfigtypes.ConfigVarString  `json:"subnetName"`
-	StorageSubnetName *providerconfigtypes.ConfigVarString `json:"storageSubnetName,omitempty"`
-	ImageName         providerconfigtypes.ConfigVarString  `json:"imageName"`
+	ClusterName           providerconfigtypes.ConfigVarString  `json:"clusterName"`
+	ProjectName           *providerconfigtypes.ConfigVarString `json:"projectName,omitempty"`
+	SubnetName            providerconfigtypes.ConfigVarString  `json:"subnetName"`
+	AdditionalSubnetNames []string                             `json:"additionalSubnetNames,omitempty"`
+	ImageName             providerconfigtypes.ConfigVarString  `json:"imageName"`
 
 	// VM sizing configuration
 	CPUs           int64  `json:"cpus"`

--- a/pkg/cloudprovider/provider/nutanix/types/types.go
+++ b/pkg/cloudprovider/provider/nutanix/types/types.go
@@ -38,10 +38,11 @@ type RawConfig struct {
 	AllowInsecure providerconfigtypes.ConfigVarBool   `json:"allowInsecure"`
 	ProxyURL      providerconfigtypes.ConfigVarString `json:"proxyURL,omitempty"`
 
-	ClusterName providerconfigtypes.ConfigVarString  `json:"clusterName"`
-	ProjectName *providerconfigtypes.ConfigVarString `json:"projectName,omitempty"`
-	SubnetName  providerconfigtypes.ConfigVarString  `json:"subnetName"`
-	ImageName   providerconfigtypes.ConfigVarString  `json:"imageName"`
+	ClusterName       providerconfigtypes.ConfigVarString  `json:"clusterName"`
+	ProjectName       *providerconfigtypes.ConfigVarString `json:"projectName,omitempty"`
+	SubnetName        providerconfigtypes.ConfigVarString  `json:"subnetName"`
+	StorageSubnetName *providerconfigtypes.ConfigVarString `json:"storageSubnetName,omitempty"`
+	ImageName         providerconfigtypes.ConfigVarString  `json:"imageName"`
 
 	// VM sizing configuration
 	CPUs           int64  `json:"cpus"`

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -949,6 +949,7 @@ func getNutanixTestParams(t *testing.T) []string {
 	cluster := os.Getenv("NUTANIX_E2E_CLUSTER_NAME")
 	project := os.Getenv("NUTANIX_E2E_PROJECT_NAME")
 	subnet := os.Getenv("NUTANIX_E2E_SUBNET_NAME")
+	storageSubnet := os.Getenv("NUTANIX_E2E_STORAGESUBNET_NAME")
 	endpoint := os.Getenv("NUTANIX_E2E_ENDPOINT")
 
 	if password == "" || username == "" || endpoint == "" || cluster == "" || project == "" || subnet == "" {
@@ -963,6 +964,7 @@ func getNutanixTestParams(t *testing.T) []string {
 		fmt.Sprintf("<< NUTANIX_CLUSTER >>=%s", cluster),
 		fmt.Sprintf("<< NUTANIX_PROJECT >>=%s", project),
 		fmt.Sprintf("<< NUTANIX_SUBNET >>=%s", subnet),
+		fmt.Sprintf("<< NUTANIX_STORAGESUBNET >>=%s", storageSubnet),
 	}
 	return params
 }

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -949,7 +949,7 @@ func getNutanixTestParams(t *testing.T) []string {
 	cluster := os.Getenv("NUTANIX_E2E_CLUSTER_NAME")
 	project := os.Getenv("NUTANIX_E2E_PROJECT_NAME")
 	subnet := os.Getenv("NUTANIX_E2E_SUBNET_NAME")
-	storageSubnet := os.Getenv("NUTANIX_E2E_STORAGESUBNET_NAME")
+	additionalSubnetNames := os.Getenv("NUTANIX_E2E_ADDITIONAL_SUBNET_NAMES")
 	endpoint := os.Getenv("NUTANIX_E2E_ENDPOINT")
 
 	if password == "" || username == "" || endpoint == "" || cluster == "" || project == "" || subnet == "" {
@@ -964,7 +964,7 @@ func getNutanixTestParams(t *testing.T) []string {
 		fmt.Sprintf("<< NUTANIX_CLUSTER >>=%s", cluster),
 		fmt.Sprintf("<< NUTANIX_PROJECT >>=%s", project),
 		fmt.Sprintf("<< NUTANIX_SUBNET >>=%s", subnet),
-		fmt.Sprintf("<< NUTANIX_STORAGESUBNET >>=%s", storageSubnet),
+		fmt.Sprintf("<< NUTANIX_ADDITIONAL_SUBNETS >>=%s", additionalSubnetNames),
 	}
 	return params
 }

--- a/test/e2e/provisioning/testdata/machinedeployment-nutanix.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-nutanix.yaml
@@ -33,7 +33,7 @@ spec:
             clusterName: '<< NUTANIX_CLUSTER >>'
             projectName: '<< NUTANIX_PROJECT >>'
             subnetName: '<< NUTANIX_SUBNET >>'
-            storageSubnetName: '<< NUTANIX_STORAGESUBNET >>'
+            additionalSubnetNames: []
             imageName: 'machine-controller-e2e-<< OS_NAME >>'
             cpus: 2
             memoryMB: 2048

--- a/test/e2e/provisioning/testdata/machinedeployment-nutanix.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-nutanix.yaml
@@ -33,6 +33,7 @@ spec:
             clusterName: '<< NUTANIX_CLUSTER >>'
             projectName: '<< NUTANIX_PROJECT >>'
             subnetName: '<< NUTANIX_SUBNET >>'
+            storageSubnetName: '<< NUTANIX_STORAGESUBNET >>'
             imageName: 'machine-controller-e2e-<< OS_NAME >>'
             cpus: 2
             memoryMB: 2048


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the possibility to create a VM with an additional NIC for a storage subnet for the Nutanix provider. We need this as we use a dedicated network for our Nutanix storage provider.

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:
I did the implementation as minimal as possible. But we where diskussing different options and I am open to change the code if you require it.
Second option would have been an "additionalSubnetNamess" List instead of the storageSubnetName field. But we were not sure if somebody needs more than two NICs anyways.
Third option would be replacing subnetName with a List. But this would break backwards compatibility. 
Let me know if you think any of the two options above would be a better solution for the project.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add new field, additionalSubnetNames, to the Nutanix provider which allows to configure additional network interfaces. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
