### PR TITLE
Add validation for image-cloning and custom-images for kubevirt

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -20,12 +20,14 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"errors"
 	"html/template"
 	"path"
 	"reflect"
 	"testing"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	cloudprovidertesting "github.com/kubermatic/machine-controller/pkg/cloudprovider/testing"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
@@ -36,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -316,6 +319,126 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			result := getTopologySpreadConstraints(&test.config, map[string]string{"md": "test-md"})
 			if !reflect.DeepEqual(result, test.expected) {
 				t.Errorf("expected ToplogySpreadConstraint: %v, got: %v", test.expected, result)
+			}
+		})
+	}
+}
+
+func TestValidateOsImage(t *testing.T) {
+	testClient := fakectrlruntimeclient.
+		NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&cdiv1beta1.DataVolume{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "standardDV",
+				Namespace:   kubeVirtImagesNamespace,
+				Annotations: map[string]string{dataVolumeStandardImageAnnotation: "true"}},
+		},
+			&cdiv1beta1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "customDVByAdmin",
+					Namespace:   kubeVirtImagesNamespace,
+					Annotations: map[string]string{osAnnotationForCustomDisk: "ubuntu"}},
+			},
+		).Build()
+
+	tests := []struct {
+		desc        string
+		config      Config
+		expectedErr error
+	}{
+		{
+			desc: "valid osImage with cloned standard DataVolume as pvc source, cloning enabled",
+			config: Config{
+				OSImageSource: &cdiv1beta1.DataVolumeSource{
+					PVC: &cdiv1beta1.DataVolumeSourcePVC{
+						Name:      "standardDV",
+						Namespace: kubeVirtImagesNamespace,
+					},
+				},
+				AllowPVCClone: true,
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "valid osImage with cloned standard DataVolume as pvc source, cloning disabled",
+			config: Config{
+				OSImageSource: &cdiv1beta1.DataVolumeSource{
+					PVC: &cdiv1beta1.DataVolumeSourcePVC{
+						Name:      "standardDV",
+						Namespace: kubeVirtImagesNamespace,
+					},
+				},
+				AllowPVCClone: false,
+			},
+			expectedErr: errStandardImage,
+		},
+		{
+			desc: "valid osImage with custom-image-by-admin as pvc source, custom-images enabled",
+			config: Config{
+				OSImageSource: &cdiv1beta1.DataVolumeSource{
+					PVC: &cdiv1beta1.DataVolumeSourcePVC{
+						Name:      "customDVByAdmin",
+						Namespace: kubeVirtImagesNamespace,
+					},
+				},
+				AllowCustomImages: true,
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "valid osImage with custom-image-by-admin as pvc source, custom-images disabled",
+			config: Config{
+				OSImageSource: &cdiv1beta1.DataVolumeSource{
+					PVC: &cdiv1beta1.DataVolumeSourcePVC{
+						Name:      "customDVByAdmin",
+						Namespace: kubeVirtImagesNamespace,
+					},
+				},
+				AllowCustomImages: false,
+			},
+			expectedErr: errCustomImage,
+		},
+		{
+			desc: "valid osImage with custom-image-by-user as pvc source, custom-images disabled",
+			config: Config{
+				Namespace: "cluster-test",
+				OSImageSource: &cdiv1beta1.DataVolumeSource{
+					PVC: &cdiv1beta1.DataVolumeSourcePVC{
+						Name:      "customDVByUser",
+						Namespace: "cluster-test",
+					},
+				},
+				AllowCustomImages: false,
+			},
+			expectedErr: errCustomImage,
+		},
+		{
+			desc: "invalid osImage with non-existent pvc source, cloning enabled",
+			config: Config{
+				OSImageSource: &cdiv1beta1.DataVolumeSource{
+					PVC: &cdiv1beta1.DataVolumeSourcePVC{
+						Name:      "non-existent-DV",
+						Namespace: kubeVirtImagesNamespace,
+					},
+				},
+				AllowPVCClone: true,
+			},
+			expectedErr: errInvalidOsImage,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			actualErr := validateOsImage(context.Background(), &test.config, testClient)
+			if test.expectedErr != nil {
+				if !errors.Is(actualErr, test.expectedErr) {
+					t.Errorf("expected error: %q, got: %q", test.expectedErr, actualErr)
+				}
+			} else {
+				if actualErr != nil {
+					t.Errorf("expected success, but got error: %q", actualErr)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds validation for PVC osImageSource for kubevirt machines.
Using standard cloned images and custom-images are allowed only if the respective option is enabled.

- If the user tries to use a standard cloned image with image-cloning disabled, validation will fail.
- If the user tries to use a custom image with the custom image disabled, validation will fail.
- If the user tries to use a PVC source from a namespace other than the allowed ones, validation will fail.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #https://github.com/kubermatic/kubermatic/issues/11234

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```


Signed-off-by: Sankalp Rangare <sankalprangare786@gmail.com>