### PR TITLE
Allow manually configuring containerd version via CLI flag

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -84,6 +84,7 @@ var (
 	podCIDR                           string
 	nodePortRange                     string
 	nodeRegistryCredentialsSecret     string
+	nodeContainerdVersion             string
 	nodeContainerdRegistryMirrors     = containerruntime.RegistryMirrorsFlags{}
 	overrideBootstrapKubeletAPIServer string
 )
@@ -170,6 +171,7 @@ func main() {
 	flag.StringVar(&nodePauseImage, "node-pause-image", "", "Image for the pause container including tag. If not set, the kubelet default will be used: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/")
 	flag.String("node-kubelet-repository", "quay.io/kubermatic/kubelet", "[NO-OP] Repository for the kubelet container. Has no effects.")
 	flag.StringVar(&nodeContainerRuntime, "node-container-runtime", "docker", "container-runtime to deploy")
+	flag.StringVar(&nodeContainerdVersion, "node-containerd-version", "", "version of containerd to deploy")
 	flag.Var(&nodeContainerdRegistryMirrors, "node-containerd-registry-mirrors", "Configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors")
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "path to a file containing all PEM-encoded CA certificates (will be used instead of the host's certificates if set)")
 	flag.BoolVar(&nodeCSRApprover, "node-csr-approver", true, "Enable NodeCSRApprover controller to automatically approve node serving certificate requests")
