### PR TITLE
Set EvictionStrategy to external on KubeVirt VMs

### DIFF
--- a/docs/kubevirt.md
+++ b/docs/kubevirt.md
@@ -12,7 +12,7 @@ are some things you need to keep in mind:
 
 * The machine-controller will create `VMIs` that have the same name as the underlying `machine`. To
 avoid collisions, use one namespace per cluster that runs the `machine-controller`
-* EvictionStratey of `VMIs` is set to external, so VMI eviction needs to handled properly
+* EvictionStratey of `VMIs` is set to external, so VMI eviction needs to handled properly by a custom external controller or manual action
 * Service CIDR range: The CIDR ranges of the cluster that runs Kubevirt and the cluster that hosts the machine-controller must not overlap,
 otherwise routing of services that run in the kubevirt cluster won't work anymore. This is especially important for the DNS ClusterIP.
 * `clusterName` is used to [label VMs](https://github.com/kubevirt/cloud-provider-kubevirt#prerequisites) for LoadBalancer selection

--- a/docs/kubevirt.md
+++ b/docs/kubevirt.md
@@ -12,6 +12,7 @@ are some things you need to keep in mind:
 
 * The machine-controller will create `VMIs` that have the same name as the underlying `machine`. To
 avoid collisions, use one namespace per cluster that runs the `machine-controller`
+* EvictionStratey of `VMIs` is set to external, so VMI eviction needs to handled properly
 * Service CIDR range: The CIDR ranges of the cluster that runs Kubevirt and the cluster that hosts the machine-controller must not overlap,
 otherwise routing of services that run in the kubevirt cluster won't work anymore. This is especially important for the DNS ClusterIP.
 * `clusterName` is used to [label VMs](https://github.com/kubevirt/cloud-provider-kubevirt#prerequisites) for LoadBalancer selection

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -597,6 +597,8 @@ func (p *provider) newVirtualMachine(ctx context.Context, c *Config, pc *provide
 	// The secret has an ownerRef on the VMI so garbace collection will take care of cleaning up.
 	terminationGracePeriodSeconds := int64(30)
 
+	evictionStrategy := kubevirtv1.EvictionStrategyExternal
+
 	resourceRequirements := kubevirtv1.ResourceRequirements{}
 	labels := map[string]string{"kubevirt.io/vm": machine.Name}
 	//Add a common label to all VirtualMachines spawned by the same MachineDeployment (= MachineDeployment name).
@@ -652,6 +654,7 @@ func (p *provider) newVirtualMachine(ctx context.Context, c *Config, pc *provide
 					Labels:      labels,
 				},
 				Spec: kubevirtv1.VirtualMachineInstanceSpec{
+					EvictionStrategy: &evictionStrategy,
 					Networks: []kubevirtv1.Network{
 						*kubevirtv1.DefaultPodNetwork(),
 					},

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
@@ -83,3 +83,4 @@ spec:
             secretRef:
               name: udsn
           name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
@@ -75,3 +75,4 @@ spec:
             secretRef:
               name: udsn
           name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
@@ -74,3 +74,4 @@ spec:
             secretRef:
               name: udsn
           name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
@@ -73,3 +73,4 @@ spec:
             secretRef:
               name: udsn
           name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
@@ -73,3 +73,4 @@ spec:
             secretRef:
               name: udsn
           name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
@@ -74,3 +74,4 @@ spec:
             secretRef:
               name: udsn
           name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
@@ -75,3 +75,4 @@ spec:
             secretRef:
               name: udsn
           name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
@@ -110,5 +110,6 @@ spec:
             name: secondary-disks-secondarydisk0
           name: secondary-disks-secondarydisk0
         - dataVolume:
-           name: secondary-disks-secondarydisk1
+            name: secondary-disks-secondarydisk1
           name: secondary-disks-secondarydisk1
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
@@ -80,3 +80,4 @@ spec:
             secretRef:
               name: udsn
           name: cloudinitdisk
+      evictionStrategy: External


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will block automatic VMs eviction which will then need to be handled externally. #1501 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt: Set eviction strategy of VMIs to external
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
