### PR TITLE
Increase default timeout for OpenStack provider

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -57,6 +57,7 @@ import (
 const (
 	floatingIPReleaseFinalizer = "kubermatic.io/release-openstack-floating-ip"
 	floatingIPIDAnnotationKey  = "kubermatic.io/release-openstack-floating-ip"
+	clientTimeout              = 1 * time.Minute
 )
 
 // clientGetterFunc returns an OpenStack client.
@@ -344,7 +345,10 @@ func getClient(c *Config) (*gophercloud.ProviderClient, error) {
 	}
 	if pc != nil {
 		// use the util's HTTP client to benefit, among other things, from its CA bundle.
-		pc.HTTPClient = cloudproviderutil.HTTPClientConfig{LogPrefix: "[OpenStack API]"}.New()
+		pc.HTTPClient = cloudproviderutil.HTTPClientConfig{
+			LogPrefix: "[OpenStack API]",
+			Timeout:   clientTimeout,
+		}.New()
 	}
 
 	err = goopenstack.Authenticate(pc, opts)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the timeout for the OpenStack client defaults to 15 seconds which is quite low. Self-hosted OpenStack environments might take more time than usual based on the networking configuration. Since we always authenticate before performing actions it's fine to increase the default timeout a bit.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default timeout for OpenStack client has been increased to 300 seconds.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
