### PR TITLE
Enable rockylinux and flatcar tests in vsphere

### DIFF
--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -854,7 +854,7 @@ func getVSphereTestParams(t *testing.T) []string {
 func TestVsphereProvisioningE2E(t *testing.T) {
 	t.Parallel()
 
-	selector := Not(OsSelector("amzn2", "rockylinux", "flatcar"))
+	selector := Not(OsSelector("amzn2", "centos"))
 	params := getVSphereTestParams(t)
 
 	runScenarios(t, selector, params, VSPhereManifest, fmt.Sprintf("vs-%s", *testRunIdentifier))

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -57,9 +57,9 @@ var (
 
 	vSphereOSImageTemplates = map[string]string{
 		string(providerconfigtypes.OperatingSystemCentOS):     "kkp-centos-7",
-		string(providerconfigtypes.OperatingSystemFlatcar):    "kkp-flatcar-3033.2.2",
+		string(providerconfigtypes.OperatingSystemFlatcar):    "kkp-flatcar-3139.2.0",
 		string(providerconfigtypes.OperatingSystemRHEL):       "kkp-rhel-8.6",
-		string(providerconfigtypes.OperatingSystemRockyLinux): "kkp-rockylinux-8",
+		string(providerconfigtypes.OperatingSystemRockyLinux): "kkp-rockylinux-8.5",
 		string(providerconfigtypes.OperatingSystemUbuntu):     "kkp-ubuntu-22.04",
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables a subset of tests for the os images in vSphere for the new infrastructure. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
