### PR TITLE
exact string match fails, use conventional errors.Is instead

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -763,7 +763,7 @@ func (p *provider) Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine
 		return false, osErrorToTerminalError(err, "failed to get compute client")
 	}
 
-	if err := osservers.Delete(computeClient, instance.ID()).ExtractErr(); err != nil && err.Error() != "Resource not found" {
+	if err := osservers.Delete(computeClient, instance.ID()).ExtractErr(); err != nil && !errors.Is(err, &gophercloud.ErrDefault404{}) {
 		return false, osErrorToTerminalError(err, "failed to delete instance")
 	}
 
@@ -1034,7 +1034,7 @@ func (p *provider) cleanupFloatingIP(machine *clusterv1alpha1.Machine, updater c
 	if err != nil {
 		return fmt.Errorf("failed to create the networkv2 client for region %s: %w", c.Region, err)
 	}
-	if err := osfloatingips.Delete(netClient, floatingIPID).ExtractErr(); err != nil && err.Error() != "Resource not found" {
+	if err := osfloatingips.Delete(netClient, floatingIPID).ExtractErr(); err != nil && !errors.Is(err, &gophercloud.ErrDefault404{}) {
 		return fmt.Errorf("failed to delete floating ip %s: %w", floatingIPID, err)
 	}
 	if err := updater(machine, func(m *clusterv1alpha1.Machine) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug when machine-controller fails on 404 when deleting already gone floating-ip or server. 
Example failure
```
failed to delete machine at cloud provider, due to failed to clean up floating ip: failed to delete floating ip a87484bd-4ba6-4c18-8b7e-27b98606d240: Resource not found: [DELETE https://example-cloud.net:9696/v2.0/floatingips/a87484bd-4ba6-4c18-8b7e-27b98606d240], error message: {"NeutronError": {"message": "Floating IP a87484bd-4ba6-4c18-8b7e-27b98606d240 could not be found", "type": "FloatingIPNotFound", "detail": ""}}
```

Exact string match against `"Resource not found"` does not work because gophercloud v1.1.1, as well as previous versions, [return](https://github.com/gophercloud/gophercloud/blob/v1.1.1/errors.go#L193) 
```golang
 fmt.Sprintf(
        "Resource not found: [%s %s], error message: %s",
	e.Method, e.URL, e.Body,
)
``` 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Openstack IP cleanup
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
