### PR TITLE
Add providerID support for cloud providers

### DIFF
--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -403,9 +403,8 @@ func (d *linodeInstance) ID() string {
 	return strconv.Itoa(d.linode.ID)
 }
 
-// TODO: Implement once we start supporting Linode CCM.
 func (d *linodeInstance) ProviderID() string {
-	return ""
+	return fmt.Sprintf("linode://%s", d.ID())
 }
 
 func (d *linodeInstance) Addresses() map[string]v1.NodeAddressType {

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -86,9 +86,8 @@ func (nutanixServer Server) ID() string {
 	return nutanixServer.id
 }
 
-// NB: Nutanix doesn't have a CCM.
 func (nutanixServer Server) ProviderID() string {
-	return ""
+	return fmt.Sprintf("nutanix://%s", nutanixServer.ID())
 }
 
 func (nutanixServer Server) Addresses() map[string]corev1.NodeAddressType {

--- a/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
@@ -120,9 +120,8 @@ func (s Server) ID() string {
 	return s.id
 }
 
-// TODO: Implement once we start supporting vCloud Director CCM.
 func (s Server) ProviderID() string {
-	return ""
+	return fmt.Sprintf("vmware-cloud-director://%s", s.ID())
 }
 
 func (s Server) Addresses() map[string]corev1.NodeAddressType {


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on the CCM implementations and the information provided [here](https://github.com/kubermatic/machine-controller/issues/1552#issuecomment-1418706484) for VCD. I've implemented the providerID methods for VMware Cloud Director, Nutanix, and Linode. 

One drawback of not having providerID was that the cluster auto-scaler wouldn't work for these machines.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for finding nodes by providerID for VMware Cloud Director, Nutanix, and linode.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
