### PR TITLE
Refactor overwriteCloudConfigSpec for MDs 

### DIFF
--- a/pkg/userdata/amzn2/provider.go
+++ b/pkg/userdata/amzn2/provider.go
@@ -256,10 +256,12 @@ write_files:
   content: |
 {{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .ProviderSpec.Network.GetIPFamily .PauseImage .MachineSpec.Taints .ExtraKubeletFlags true | indent 4 }}
 
+{{- if ne (len .CloudConfig) 0 }}
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |
 {{ .CloudConfig | indent 4 }}
+{{- end }}
 
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws-external.yaml
@@ -230,7 +230,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-aws.yaml
@@ -230,7 +230,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -247,7 +247,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -247,7 +247,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.23-vsphere.yaml
@@ -238,7 +238,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.24-aws.yaml
@@ -232,7 +232,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/amzn2/testdata/kubelet-v1.25-aws.yaml
+++ b/pkg/userdata/amzn2/testdata/kubelet-v1.25-aws.yaml
@@ -232,7 +232,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/centos/provider.go
+++ b/pkg/userdata/centos/provider.go
@@ -274,10 +274,12 @@ write_files:
   content: |
 {{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .ProviderSpec.Network.GetIPFamily .PauseImage .MachineSpec.Taints .ExtraKubeletFlags true | indent 4 }}
 
+{{- if ne (len .CloudConfig) 0 }}
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |
 {{ .CloudConfig | indent 4 }}
+{{- end }}
 
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-aws-external.yaml
@@ -240,7 +240,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-aws.yaml
@@ -240,7 +240,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-nutanix.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-nutanix.yaml
@@ -248,7 +248,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -257,7 +257,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -257,7 +257,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.23-vsphere.yaml
@@ -248,7 +248,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.24-aws.yaml
@@ -238,7 +238,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/centos/testdata/kubelet-v1.25-aws.yaml
+++ b/pkg/userdata/centos/testdata/kubelet-v1.25-aws.yaml
@@ -238,7 +238,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -388,12 +388,14 @@ storage:
         inline: |
 {{ .Kubeconfig | indent 10 }}
 
+{{- if ne (len .CloudConfig) 0 }}
     - path: /etc/kubernetes/cloud-config
       filesystem: root
       mode: 0400
       contents:
         inline: |
 {{ .CloudConfig | indent 10 }}
+{{- end }}
 
     - path: /etc/kubernetes/pki/ca.crt
       filesystem: root

--- a/pkg/userdata/rhel/provider.go
+++ b/pkg/userdata/rhel/provider.go
@@ -281,10 +281,12 @@ write_files:
   content: |
 {{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .ProviderSpec.Network.GetIPFamily .PauseImage .MachineSpec.Taints .ExtraKubeletFlags true | indent 4 }}
 
+{{- if ne (len .CloudConfig) 0 }}
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |
 {{ .CloudConfig | indent 4 }}
+{{- end }}
 
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws-external.yaml
@@ -247,7 +247,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-aws.yaml
@@ -247,7 +247,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -265,7 +265,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -265,7 +265,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.23-vsphere.yaml
@@ -256,7 +256,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws-external.yaml
@@ -245,7 +245,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.24-aws.yaml
@@ -245,7 +245,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rhel/testdata/kubelet-v1.25-aws.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.25-aws.yaml
@@ -245,7 +245,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rhel/testdata/kubelet-v1.25-nutanix.yaml
+++ b/pkg/userdata/rhel/testdata/kubelet-v1.25-nutanix.yaml
@@ -254,7 +254,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
+++ b/pkg/userdata/rhel/testdata/pod-cidr-azure-rhel.yaml
@@ -251,7 +251,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rockylinux/provider.go
+++ b/pkg/userdata/rockylinux/provider.go
@@ -278,10 +278,12 @@ write_files:
   content: |
 {{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .ProviderSpec.Network.GetIPFamily .PauseImage .MachineSpec.Taints .ExtraKubeletFlags true | indent 4 }}
 
+{{- if ne (len .CloudConfig) 0 }}
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |
 {{ .CloudConfig | indent 4 }}
+{{- end }}
 
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-aws-external.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-aws-external.yaml
@@ -247,7 +247,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-aws.yaml
@@ -247,7 +247,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-nutanix.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-nutanix.yaml
@@ -255,7 +255,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-vsphere-mirrors.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-vsphere-mirrors.yaml
@@ -264,7 +264,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-vsphere-proxy.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-vsphere-proxy.yaml
@@ -264,7 +264,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.23-vsphere.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.23-vsphere.yaml
@@ -255,7 +255,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.24-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.24-aws.yaml
@@ -245,7 +245,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/rockylinux/testdata/kubelet-v1.25-aws.yaml
+++ b/pkg/userdata/rockylinux/testdata/kubelet-v1.25-aws.yaml
@@ -245,7 +245,6 @@ write_files:
 
     [Install]
     WantedBy=multi-user.target
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/sles/provider.go
+++ b/pkg/userdata/sles/provider.go
@@ -223,10 +223,12 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
 
