### PR TITLE
Anexia Provider: Utilize `Creating` state instead of blocking `Create` call

### DIFF
--- a/pkg/cloudprovider/provider/anexia/helper_test.go
+++ b/pkg/cloudprovider/provider/anexia/helper_test.go
@@ -18,11 +18,9 @@ package anexia
 
 import (
 	"encoding/json"
-	"net/http"
 	"testing"
 
 	"github.com/gophercloud/gophercloud/testhelper"
-	"go.anx.io/go-anxcloud/pkg/vsphere/search"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
@@ -62,27 +60,6 @@ func getSpecsForValidationTest(t *testing.T, configCases []ConfigTestCase) []Val
 		})
 	}
 	return testCases
-}
-
-func createSearchHandler(t *testing.T, iterations int) http.HandlerFunc {
-	counter := 0
-	return func(writer http.ResponseWriter, request *http.Request) {
-		test := request.URL.Query().Get("name")
-		testhelper.AssertEquals(t, "%-TestMachine", test)
-		testhelper.TestMethod(t, request, http.MethodGet)
-		if iterations == counter {
-			encoder := json.NewEncoder(writer)
-			testhelper.AssertNoErr(t, encoder.Encode(map[string]interface{}{
-				"data": []search.VM{
-					{
-						Name:       "543053-TestMachine",
-						Identifier: TestIdentifier,
-					},
-				},
-			}))
-		}
-		counter++
-	}
 }
 
 func newConfigVarString(str string) types.ConfigVarString {

--- a/pkg/cloudprovider/provider/anexia/instance.go
+++ b/pkg/cloudprovider/provider/anexia/instance.go
@@ -28,6 +28,7 @@ import (
 )
 
 type anexiaInstance struct {
+	isCreating        bool
 	info              *info.Info
 	reservedAddresses []string
 }
@@ -85,6 +86,10 @@ func (ai *anexiaInstance) Addresses() map[string]v1.NodeAddressType {
 }
 
 func (ai *anexiaInstance) Status() instance.Status {
+	if ai.isCreating {
+		return instance.StatusCreating
+	}
+
 	if ai.info != nil {
 		if ai.info.Status == anxtypes.MachinePoweredOn {
 			return instance.StatusRunning

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -50,38 +50,6 @@ func TestAnexiaProvider(t *testing.T) {
 		server.Close()
 	})
 
-	t.Run("Test waiting for VM", func(t *testing.T) {
-		t.Parallel()
-
-		waitUntilVMIsFound := 2
-		testhelper.Mux.HandleFunc("/api/vsphere/v1/search/by_name.json", createSearchHandler(t, waitUntilVMIsFound))
-
-		providerStatus := anxtypes.ProviderStatus{}
-		ctx := createReconcileContext(context.Background(), reconcileContext{
-			Machine: &v1alpha1.Machine{
-				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
-			},
-			Status:   &providerStatus,
-			UserData: "",
-			Config:   resolvedConfig{},
-
-			ProviderData: &cloudprovidertypes.ProviderData{
-				Update: func(m *clusterv1alpha1.Machine, mod ...cloudprovidertypes.MachineModifier) error {
-					return nil
-				},
-			},
-		})
-
-		err := waitForVM(ctx, client)
-		if err != nil {
-			t.Fatal("No error was expected", err)
-		}
-
-		if providerStatus.InstanceID != TestIdentifier {
-			t.Error("Expected InstanceID to be set")
-		}
-	})
-
 	t.Run("Test provision VM", func(t *testing.T) {
 		t.Parallel()
 		testhelper.Mux.HandleFunc("/api/ipam/v1/address/reserve/ip/count.json", func(writer http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
**What this PR does / why we need it**:

The `machine-controller` calls the providers `Create` method sequentially and only starts with the provisioning of another instance after `Create` returned without any errors. This PR changes the

- `Create` method to not block until the VM provisioning has completed 
- `Get` method to check via the instance status whether `InstanceID` and `ProvisioningID` are set

and utilizes the `Creating` state until the VM is ready.

This reduces the provisioning duration of node pools with more than one replica significantly as there are now only a couple of seconds (~10s) between the provisioning starts.


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anexia: Refactor code to reduce provisioning time for node pools with multiple replicas.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
