### PR TITLE
Set ownership for kubevirt provider to sig-virt

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -14,6 +14,12 @@ aliases:
     - xmudrii
     - xrstf
 
+  sig-virtualization:
+    - dermorz
+    - hdurand0710
+    - mfranczy
+    - sankalp-r
+
   # Temporary SIG to oversee changes in userdata and cloudprovider sub-directories
   # This SIG is responsible for ensuring that OSM and machine-controller are in sync
   sig-osm:

--- a/pkg/cloudprovider/provider/kubevirt/OWNERS
+++ b/pkg/cloudprovider/provider/kubevirt/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-virtualization
+
+reviewers:
+  - sig-virtualization
+
+labels:
+  - sig/virtualization
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
Signed-off-by: Moritz Bracht <mail@morz.me>

**What this PR does / why we need it**:
This relieves dependency of sig-osm for kubevirt development.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
