### PR TITLE
[release/v1.45] Use new vSphere preset

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -550,7 +550,7 @@ presubmits:
     labels:
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
-      preset-vsphere-legacy: "true"
+      preset-vsphere: "true"
       preset-rhel: "true"
       preset-goproxy: "true"
     spec:
@@ -794,7 +794,7 @@ presubmits:
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     labels:
-      preset-vsphere-legacy: "true"
+      preset-vsphere: "true"
       preset-rhel: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"
@@ -817,7 +817,7 @@ presubmits:
     error_on_eviction: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     labels:
-      preset-vsphere-legacy: "true"
+      preset-vsphere: "true"
       preset-rhel: "true"
       preset-hetzner: "true"
       preset-e2e-ssh: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR tries to restore vSphere test functionality by using the ne vSphere preset.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
