### PR TITLE
Skip validation for MachineDeployments and Machines that are marked for deletion

### DIFF
--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -56,6 +56,11 @@ func (ad *admissionData) mutateMachines(ctx context.Context, ar admissionv1.Admi
 	// as well, since on the CREATE request for machines, there is only Metadata.GenerateName set
 	// so we can't default it initially.
 	if ar.Operation == admissionv1.Update {
+		// Validation is not required if the Machine is marked for deletion.
+		if machine.DeletionTimestamp != nil {
+			return nil, nil
+		}
+
 		oldMachine := clusterv1alpha1.Machine{}
 		if err := json.Unmarshal(ar.OldObject.Raw, &oldMachine); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal OldObject: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
It's not wise to apply validation webhooks when a resource is marked for deletion. Any misconfiguration might mean that the resource is stuck in deletion forever. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
