### PR TITLE
vSphere: only delete tags created by machine-controller

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/helper_test.go
+++ b/pkg/cloudprovider/provider/vsphere/helper_test.go
@@ -35,6 +35,10 @@ import (
 	_ "github.com/vmware/govmomi/vapi/simulator"
 )
 
+const (
+	testDatacenter = "DC0"
+)
+
 func TestResolveDatastoreRef(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -100,7 +104,7 @@ func TestResolveDatastoreRef(t *testing.T) {
 			tt.config.VSphereURL = strings.TrimSuffix(s.URL.String(), "/sdk")
 			tt.config.Username = simulator.DefaultLogin.Username()
 			tt.config.Password, _ = simulator.DefaultLogin.Password()
-			tt.config.Datacenter = "DC0"
+			tt.config.Datacenter = testDatacenter
 
 			session, err := NewSession(ctx, tt.config)
 			defer session.Logout(ctx)
@@ -218,7 +222,7 @@ func TestResolveResourcePoolRef(t *testing.T) {
 			tt.config.VSphereURL = strings.TrimSuffix(s.URL.String(), "/sdk")
 			tt.config.Username = simulator.DefaultLogin.Username()
 			tt.config.Password, _ = simulator.DefaultLogin.Password()
-			tt.config.Datacenter = "DC0"
+			tt.config.Datacenter = testDatacenter
 
 			session, err := NewSession(ctx, tt.config)
 			defer session.Logout(ctx)
@@ -334,7 +338,7 @@ func TestMachineTagging(t *testing.T) {
 				tt.config.VSphereURL = strings.TrimSuffix(c.URL().String(), "/sdk")
 				tt.config.Username = simulator.DefaultLogin.Username()
 				tt.config.Password, _ = simulator.DefaultLogin.Password()
-				tt.config.Datacenter = "DC0"
+				tt.config.Datacenter = testDatacenter
 				tt.config.AllowInsecure = true
 
 				expectedTagsAfterAttach := map[string]struct{}{}


### PR DESCRIPTION
**What this PR does / why we need it**: 
In vSphere machine tags are distinct objects. When machine-controller tags a machine it creates a new tag object and attaches it to the machine. When the machine is deleted, machine-controller deletes all the tag objects attached to the machine in order to not leave any orphaned tags behind.

The current assumption is that all tag objects on the machine are created by machine-controller and only attached to the machine that is being removed. This is probably not true in most vSphere deployments as many external systems interfacing with vSphere such as monitoring and backup tools attach tags to machines. The deletion of these external tag objects can lead to two outcomes:

1. machine-controller does not have permission to delete the tag and will crash. Nodes will not be deleted and remain in an unschedulable state indefinitely.
2. machine-controller deletes the tag object which will remove it from *all* machines it was attached to potentially wreaking havoc on a backup system or similar.

**Which issue(s) this PR fixes**:
Fixes #1433

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
