### PR TITLE
[release/v1.45] Update filter for CentOS Linux images

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -550,7 +550,7 @@ presubmits:
     labels:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
-      preset-vsphere-legacy: "true"
+      preset-vsphere: "true"
       preset-rhel: "true"
       preset-goproxy: "true"
     spec:
@@ -794,7 +794,7 @@ presubmits:
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     labels:
-      preset-vsphere-legacy: "true"
+      preset-vsphere: "true"
       preset-rhel: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
@@ -817,7 +817,7 @@ presubmits:
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     labels:
-      preset-vsphere-legacy: "true"
+      preset-vsphere: "true"
       preset-rhel: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -101,12 +101,12 @@ var (
 		// Source: https://wiki.centos.org/Cloud/AWS
 		providerconfigtypes.OperatingSystemCentOS: {
 			awstypes.CPUArchitectureX86_64: {
-				description: "CentOS 7* x86_64",
+				description: "CentOS Linux 7* x86_64*",
 				// The AWS marketplace ID from CentOS Community Platform Engineering (CPE)
 				owner: "125523088429",
 			},
 			awstypes.CPUArchitectureARM64: {
-				description: "CentOS 7* aarch64",
+				description: "CentOS Linux 7* aarch64*",
 				// The AWS marketplace ID from CentOS Community Platform Engineering (CPE)
 				owner: "125523088429",
 			},

--- a/test/e2e/provisioning/testdata/machinedeployment-nutanix.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-nutanix.yaml
@@ -27,7 +27,6 @@ spec:
             username: '<< NUTANIX_USERNAME >>'
             password: '<< NUTANIX_PASSWORD >>'
             endpoint: '<< NUTANIX_ENDPOINT >>'
-            proxyURL: '<< NUTANIX_PROXY_URL >>'
             allowInsecure: true
             clusterName: '<< NUTANIX_CLUSTER >>'
             projectName: '<< NUTANIX_PROJECT >>'

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
@@ -27,8 +27,8 @@ spec:
             templateVMName: 'machine-controller-e2e-<< OS_NAME >>'
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
-            datacenter: 'dc-1'
-            folder: '/dc-1/vm/e2e-tests'
+            datacenter: 'Hamburg'
+            folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
             datastoreCluster: 'dsc-1'

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
@@ -27,8 +27,8 @@ spec:
             templateVMName: 'machine-controller-e2e-<< OS_NAME >>'
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
-            datacenter: 'dc-1'
-            folder: '/dc-1/vm/e2e-tests'
+            datacenter: 'Hamburg'
+            folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
             datastoreCluster: 'dsc-1'

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -27,11 +27,11 @@ spec:
             templateVMName: '<< OS_NAME >>-template'
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
-            datacenter: 'dc-1'
-            folder: '/dc-1/vm/e2e-tests'
+            datacenter: 'Hamburg'
+            folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            datastore: datastore1
+            datastore: ceph-vm
             allowInsecure: true
             cpus: 2
             MemoryMB: 2048

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -27,11 +27,11 @@ spec:
             templateVMName: 'machine-controller-e2e-<< OS_NAME >>'
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
-            datacenter: 'dc-1'
-            folder: '/dc-1/vm/e2e-tests'
+            datacenter: 'Hamburg'
+            folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            datastore: HS-FreeNAS
+            datastore: ceph-vm
             cpus: 2
             MemoryMB: 4096
             diskSizeGB: << DISK_SIZE >>


### PR DESCRIPTION
**What this PR does / why we need it**:
CentOS changed their image names in a way our filters did not match anymore: https://wiki.centos.org/Cloud/AWS

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update CentOS AMI filter
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
