### PR TITLE
Make ID an optional field for vSphere tags

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -226,11 +226,8 @@ func (p *provider) Validate(ctx context.Context, spec clusterv1alpha1.MachineSpe
 		tagManager := tags.NewManager(restAPISession.Client)
 		klog.V(3).Info("Found tags")
 		for _, tag := range config.Tags {
-			if tag.ID == "" {
-				return fmt.Errorf("one of the tags id is empty")
-			}
-			if tag.Name == "" {
-				return fmt.Errorf("one of the tags name is empty")
+			if tag.ID == "" && tag.Name == "" {
+				return fmt.Errorf("either tag id or name must be specified")
 			}
 			if tag.CategoryID == "" {
 				return fmt.Errorf("one of the tags category is empty")

--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -50,8 +50,8 @@ type RawConfig struct {
 // Tag represents vsphere tag.
 type Tag struct {
 	Description string `json:"description,omitempty"`
-	ID          string `json:"id"`
-	Name        string `json:"name"`
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name,omitempty"`
 	CategoryID  string `json:"categoryID"`
 }
 


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
Either ID or a combination of Name and Category ID can be used to uniquely determine a tag.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind design

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VSphere tags can use name or ID as the unique identifier
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
