### PR TITLE
Use AWS spot instances for tests that always run

### DIFF
--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -14,7 +14,7 @@
 
 presubmits:
   - name: pull-machine-controller-e2e-aws
-    always_run: true
+    run_if_changed: "(pkg/cloudprovider/provider/aws/|pkg/userdata)"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     labels:
@@ -45,7 +45,7 @@ presubmits:
             limits:
               memory: 7Gi
 
-  - name: pull-machine-controller-e2e-aws-legacy-userdata
+  - name: pull-machine-controller-e2e-aws-spot-instance-legacy-userdata
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
@@ -69,7 +69,7 @@ presubmits:
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
-            - "TestAWSProvisioningE2E"
+            - "TestAWSSpotInstanceProvisioningE2E"
           securityContext:
             privileged: true
           resources:
@@ -141,39 +141,8 @@ presubmits:
             limits:
               memory: 7Gi
 
-  - name: pull-machine-controller-e2e-aws-flatcar-containerd
-    run_if_changed: "(pkg/cloudprovider/provider/aws/|pkg/userdata)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
-    labels:
-      preset-aws: "true"
-      preset-hetzner: "true"
-      preset-e2e-ssh: "true"
-      preset-goproxy: "true"
-      preset-kind-volume-mounts: "true"
-      preset-docker-mirror: "true"
-      preset-kubeconfig-ci: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          command:
-            - "./hack/ci/run-e2e-tests.sh"
-          args:
-            - "TestAWSFlatcarContainerdProvisioningE2E"
-          env:
-            - name: CLOUD_PROVIDER
-              value: aws
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 7Gi
-              cpu: 2
-            limits:
-              memory: 7Gi
-
   - name: pull-machine-controller-e2e-aws-spot-instance
-    run_if_changed: "(pkg/cloudprovider/provider/aws/|pkg/userdata)"
+    always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     labels:

--- a/pkg/cloudprovider/provider/anexia/instance_test.go
+++ b/pkg/cloudprovider/provider/anexia/instance_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/testhelper"
-
 	"go.anx.io/go-anxcloud/pkg/vsphere/info"
+
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -34,7 +34,6 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go"
-
 	gocache "github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 

--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -25,9 +25,10 @@ import (
 	"reflect"
 	"testing"
 
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
 	cloudprovidertesting "github.com/kubermatic/machine-controller/pkg/cloudprovider/testing"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
-	kubevirtv1 "kubevirt.io/api/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"


### PR DESCRIPTION
**What this PR does / why we need it**:
We run tests on AWS unconditionally, for E2E/sanity testing, which covers legacy userdata and OSM userdata testing. We should rely on spot instances for these tests for cost-cutting purposes.

A small downside of this is that we'll have to make adjustments in the code if we can't match the spot pricing from AWS. But imo it's still worth it.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:
The code changes are the result of running `gimps` on this repo. I just figured out that we don't have a job to verify imports in this repo. 

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