+{{- if ne (len .CloudConfig) 0 }}
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |
 {{ .CloudConfig | indent 4 }}
+{{- end }}
 
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"

--- a/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/sles/testdata/dist-upgrade-on-boot.yaml
@@ -201,11 +201,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/sles/testdata/kubelet-version-without-v-prefix.yaml
@@ -199,11 +199,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/sles/testdata/multiple-dns-servers.yaml
@@ -199,11 +199,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/sles/testdata/multiple-ssh-keys.yaml
@@ -201,11 +201,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/sles/testdata/openstack-overwrite-cloud-config.yaml
@@ -200,7 +200,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/sles/testdata/openstack.yaml
+++ b/pkg/userdata/sles/testdata/openstack.yaml
@@ -200,7 +200,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/sles/testdata/version-1.23.13.yaml
+++ b/pkg/userdata/sles/testdata/version-1.23.13.yaml
@@ -199,11 +199,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/sles/testdata/version-1.24.7.yaml
+++ b/pkg/userdata/sles/testdata/version-1.24.7.yaml
@@ -198,11 +198,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/sles/testdata/version-1.25.3.yaml
+++ b/pkg/userdata/sles/testdata/version-1.25.3.yaml
@@ -198,11 +198,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-mirrors.yaml
@@ -211,7 +211,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/sles/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/sles/testdata/vsphere-proxy.yaml
@@ -211,7 +211,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/sles/testdata/vsphere.yaml
+++ b/pkg/userdata/sles/testdata/vsphere.yaml
@@ -201,7 +201,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/var/run/netconfig/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/ubuntu/provider.go
+++ b/pkg/userdata/ubuntu/provider.go
@@ -270,10 +270,12 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
+{{- if ne (len .CloudConfig) 0 }}
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |
 {{ .CloudConfig | indent 4 }}
+{{- end }}
 
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"

--- a/pkg/userdata/ubuntu/testdata/containerd.yaml
+++ b/pkg/userdata/ubuntu/testdata/containerd.yaml
@@ -245,11 +245,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/digitalocean-dualstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/digitalocean-dualstack.yaml
@@ -242,7 +242,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
+++ b/pkg/userdata/ubuntu/testdata/dist-upgrade-on-boot.yaml
@@ -245,11 +245,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/docker.yaml
+++ b/pkg/userdata/ubuntu/testdata/docker.yaml
@@ -245,11 +245,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
+++ b/pkg/userdata/ubuntu/testdata/kubelet-version-without-v-prefix.yaml
@@ -243,11 +243,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-dns-servers.yaml
@@ -243,11 +243,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
+++ b/pkg/userdata/ubuntu/testdata/multiple-ssh-keys.yaml
@@ -245,11 +245,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/nutanix.yaml
+++ b/pkg/userdata/ubuntu/testdata/nutanix.yaml
@@ -245,7 +245,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/ubuntu/testdata/openstack-dualstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-dualstack.yaml
@@ -242,7 +242,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack-overwrite-cloud-config.yaml
@@ -244,7 +244,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/ubuntu/testdata/openstack.yaml
+++ b/pkg/userdata/ubuntu/testdata/openstack.yaml
@@ -244,7 +244,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/ubuntu/testdata/version-1.23.13.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.23.13.yaml
@@ -241,11 +241,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/version-1.24.7.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.24.7.yaml
@@ -240,11 +240,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/version-1.25.3.yaml
+++ b/pkg/userdata/ubuntu/testdata/version-1.25.3.yaml
@@ -240,11 +240,6 @@ write_files:
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
 
-- path: "/etc/kubernetes/cloud-config"
-  permissions: "0600"
-  content: |
-
-
 - path: "/opt/bin/setup_net_env.sh"
   permissions: "0755"
   content: |

--- a/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-mirrors.yaml
@@ -255,7 +255,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere-proxy.yaml
@@ -255,7 +255,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |

--- a/pkg/userdata/ubuntu/testdata/vsphere.yaml
+++ b/pkg/userdata/ubuntu/testdata/vsphere.yaml
@@ -245,7 +245,6 @@ write_files:
   content: |
     [Service]
     Environment="KUBELET_EXTRA_ARGS=--resolv-conf=/run/systemd/resolve/resolv.conf"
-
 - path: "/etc/kubernetes/cloud-config"
   permissions: "0600"
   content: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Machine deployment for vSphere, contains the credentials for vcenter, written explicitly. This pr removes that overwriteCloudSpec field and rely only on the OSM configs

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #https://github.com/kubermatic/kubermatic/issues/4974

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove the overwriteCloudSpec field from vSphere Machine Deployment 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
