### PR TITLE
Allow specifying full image reference for GCP

### DIFF
--- a/pkg/cloudprovider/provider/gce/config.go
+++ b/pkg/cloudprovider/provider/gce/config.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
@@ -279,6 +280,12 @@ func (cfg *config) diskTypeDescriptor() string {
 // for the source image of an instance boot disk.
 func (cfg *config) sourceImageDescriptor() (string, error) {
 	if cfg.customImage != "" {
+		// If a full image identifier is provided, use it
+		if strings.HasPrefix("projects/", cfg.customImage) {
+			return cfg.customImage, nil
+		}
+
+		// Otherwise, make sure to properly prefix the image identifier
 		return fmt.Sprintf("global/images/%s", cfg.customImage), nil
 	}
 	project, ok := imageProjects[cfg.providerConfig.OperatingSystem]


### PR DESCRIPTION
**What this PR does / why we need it**:

We have an issue when creating ARM64-based instances on GCP:

```
An error of type = InvalidConfiguration, with message = Failed to insert instance: googleapi: Error 400: Invalid resource usage: 'Requested boot disk architecture (X86_64) is not compatible with machine type architecture (ARM64).'., invalidResourceUsage occurred 
```

It appears that the image we use is only compatible with AMD64-based instances. We would have to use another image with ARM64-based instances, which appears to be `projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts-arm64`.

We could do that by using the custom image option, but the current implementation assumes that the custom image is in the user's project. That's not the case because this image is in the global `ubuntu-os-cloud` project.

This PR ensures that we can specify custom images in other projects while making sure we don't break backwards compatibility.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Allow specifying full image reference (`project/`) for GCP
```

**Documentation**:
```documentation
NONE
```