### PR TITLE
Refactor vsphere tagging mechanism

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -196,6 +196,7 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	for _, tag := range rawConfig.Tags {
 		c.Tags = append(c.Tags, tags.Tag{
 			Description: tag.Description,
+			ID:          tag.ID,
 			Name:        tag.Name,
 			CategoryID:  tag.CategoryID,
 		})
@@ -229,6 +230,9 @@ func (p *provider) Validate(ctx context.Context, spec clusterv1alpha1.MachineSpe
 		tagManager := tags.NewManager(restAPISession.Client)
 		klog.V(3).Info("Found tags")
 		for _, tag := range config.Tags {
+			if tag.ID == "" {
+				return fmt.Errorf("one of the tags id is empty")
+			}
 			if tag.Name == "" {
 				return fmt.Errorf("one of the tags name is empty")
 			}
@@ -338,8 +342,8 @@ func (p *provider) create(ctx context.Context, machine *clusterv1alpha1.Machine,
 		return nil, machineInvalidConfigurationTerminalError(fmt.Errorf("failed to create cloned vm: '%w'", err))
 	}
 
-	if err := createAndAttachTags(ctx, config, virtualMachine); err != nil {
-		return nil, fmt.Errorf("failed create and attach tags: %w", err)
+	if err := attachTags(ctx, config, virtualMachine); err != nil {
+		return nil, fmt.Errorf("failed to attach tags: %w", err)
 	}
 
 	if pc.OperatingSystem != providerconfigtypes.OperatingSystemFlatcar {
@@ -400,7 +404,7 @@ func (p *provider) Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine
 		return false, fmt.Errorf("failed to get instance from vSphere: %w", err)
 	}
 
-	if err := deleteTags(ctx, config, virtualMachine); err != nil {
+	if err := detachTags(ctx, config, virtualMachine); err != nil {
 		return false, fmt.Errorf("failed to delete tags: %w", err)
 	}
 

--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -50,6 +50,7 @@ type RawConfig struct {
 // Tag represents vsphere tag.
 type Tag struct {
 	Description string `json:"description,omitempty"`
+	ID          string `json:"id"`
 	Name        string `json:"name"`
 	CategoryID  string `json:"categoryID"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When a new tag is being added to a vsphere machine deployment, a new tag is being created(if it didn't exist) and assign it to the machine. Once the machine is cleaned up, machine controller would simply delete that tag. Such a scenario is implemented in different cloud provider. However, vSphere tags are kinda different from a structure perspective, as tags must first belong to a tag category and then they can be assigned. In addition to that, tags can from different categories can be shared across different inventory resources. 

With that being said, if a machine being cleaned up and one tag is assigned to another VM, this tag will be lost. Also, if tags are created manually be users and assign across different resources, machine controller should never delete any resources which is not managed by it. 

This PR changes this behaviour to either attach tags on VMs or detach them in case of machine cleanups instead of deleting or creating those tags. 
  
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind api-change
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:

/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stop creating and deleting vSphere tags unconditionally in machine controller.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