@@ -240,6 +242,7 @@ func main() {
 
 	containerRuntimeOpts := containerruntime.Opts{
 		ContainerRuntime:          nodeContainerRuntime,
+		ContainerdVersion:         nodeContainerdVersion,
 		ContainerdRegistryMirrors: nodeContainerdRegistryMirrors,
 		InsecureRegistries:        nodeInsecureRegistries,
 		PauseImage:                nodePauseImage,

--- a/pkg/containerruntime/config.go
+++ b/pkg/containerruntime/config.go
@@ -31,6 +31,7 @@ import (
 
 type Opts struct {
 	ContainerRuntime          string
+	ContainerdVersion         string
 	InsecureRegistries        string
 	RegistryMirrors           string
 	RegistryCredentialsSecret string
@@ -92,6 +93,7 @@ func BuildConfig(opts Opts) (Config, error) {
 		withInsecureRegistries(insecureRegistries),
 		withRegistryMirrors(opts.ContainerdRegistryMirrors),
 		withSandboxImage(opts.PauseImage),
+		withContainerdVersion(opts.ContainerdVersion),
 	), nil
 }
 

--- a/pkg/containerruntime/containerd.go
+++ b/pkg/containerruntime/containerd.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	LegacyContainerdVersion  = "1.4"
-	DefaultContainerdVersion = "1.6"
+	LegacyContainerdVersion  = "1.4*"
+	DefaultContainerdVersion = "1.6*"
 )
 
 type Containerd struct {
@@ -123,7 +123,7 @@ runtime-endpoint: unix:///run/containerd/containerd.sock
 EOF
 
 yum install -y \
-	containerd-{{ .ContainerdVersion }}* \
+	containerd-{{ .ContainerdVersion }} \
 	yum-plugin-versionlock
 yum versionlock add containerd
 
@@ -151,7 +151,7 @@ Restart=always
 EnvironmentFile=-/etc/environment
 EOF
 
-yum install -y containerd.io-{{ .ContainerdVersion }}* yum-plugin-versionlock
+yum install -y containerd.io-{{ .ContainerdVersion }} yum-plugin-versionlock
 yum versionlock add containerd.io
 
 systemctl daemon-reload
@@ -175,7 +175,7 @@ Restart=always
 EnvironmentFile=-/etc/environment
 EOF
 
-apt-get install -y --allow-downgrades containerd.io={{ .ContainerdVersion }}*
+apt-get install -y --allow-downgrades containerd.io={{ .ContainerdVersion }}
 apt-mark hold containerd.io
 
 systemctl daemon-reload

--- a/pkg/containerruntime/containerruntime.go
+++ b/pkg/containerruntime/containerruntime.go
@@ -57,6 +57,12 @@ func withSandboxImage(image string) Opt {
 	}
 }
 
+func withContainerdVersion(version string) Opt {
+	return func(cfg *Config) {
+		cfg.ContainerdVersion = version
+	}
+}
+
 func get(containerRuntimeName string, opts ...Opt) Config {
 	cfg := Config{}
 
@@ -88,6 +94,7 @@ type Config struct {
 	SandboxImage         string                `json:",omitempty"`
 	ContainerLogMaxFiles string                `json:",omitempty"`
 	ContainerLogMaxSize  string                `json:",omitempty"`
+	ContainerdVersion    string                `json:",omitempty"`
 }
 
 // AuthConfig is a COPY of github.com/containerd/containerd/pkg/cri/config.AuthConfig.
@@ -130,6 +137,7 @@ func (cfg Config) Engine(kubeletVersion *semver.Version) Engine {
 		registryMirrors:     cfg.RegistryMirrors,
 		sandboxImage:        cfg.SandboxImage,
 		registryCredentials: cfg.RegistryCredentials,
+		version:             cfg.ContainerdVersion,
 	}
 
 	moreThan124, _ := semver.NewConstraint(">= 1.24")

--- a/pkg/containerruntime/containerruntime.go
+++ b/pkg/containerruntime/containerruntime.go
@@ -130,6 +130,7 @@ func (cfg Config) Engine(kubeletVersion *semver.Version) Engine {
 		containerLogMaxFiles: cfg.ContainerLogMaxFiles,
 		containerLogMaxSize:  cfg.ContainerLogMaxSize,
 		registryCredentials:  cfg.RegistryCredentials,
+		containerdVersion:    cfg.ContainerdVersion,
 	}
 
 	containerd := &Containerd{

--- a/pkg/containerruntime/docker.go
+++ b/pkg/containerruntime/docker.go
@@ -27,8 +27,8 @@ import (
 )
 
 const (
-	LegacyDockerContainerdVersion  = "1.4"
-	DefaultDockerContainerdVersion = "1.6"
+	LegacyDockerContainerdVersion  = "1.4*"
+	DefaultDockerContainerdVersion = "1.6*"
 	DefaultDockerVersion           = "20.10"
 	LegacyDockerVersion            = "19.03"
 )
@@ -39,6 +39,7 @@ type Docker struct {
 	containerLogMaxFiles string
 	containerLogMaxSize  string
 	registryCredentials  map[string]AuthConfig
+	containerdVersion    string
 }
 
 type DockerCfgJSON struct {
@@ -88,6 +89,10 @@ func (eng *Docker) ScriptFor(os types.OperatingSystem) (string, error) {
 		ContainerdVersion: DefaultDockerContainerdVersion,
 	}
 
+	if eng.containerdVersion != "" {
+		args.ContainerdVersion = eng.containerdVersion
+	}
+
 	switch os {
 	case types.OperatingSystemAmazonLinux2:
 		args.ContainerdVersion = LegacyDockerContainerdVersion
@@ -126,7 +131,7 @@ EOF
 
 yum install -y \
 {{- if .ContainerdVersion }}
-    containerd-{{ .ContainerdVersion }}* \
+    containerd-{{ .ContainerdVersion }} \
 {{- end }}
     docker-{{ .DockerVersion }}* \
     yum-plugin-versionlock
@@ -152,7 +157,7 @@ EOF
 yum install -y \
 {{- if .ContainerdVersion }}
     docker-ce-cli-{{ .DockerVersion }}* \
-    containerd.io-{{ .ContainerdVersion }}* \
+    containerd.io-{{ .ContainerdVersion }} \
 {{- end }}
     docker-ce-{{ .DockerVersion }}* \
     yum-plugin-versionlock
@@ -178,7 +183,7 @@ EOF
 
 apt-get install --allow-downgrades -y \
 {{- if .ContainerdVersion }}
-    containerd.io={{ .ContainerdVersion }}* \
+    containerd.io={{ .ContainerdVersion }} \
     docker-ce-cli=5:{{ .DockerVersion }}* \
 {{- end }}
     docker-ce=5:{{ .DockerVersion }}*


### PR DESCRIPTION
**What this PR does / why we need it**:
A [broken containerd release](https://github.com/containerd/containerd/pull/7838) made it impossible for our setup to provision working new nodes. This was a result of `machine-controller` automatically installing the latest `1.6*` release of `containerd` available.

This PR introduces the command line flag `--node-containerd-version` to manually pin the `containerd` version to install to a specific release.

The default for this new flag is empty, so the previously existing behavior remains intact if the flag is not specified.

**Which issue(s) this PR fixes**:
Implements partially https://github.com/kubermatic/kubeone/issues/2545

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Introduce `--node-conterainerd-version` CLI flag.
```

**Documentation**:
```documentation
NONE
```
