### PR TITLE
Always use latest OSM image in e2e tests

### DIFF
--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   - name: pull-machine-controller-e2e-azure
-    always_run: true
+    run_if_changed: "(pkg/cloudprovider/provider/azure/|pkg/userdata)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     labels:

--- a/examples/operating-system-manager.yaml
+++ b/examples/operating-system-manager.yaml
@@ -974,8 +974,7 @@ spec:
     spec:
       serviceAccountName: operating-system-manager-webhook
       containers:
-        # TODO: Update this to a semver tag before release.
-        - image: quay.io/kubermatic/operating-system-manager:8688a1fde001705f4c0b394ed2f4ff4a292b20a9
+        - image: quay.io/kubermatic/operating-system-manager:latest
           imagePullPolicy: IfNotPresent
           name: webhook
           command:
@@ -1303,8 +1302,7 @@ spec:
     spec:
       serviceAccountName: operating-system-manager
       containers:
-        # TODO: Update this to a semver tag before release.
-        - image: quay.io/kubermatic/operating-system-manager:8688a1fde001705f4c0b394ed2f4ff4a292b20a9
+        - image: quay.io/kubermatic/operating-system-manager:latest
           imagePullPolicy: IfNotPresent
           name: operating-system-manager
           command:

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -33,9 +33,9 @@ var (
 	scenarios = buildScenarios()
 
 	versions = []*semver.Version{
-		semver.MustParse("v1.24.9"),
-		semver.MustParse("v1.25.5"),
-		semver.MustParse("v1.26.0"),
+		semver.MustParse("v1.24.10"),
+		semver.MustParse("v1.25.6"),
+		semver.MustParse("v1.26.1"),
 	}
 
 	operatingSystems = []providerconfigtypes.OperatingSystem{


### PR DESCRIPTION
**What this PR does / why we need it**:
The E2E tests that we run in machine-controller should always be in sync with the latest state in OSM. This helps us avoid manually updating the image tag for testing OSM changes.

We also don't need to run tests on Azure unconditionally.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
