### PR TITLE
support prow-based provider disabling

### DIFF
--- a/.prow/provider-alibaba.yaml
+++ b/.prow/provider-alibaba.yaml
@@ -34,6 +34,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAlibabaProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: alibaba
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -36,6 +36,8 @@ presubmits:
             # OperatingSystemManager does not yet support Anexia
             - name: OPERATING_SYSTEM_MANAGER
               value: "false"
+            - name: CLOUD_PROVIDER
+              value: anexia
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -33,6 +33,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAWSProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: aws
           securityContext:
             privileged: true
           resources:
@@ -61,6 +64,8 @@ presubmits:
           env:
             - name: OPERATING_SYSTEM_MANAGER
               value: "false"
+            - name: CLOUD_PROVIDER
+              value: aws
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -93,6 +98,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAWSARMProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: aws
           securityContext:
             privileged: true
           resources:
@@ -121,6 +129,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAWSEbsEncryptionEnabledProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: aws
           securityContext:
             privileged: true
           resources:
@@ -149,6 +160,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAWSFlatcarContainerdProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: aws
           securityContext:
             privileged: true
           resources:
@@ -178,6 +192,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAWSSpotInstanceProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: aws
           securityContext:
             privileged: true
           resources:
@@ -206,6 +223,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAWSSLESProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: aws
           securityContext:
             privileged: true
           resources:
@@ -234,6 +254,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAWSFlatcarCoreOSCloudInit8ProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: aws
           securityContext:
             privileged: true
           resources:
@@ -262,6 +285,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAWSCentOS8ProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: aws
           securityContext:
             privileged: true
           resources:
@@ -290,6 +316,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAWSAssumeRoleProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: aws
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -33,6 +33,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAzureProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: azure
           securityContext:
             privileged: true
           resources:
@@ -62,6 +65,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAzureCustomImageReferenceProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: azure
           securityContext:
             privileged: true
           resources:
@@ -92,6 +98,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestAzureProvisioningE2ERedhatSatellite"
+          env:
+            - name: CLOUD_PROVIDER
+              value: azure
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -32,6 +32,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestDigitalOceanProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: digitalocean
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-equinix-metal.yaml
+++ b/.prow/provider-equinix-metal.yaml
@@ -33,6 +33,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestEquinixMetalProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: metal
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -33,6 +33,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestGCEProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: gce
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -31,6 +31,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestHetznerProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: hetzner
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -15,7 +15,6 @@
 presubmits:
   - name: pull-machine-controller-e2e-kubevirt
     run_if_changed: "(pkg/cloudprovider/provider/kubevirt/|pkg/userdata)"
-    always_run: false
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     max_concurrency: 1

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -35,6 +35,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestKubevirtProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: kubevirt
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-linode.yaml
+++ b/.prow/provider-linode.yaml
@@ -33,6 +33,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestLinodeProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: linode
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -32,6 +32,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestNutanixProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: nutanix
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -33,6 +33,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestOpenstackProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: openstack
           securityContext:
             privileged: true
           resources:
@@ -62,6 +65,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestOpenstackProjectAuthProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: openstack
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-scaleway.yaml
+++ b/.prow/provider-scaleway.yaml
@@ -32,6 +32,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestScalewayProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: scaleway
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -34,6 +34,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestVMwareCloudDirectorProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: vcd
           securityContext:
             privileged: true
           resources:

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -33,6 +33,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestVsphereProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: vsphere
           securityContext:
             privileged: true
           resources:
@@ -62,6 +65,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestVsphereDatastoreClusterProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: vsphere
           securityContext:
             privileged: true
           resources:
@@ -91,6 +97,9 @@ presubmits:
             - "./hack/ci/run-e2e-tests.sh"
           args:
             - "TestVsphereResourcePoolProvisioningE2E"
+          env:
+            - name: CLOUD_PROVIDER
+              value: vsphere
           securityContext:
             privileged: true
           resources:

--- a/hack/ci/run-e2e-tests.sh
+++ b/hack/ci/run-e2e-tests.sh
@@ -19,6 +19,10 @@ set -euo pipefail
 cd $(dirname $0)/../..
 source hack/lib.sh
 
+if provider_disabled "${CLOUD_PROVIDER:-}"; then
+  exit 0
+fi
+
 function cleanup {
   set +e
 

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -242,6 +242,22 @@ check_all_deployments_ready() {
   return 0
 }
 
+pr_has_label() {
+  if [ -z "${REPO_OWNER:-}" ] || [ -z "${REPO_NAME:-}" ] || [ -z "${PULL_NUMBER:-}" ]; then
+    echo "PR check only works on CI."
+    return 1
+  fi
+
+  matched=$(curl \
+    --header "Accept: application/vnd.github+json" \
+    --silent \
+    --fail \
+    https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/pulls/$PULL_NUMBER |
+    jq --arg labelName "$1" '.labels[] | select(.name == $labelName)')
+
+  [ -n "$matched" ]
+}
+
 provider_disabled() {
   # e.g. "VSPHERE_E2E_DISABLED"
   local disableEnv="${1^^}_E2E_DISABLED"

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -291,7 +291,7 @@ func TestKubevirtProvisioningE2E(t *testing.T) {
 		t.Fatalf("Unable to run kubevirt tests, KUBEVIRT_E2E_TESTS_KUBECONFIG must be set")
 	}
 
-	selector := Not(OsSelector("ubuntu", "centos", "flatcar", "rockylinux"))
+	selector := OsSelector("ubuntu", "centos", "flatcar", "rockylinux")
 
 	params := []string{
 		fmt.Sprintf("<< KUBECONFIG_BASE64 >>=%s", safeBase64Encoding(kubevirtKubeconfig)),


### PR DESCRIPTION
**What this PR does / why we need it**:
A few weeks ago we introduced a way in Prow to disable certain cloud providers globally in our infrastructure. So intead of manually doing #1523, we can just rely on the global configuration. This PR adds support for these new `$<PROVIDER>_DISABLED` env variables and undoes the manual kubevirt changes from #1523.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
