### PR TITLE
[release/v1.54] Update filter for CentOS Linux images

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -102,12 +102,12 @@ var (
 		// Source: https://wiki.centos.org/Cloud/AWS
 		providerconfigtypes.OperatingSystemCentOS: {
 			awstypes.CPUArchitectureX86_64: {
-				description: "CentOS 7* x86_64",
+				description: "CentOS Linux 7* x86_64*",
 				// The AWS marketplace ID from CentOS Community Platform Engineering (CPE)
 				owner: "125523088429",
 			},
 			awstypes.CPUArchitectureARM64: {
-				description: "CentOS 7* aarch64",
+				description: "CentOS Linux 7* aarch64*",
 				// The AWS marketplace ID from CentOS Community Platform Engineering (CPE)
 				owner: "125523088429",
 			},

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -31,7 +31,7 @@ spec:
             folder: '/Hamburg/vm/Kubermatic-dev'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            datastore: alpha1
+            datastore: ceph-vm
             allowInsecure: true
             cpus: 2
             MemoryMB: 2048

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -31,7 +31,7 @@ spec:
             folder: '/Hamburg/vm/Kubermatic-dev'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            datastore: alpha1
+            datastore: ceph-vm
             cpus: 2
             MemoryMB: 4096
             diskSizeGB: << DISK_SIZE >>


### PR DESCRIPTION
**What this PR does / why we need it**:
CentOS changed their image names in a way our filters did not match anymore: https://wiki.centos.org/Cloud/AWS

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update CentOS AMI filter
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```