### PR TITLE
KubeVirt small cleanup: Flavor and PodAffinity

### DIFF
--- a/examples/kubevirt-machinedeployment.yaml
+++ b/examples/kubevirt-machinedeployment.yaml
@@ -38,9 +38,6 @@ spec:
               preference:
                 name: "sockets-advantage"
                 kind: "VirtualMachinePreference" # Allowed values: "VirtualMachinePreference"/"VirtualMachineClusterPreference"
-              # will be deprecated: in favor instancetype and preference
-              flavor:
-                name: "kubermatic-standard"
               template:
                 cpus: "1"
                 memory: "2048M"
@@ -49,10 +46,6 @@ spec:
                   size: "10Gi"
                   storageClassName: kubermatic-fast
             affinity:
-              # Deprecated: Use topologySpreadConstraints instead.
-              podAffinityPreset: "" # Allowed values: "", "soft", "hard"
-              # Deprecated: Use topologySpreadConstraints instead.
-              podAntiAffinityPreset: "" # Allowed values: "", "soft", "hard"
               nodeAffinityPreset:
                 type: "" # Allowed values: "", "soft", "hard"
                 key: "foo"
@@ -62,7 +55,6 @@ spec:
               - maxSkew: "1"
                 topologyKey: "kubernetes.io/hostname"
                 whenUnsatisfiable: "" # Allowed values: "DoNotSchedule", "ScheduleAnyway"
-
           # Can also be `centos`, must align with he configured registryImage above
           operatingSystem: "ubuntu"
           operatingSystemSpec:

--- a/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-kubevirt.yaml
@@ -43,14 +43,6 @@ spec:
               dnsConfig:
                 nameservers:
                   - 8.8.8.8
-            affinity:
-              podAffinityPreset: "" # Allowed values: "", "soft", "hard"
-              podAntiAffinityPreset: "" # Allowed values: "", "soft", "hard"
-              nodeAffinityPreset:
-                type: "" # Allowed values: "", "soft", "hard"
-                key: "foo"
-                values:
-                  - bar
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
A small cleanup for Flavor and PodAffinity for KubeVirt.
- Removed even the // Deprecated from the example
- Removed useless MD fields in the e2e tests (they were already have no effect on the VM)
This PR is part of KKP + dashboard + machine-controller cleanup of any existing useless code/example/doc for GA.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1492 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
