### PR TITLE
[release/v1.54] Fix Flatcar network issues when IPAM is not used

### DIFF
--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -170,7 +170,7 @@ const userDataIgnitionTemplate = `passwd:
         {{end}}
 {{- end }}
 
-{{- if .ProviderSpec.Network }}
+{{- if .ProviderSpec.Network.IsStaticIPConfig }}
 networkd:
   units:
     - name: static-nic.network
@@ -544,7 +544,7 @@ users:
 
 coreos:
   units:
-{{- if .ProviderSpec.Network }}
+{{- if .ProviderSpec.Network.IsStaticIPConfig }}
   - name: static-nic.network
     content: |
       [Match]


### PR DESCRIPTION
**What this PR does / why we need it**:

We have an issue where Flatcar nodes are not joining the cluster because the network configuration is broken. This happens only for machines that have `.ProviderSpec.Network.IPFamily` set (e.g. to `IPv4`). In such case, we try to configure IPAM on that node, however, in many cases IPAM is not used at all. This breaks the network configuration and usually that node doesn't have network connectivity at all.

This PR is supposed to fix that issue by configuring IPAM only if IPAM-related parameters are provided. This fix is already present on the `main` branch.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

OSM doesn't support IPAM and is not affected by this issue.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix an issue with Flatcar nodes not getting provisioned properly if `.ProviderSpec.Network.IPFamily` is set but IPAM is not configured/used
```

**Documentation**:
```documentation
NONE
```