### PR TITLE
Anexia Provider: Postpone machine cleanup when instance is still being created

### DIFF
--- a/pkg/cloudprovider/provider/anexia/instance.go
+++ b/pkg/cloudprovider/provider/anexia/instance.go
@@ -29,6 +29,7 @@ import (
 
 type anexiaInstance struct {
 	isCreating        bool
+	isDeleting        bool
 	info              *info.Info
 	reservedAddresses []string
 }
@@ -86,6 +87,9 @@ func (ai *anexiaInstance) Addresses() map[string]v1.NodeAddressType {
 }
 
 func (ai *anexiaInstance) Status() instance.Status {
+	if ai.isDeleting {
+		return instance.StatusDeleting
+	}
 	if ai.isCreating {
 		return instance.StatusCreating
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a race condition in the Anexia provider Cleanup method - introduced in https://github.com/kubermatic/machine-controller/pull/1483 - which occurs when a machine is deleted before the instance has been created.


**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anexia Provider: fixed race condition in `Cleanup` method
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```