### PR TITLE
KubeVirt export few names as public

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -331,14 +331,14 @@ func TestValidateOsImage(t *testing.T) {
 		WithObjects(&cdiv1beta1.DataVolume{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "standardDV",
-				Namespace:   kubeVirtImagesNamespace,
-				Annotations: map[string]string{dataVolumeStandardImageAnnotation: "true"}},
+				Namespace:   KubeVirtImagesNamespace,
+				Annotations: map[string]string{DataVolumeStandardImageAnnotationKey: DataVolumeStandardImageAnnotationValue}},
 		},
 			&cdiv1beta1.DataVolume{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "customDVByAdmin",
-					Namespace:   kubeVirtImagesNamespace,
-					Annotations: map[string]string{osAnnotationForCustomDisk: "ubuntu"}},
+					Namespace:   KubeVirtImagesNamespace,
+					Annotations: map[string]string{DataVolumeCustomDiskOsAnnotationKey: "ubuntu"}},
 			},
 		).Build()
 
@@ -353,7 +353,7 @@ func TestValidateOsImage(t *testing.T) {
 				OSImageSource: &cdiv1beta1.DataVolumeSource{
 					PVC: &cdiv1beta1.DataVolumeSourcePVC{
 						Name:      "standardDV",
-						Namespace: kubeVirtImagesNamespace,
+						Namespace: KubeVirtImagesNamespace,
 					},
 				},
 				AllowPVCClone: true,
@@ -366,7 +366,7 @@ func TestValidateOsImage(t *testing.T) {
 				OSImageSource: &cdiv1beta1.DataVolumeSource{
 					PVC: &cdiv1beta1.DataVolumeSourcePVC{
 						Name:      "standardDV",
-						Namespace: kubeVirtImagesNamespace,
+						Namespace: KubeVirtImagesNamespace,
 					},
 				},
 				AllowPVCClone: false,
@@ -379,7 +379,7 @@ func TestValidateOsImage(t *testing.T) {
 				OSImageSource: &cdiv1beta1.DataVolumeSource{
 					PVC: &cdiv1beta1.DataVolumeSourcePVC{
 						Name:      "customDVByAdmin",
-						Namespace: kubeVirtImagesNamespace,
+						Namespace: KubeVirtImagesNamespace,
 					},
 				},
 				AllowCustomImages: true,
@@ -392,7 +392,7 @@ func TestValidateOsImage(t *testing.T) {
 				OSImageSource: &cdiv1beta1.DataVolumeSource{
 					PVC: &cdiv1beta1.DataVolumeSourcePVC{
 						Name:      "customDVByAdmin",
-						Namespace: kubeVirtImagesNamespace,
+						Namespace: KubeVirtImagesNamespace,
 					},
 				},
 				AllowCustomImages: false,
@@ -419,7 +419,7 @@ func TestValidateOsImage(t *testing.T) {
 				OSImageSource: &cdiv1beta1.DataVolumeSource{
 					PVC: &cdiv1beta1.DataVolumeSourcePVC{
 						Name:      "non-existent-DV",
-						Namespace: kubeVirtImagesNamespace,
+						Namespace: KubeVirtImagesNamespace,
 					},
 				},
 				AllowPVCClone: true,


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Make some variable names public, so they will not be re-declared/duplicated in KKP or elsewhere.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt make some variable names public for standard and custom images.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
