### PR TITLE
Add cluster labels to kubevirt vm

### DIFF
--- a/docs/kubevirt.md
+++ b/docs/kubevirt.md
@@ -7,13 +7,14 @@ under `examples/cdi-operator.yaml` to provision storage. It is important to have
 information regarding which types of storage can be used please refer to [KubeVirt documentation](https://github.com/kubevirt/containerized-data-importer/blob/main/doc/basic_pv_pvc_dv.md).
 
 
-Afterwards, you can use the provided `exampes/examples/kubevirt-machinedeployment.yaml` as base. There
+Afterwards, you can use the provided `examples/kubevirt-machinedeployment.yaml` as base. There
 are some things you need to keep in mind:
 
 * The machine-controller will create `VMIs` that have the same name as the underlying `machine`. To
 avoid collisions, use one namespace per cluster that runs the `machine-controller`
 * Service CIDR range: The CIDR ranges of the cluster that runs Kubevirt and the cluster that hosts the machine-controller must not overlap,
 otherwise routing of services that run in the kubevirt cluster won't work anymore. This is especially important for the DNS ClusterIP.
+* `clusterName` is used to [label VMs](https://github.com/kubevirt/cloud-provider-kubevirt#prerequisites) for LoadBalancer selection
 
 ## Serving Supported Images
 

--- a/examples/kubevirt-machinedeployment.yaml
+++ b/examples/kubevirt-machinedeployment.yaml
@@ -26,6 +26,7 @@ spec:
             - "<< YOUR_PUBLIC_KEY >>"
           cloudProvider: "kubevirt"
           cloudProviderSpec:
+            clusterName: cluster-name
             auth:
               kubeconfig:
                 # Can also be set via the env var 'KUBEVIRT_KUBECONFIG' on the machine-controller.

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kubelet v0.24.2
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
-	kubevirt.io/api v0.57.1
+	kubevirt.io/api v0.58.0
 	kubevirt.io/containerized-data-importer-api v1.55.0
 	sigs.k8s.io/controller-runtime v0.12.1
 	sigs.k8s.io/yaml v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1678,8 +1678,8 @@ k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-kubevirt.io/api v0.57.1 h1:z6ImWKCQL2efFYqMWmxEsDNyt8c6mbWk7oCY6ZAa06U=
-kubevirt.io/api v0.57.1/go.mod h1:U0CQlZR0JoJCaC+Va0wz4dMOtYDdVywJ98OT1KmOkzI=
+kubevirt.io/api v0.58.0 h1:qeNeRtD6AIJ5WVJuRXajmmXtnrO5dYchy+hpCm6QwhE=
+kubevirt.io/api v0.58.0/go.mod h1:U0CQlZR0JoJCaC+Va0wz4dMOtYDdVywJ98OT1KmOkzI=
 kubevirt.io/containerized-data-importer-api v1.55.0 h1:IQNc8PYVq1cTwKNPEJza5xSlcnXeYVNt76M5kZ8X7xo=
 kubevirt.io/containerized-data-importer-api v1.55.0/go.mod h1:92HiQEyzPoeMiCbgfG5Qe10JQVbtWMZOXucy56dKdGg=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 h1:QMrd0nKP0BGbnxTqakhDZAUhGKxPiPiN5gSDqKUmGGc=

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -608,6 +608,10 @@ func (p *provider) newVirtualMachine(ctx context.Context, c *Config, pc *provide
 		resourceRequirements.Limits = *requestsAndLimits
 	}
 
+	// Add cluster labels
+	labels["cluster.x-k8s.io/cluster-name"] = c.Namespace
+	labels["cluster.x-k8s.io/role"] = "worker"
+
 	var (
 		dataVolumeName = machine.Name
 		annotations    map[string]string

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -93,6 +93,7 @@ func New(configVarResolver *providerconfig.ConfigVarResolver) cloudprovidertypes
 
 type Config struct {
 	Kubeconfig                string
+	ClusterName               string
 	RestConfig                *rest.Config
 	DNSConfig                 *corev1.PodDNSConfig
 	DNSPolicy                 corev1.DNSPolicy
@@ -229,6 +230,11 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 		if err == nil {
 			config.Kubeconfig = string(val)
 		}
+	}
+
+	config.ClusterName, err = p.configVarResolver.GetConfigVarStringValue(rawConfig.ClusterName)
+	if err != nil {
+		return nil, nil, fmt.Errorf(`failed to get value of "clusterName" field: %w`, err)
 	}
 
 	config.RestConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(config.Kubeconfig))
@@ -609,7 +615,7 @@ func (p *provider) newVirtualMachine(ctx context.Context, c *Config, pc *provide
 	}
 
 	// Add cluster labels
-	labels["cluster.x-k8s.io/cluster-name"] = c.Namespace
+	labels["cluster.x-k8s.io/cluster-name"] = c.ClusterName
 	labels["cluster.x-k8s.io/role"] = "worker"
 
 	var (

--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -86,20 +86,20 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 		"affinity": {
 		  "nodeAffinityPreset": {
 		    "type": "hard",
-			"key": "key1", 
+			"key": "key1",
 			"values": [
 				"foo1", "foo2" ]
 		  }
 		},
 		{{- end }}
 		"virtualMachine": {
-			{{- if .Instancetype }}		
+			{{- if .Instancetype }}
 			"instancetype": {
 				"name": "{{ .Instancetype.Name }}",
 				"kind": "{{ .Instancetype.Kind }}"
 			},
 			{{- end }}
-			{{- if .Preference }}		
+			{{- if .Preference }}
 			"preference": {
 				"name": "{{ .Preference.Name }}",
 				"kind": "{{ .Preference.Kind }}"

--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -70,6 +70,7 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 	tmpl, err := template.New("test").Parse(`{
 	"cloudProvider": "kubevirt",
 	"cloudProviderSpec": {
+		"clusterName": "cluster-name",
 		"auth": {
 			"kubeconfig": "eyJhcGlWZXJzaW9uIjoidjEiLCJjbHVzdGVycyI6W3siY2x1c3RlciI6eyJjZXJ0aWZpY2F0ZS1hdXRob3JpdHktZGF0YSI6IiIsInNlcnZlciI6Imh0dHBzOi8vOTUuMjE2LjIwLjE0Njo2NDQzIn0sIm5hbWUiOiJrdWJlcm5ldGVzIn1dLCJjb250ZXh0cyI6W3siY29udGV4dCI6eyJjbHVzdGVyIjoia3ViZXJuZXRlcyIsIm5hbWVzcGFjZSI6Imt1YmUtc3lzdGVtIiwidXNlciI6Imt1YmVybmV0ZXMtYWRtaW4ifSwibmFtZSI6Imt1YmVybmV0ZXMtYWRtaW5Aa3ViZXJuZXRlcyJ9XSwiY3VycmVudC1jb250ZXh0Ijoia3ViZXJuZXRlcy1hZG1pbkBrdWJlcm5ldGVzIiwia2luZCI6IkNvbmZpZyIsInByZWZlcmVuY2VzIjp7fSwidXNlcnMiOlt7Im5hbWUiOiJrdWJlcm5ldGVzLWFkbWluIiwidXNlciI6eyJjbGllbnQtY2VydGlmaWNhdGUtZGF0YSI6IiIsImNsaWVudC1rZXktZGF0YSI6IiJ9fV19"
 		},

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
@@ -3,6 +3,8 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
+    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/role: worker
     kubevirt.io/vm: affinity
     md: md-name
   name: affinity
@@ -27,6 +29,8 @@ spec:
   template:
     metadata:
       labels:
+        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/role: worker
         kubevirt.io/vm: affinity
         md: md-name
     spec:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
-    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/cluster-name: cluster-name
     cluster.x-k8s.io/role: worker
     kubevirt.io/vm: affinity
     md: md-name
@@ -29,7 +29,7 @@ spec:
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
         kubevirt.io/vm: affinity
         md: md-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
-    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/cluster-name: cluster-name
     cluster.x-k8s.io/role: worker
     kubevirt.io/vm: custom-local-disk
     md: md-name
@@ -30,7 +30,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
         kubevirt.io/vm: custom-local-disk
         md: md-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
@@ -3,6 +3,8 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
+    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/role: worker
     kubevirt.io/vm: custom-local-disk
     md: md-name
   name: custom-local-disk
@@ -28,6 +30,8 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/role: worker
         kubevirt.io/vm: custom-local-disk
         md: md-name
     spec:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
   labels:
     kubevirt.io/vm: http-image-source
+    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/role: worker
     md: md-name
   name: http-image-source
   namespace: test-namespace
@@ -28,6 +30,8 @@ spec:
       creationTimestamp: null
       labels:
         kubevirt.io/vm: http-image-source
+        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/role: worker
         md: md-name
     spec:
       affinity: {}

--- a/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
   labels:
     kubevirt.io/vm: http-image-source
-    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/cluster-name: cluster-name
     cluster.x-k8s.io/role: worker
     md: md-name
   name: http-image-source
@@ -30,7 +30,7 @@ spec:
       creationTimestamp: null
       labels:
         kubevirt.io/vm: http-image-source
-        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
         md: md-name
     spec:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
-    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/cluster-name: cluster-name
     cluster.x-k8s.io/role: worker
     kubevirt.io/vm: instancetype-preference-custom
     md: md-name
@@ -35,7 +35,7 @@ spec:
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
         kubevirt.io/vm: instancetype-preference-custom
         md: md-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
@@ -3,6 +3,8 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
+    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/role: worker
     kubevirt.io/vm: instancetype-preference-custom
     md: md-name
   name: instancetype-preference-custom
@@ -33,6 +35,8 @@ spec:
   template:
     metadata:
       labels:
+        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/role: worker
         kubevirt.io/vm: instancetype-preference-custom
         md: md-name
     spec:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
@@ -3,6 +3,8 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
+    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/role: worker
     kubevirt.io/vm: instancetype-preference-standard
     md: md-name
   name: instancetype-preference-standard
@@ -33,6 +35,8 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/role: worker
         kubevirt.io/vm: instancetype-preference-standard
         md: md-name
     spec:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
-    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/cluster-name: cluster-name
     cluster.x-k8s.io/role: worker
     kubevirt.io/vm: instancetype-preference-standard
     md: md-name
@@ -35,7 +35,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
         kubevirt.io/vm: instancetype-preference-standard
         md: md-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
@@ -3,6 +3,8 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
+    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/role: worker
     kubevirt.io/vm: nominal-case
     md: md-name
   name: nominal-case
@@ -27,6 +29,8 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/role: worker
         kubevirt.io/vm: nominal-case
         md: md-name
     spec:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
-    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/cluster-name: cluster-name
     cluster.x-k8s.io/role: worker
     kubevirt.io/vm: nominal-case
     md: md-name
@@ -29,7 +29,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
         kubevirt.io/vm: nominal-case
         md: md-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
   labels:
     kubevirt.io/vm: pvc-image-source
-    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/cluster-name: cluster-name
     cluster.x-k8s.io/role: worker
     md: md-name
   name: pvc-image-source
@@ -31,7 +31,7 @@ spec:
       creationTimestamp: null
       labels:
         kubevirt.io/vm: pvc-image-source
-        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
         md: md-name
     spec:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
   labels:
     kubevirt.io/vm: pvc-image-source
+    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/role: worker
     md: md-name
   name: pvc-image-source
   namespace: test-namespace
@@ -29,6 +31,8 @@ spec:
       creationTimestamp: null
       labels:
         kubevirt.io/vm: pvc-image-source
+        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/role: worker
         md: md-name
     spec:
       affinity: {}

--- a/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
-    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/cluster-name: cluster-name
     cluster.x-k8s.io/role: worker
     kubevirt.io/vm: secondary-disks
     md: md-name
@@ -55,7 +55,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
         kubevirt.io/vm: secondary-disks
         md: md-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
@@ -3,6 +3,8 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
+    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/role: worker
     kubevirt.io/vm: secondary-disks
     md: md-name
   name: secondary-disks
@@ -53,6 +55,8 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/role: worker
         kubevirt.io/vm: secondary-disks
         md: md-name
     spec:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
@@ -3,6 +3,8 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
+    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/role: worker
     kubevirt.io/vm: topologyspreadconstraints
     md: md-name
   name: topologyspreadconstraints
@@ -27,6 +29,8 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
+        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/role: worker
         kubevirt.io/vm: topologyspreadconstraints
         md: md-name
     spec:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
@@ -3,7 +3,7 @@ kind: VirtualMachine
 metadata:
   annotations:
   labels:
-    cluster.x-k8s.io/cluster-name: test-namespace
+    cluster.x-k8s.io/cluster-name: cluster-name
     cluster.x-k8s.io/role: worker
     kubevirt.io/vm: topologyspreadconstraints
     md: md-name
@@ -29,7 +29,7 @@ spec:
     metadata:
       creationTimestamp: null
       labels:
-        cluster.x-k8s.io/cluster-name: test-namespace
+        cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
         kubevirt.io/vm: topologyspreadconstraints
         md: md-name

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -26,10 +26,11 @@ import (
 )
 
 type RawConfig struct {
-	Auth                      Auth                       `json:"auth,omitempty"`
-	VirtualMachine            VirtualMachine             `json:"virtualMachine,omitempty"`
-	Affinity                  Affinity                   `json:"affinity,omitempty"`
-	TopologySpreadConstraints []TopologySpreadConstraint `json:"topologySpreadConstraints"`
+	ClusterName               providerconfigtypes.ConfigVarString `json:"clusterName"`
+	Auth                      Auth                                `json:"auth,omitempty"`
+	VirtualMachine            VirtualMachine                      `json:"virtualMachine,omitempty"`
+	Affinity                  Affinity                            `json:"affinity,omitempty"`
+	TopologySpreadConstraints []TopologySpreadConstraint          `json:"topologySpreadConstraints"`
 }
 
 // Auth.


### PR DESCRIPTION
**What this PR does / why we need it**:
For https://github.com/kubermatic/kubermatic/issues/10923 we need to add cluster labels to KubeVirt VMs on creation.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add cluster labels to KubeVirt VM
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```