### PR TITLE
Make CloudConfigToString a struct receiver function called String

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -591,7 +591,7 @@ func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config stri
 		},
 	}
 
-	s, err := vspheretypes.CloudConfigToString(cc)
+	s, err := cc.String()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to convert the cloud-config to string: %w", err)
 	}

--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -124,7 +124,7 @@ func (c *CloudConfig) String() (string, error) {
 }
 
 // CloudConfigToString converts CloudConfig into its formatted string representation
-// Deprecated: use struct receiver function instead.
+// Deprecated: use struct receiver function String() instead.
 func CloudConfigToString(c *CloudConfig) (string, error) {
 	funcMap := sprig.TxtFuncMap()
 	funcMap["iniEscape"] = ini.Escape

--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -105,7 +105,7 @@ type CloudConfig struct {
 	VirtualCenter map[string]*VirtualCenterConfig
 }
 
-// String converts CloudConfig into its formatted string representation
+// String converts CloudConfig into its formatted string representation.
 func (c *CloudConfig) String() (string, error) {
 	funcMap := sprig.TxtFuncMap()
 	funcMap["iniEscape"] = ini.Escape
@@ -123,7 +123,7 @@ func (c *CloudConfig) String() (string, error) {
 	return buf.String(), nil
 }
 
-// CloudConfigToString converts CloudConfig into its formatted string representation
+// CloudConfigToString converts CloudConfig into its formatted string representation.
 // Deprecated: use struct receiver function String() instead.
 func CloudConfigToString(c *CloudConfig) (string, error) {
 	funcMap := sprig.TxtFuncMap()

--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig.go
@@ -105,6 +105,26 @@ type CloudConfig struct {
 	VirtualCenter map[string]*VirtualCenterConfig
 }
 
+// String converts CloudConfig into its formatted string representation
+func (c *CloudConfig) String() (string, error) {
+	funcMap := sprig.TxtFuncMap()
+	funcMap["iniEscape"] = ini.Escape
+
+	tpl, err := template.New("cloud-config").Funcs(funcMap).Parse(cloudConfigTpl)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse the cloud config template: %w", err)
+	}
+
+	buf := &bytes.Buffer{}
+	if err := tpl.Execute(buf, c); err != nil {
+		return "", fmt.Errorf("failed to execute cloud config template: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// CloudConfigToString converts CloudConfig into its formatted string representation
+// Deprecated: use struct receiver function instead.
 func CloudConfigToString(c *CloudConfig) (string, error) {
 	funcMap := sprig.TxtFuncMap()
 	funcMap["iniEscape"] = ini.Escape

--- a/pkg/cloudprovider/provider/vsphere/types/cloudconfig_test.go
+++ b/pkg/cloudprovider/provider/vsphere/types/cloudconfig_test.go
@@ -121,7 +121,7 @@ func TestCloudConfigToString(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			s, err := CloudConfigToString(test.config)
+			s, err := test.config.String()
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->



**What type of PR is this?**

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
