### PR TITLE
Add metrics for provisioning nodes

### DIFF
--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -155,12 +155,19 @@ type KubeconfigProvider interface {
 // MetricsCollection is a struct of all metrics used in
 // this controller.
 type MetricsCollection struct {
-	Workers prometheus.Gauge
-	Errors  prometheus.Counter
+	Workers        prometheus.Gauge
+	Errors         prometheus.Counter
+	Provisioning   prometheus.Histogram
+	Deprovisioning prometheus.Histogram
 }
 
 func (mc *MetricsCollection) MustRegister(registerer prometheus.Registerer) {
-	registerer.MustRegister(mc.Errors, mc.Workers)
+	registerer.MustRegister(
+		mc.Errors,
+		mc.Workers,
+		mc.Provisioning,
+		mc.Deprovisioning,
+	)
 }
 
 func Add(
@@ -458,6 +465,9 @@ func (r *Reconciler) ensureMachineHasNodeReadyCondition(machine *clusterv1alpha1
 			return nil
 		}
 	}
+
+	r.metrics.Provisioning.Observe(time.Until(machine.CreationTimestamp.Time).Abs().Seconds())
+
 	return r.updateMachine(machine, func(m *clusterv1alpha1.Machine) {
 		m.Status.Conditions = append(m.Status.Conditions, corev1.NodeCondition{Type: corev1.NodeReady,
 			Status: corev1.ConditionTrue,
@@ -595,7 +605,13 @@ func (r *Reconciler) deleteMachine(ctx context.Context, prov cloudprovidertypes.
 		return nil, err
 	}
 
-	return nil, r.deleteNodeForMachine(ctx, nodes, machine)
+	if err := r.deleteNodeForMachine(ctx, nodes, machine); err != nil {
+		return nil, err
+	}
+
+	r.metrics.Deprovisioning.Observe(time.Until(machine.DeletionTimestamp.Time).Abs().Seconds())
+
+	return nil, nil
 }
 
 func (r *Reconciler) retrieveNodesRelatedToMachine(ctx context.Context, machine *clusterv1alpha1.Machine) ([]*corev1.Node, error) {

--- a/pkg/controller/machine/metrics.go
+++ b/pkg/controller/machine/metrics.go
@@ -50,6 +50,16 @@ func NewMachineControllerMetrics() *MetricsCollection {
 			Name: metricsPrefix + "errors_total",
 			Help: "The total number or unexpected errors the controller encountered",
 		}),
+		Provisioning: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    metricsPrefix + "provisioning_time_seconds",
+			Help:    "Histogram of times spent from creating a Machine to ready state in the cluster",
+			Buckets: prometheus.ExponentialBuckets(32, 1.5, 10),
+		}),
+		Deprovisioning: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    metricsPrefix + "deprovisioning_time_seconds",
+			Help:    "Histogram of times spent from deleting a Machine to be removed from cluster and cloud provider",
+			Buckets: prometheus.ExponentialBuckets(32, 1.5, 10),
+		}),
 	}
 
 	// Set default values, so that these metrics always show up


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds 2 new buckets to the `/metrics` endpoint about provisioning

- machine_controller_provisioning_time_seconds 
- machine_controller_deprovisioning_time_seconds

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1332

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

As previously discussed in the ticket #1332 here is our announced PR

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added machine_controller_provisioning_time_seconds and machine_controller_deprovisioning_time_seconds metrics to the machine controller
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
