### PR TITLE
Backport metrics node provisioning to v1.54

### DIFF
--- a/pkg/controller/machine/machine_controller.go
+++ b/pkg/controller/machine/machine_controller.go
@@ -467,7 +467,7 @@ func (r *Reconciler) ensureMachineHasNodeReadyCondition(machine *clusterv1alpha1
 		}
 	}
 
-	r.metrics.Provisioning.Observe(time.Until(machine.CreationTimestamp.Time).Abs().Seconds())
+	r.metrics.Provisioning.Observe(time.Since(machine.CreationTimestamp.Time).Seconds())
 
 	return r.updateMachine(machine, func(m *clusterv1alpha1.Machine) {
 		m.Status.Conditions = append(m.Status.Conditions, corev1.NodeCondition{Type: corev1.NodeReady,
@@ -610,7 +610,7 @@ func (r *Reconciler) deleteMachine(ctx context.Context, prov cloudprovidertypes.
 		return nil, err
 	}
 
-	r.metrics.Deprovisioning.Observe(time.Until(machine.DeletionTimestamp.Time).Abs().Seconds())
+	r.metrics.Deprovisioning.Observe(time.Since(machine.DeletionTimestamp.Time).Seconds())
 
 	return nil, nil
 }

--- a/pkg/controller/machine/metrics.go
+++ b/pkg/controller/machine/metrics.go
@@ -50,6 +50,16 @@ func NewMachineControllerMetrics() *MetricsCollection {
 			Name: metricsPrefix + "errors_total",
 			Help: "The total number or unexpected errors the controller encountered",
 		}),
+		Provisioning: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    metricsPrefix + "provisioning_time_seconds",
+			Help:    "Histogram of times spent from creating a Machine to ready state in the cluster",
+			Buckets: prometheus.ExponentialBuckets(32, 1.5, 10),
+		}),
+		Deprovisioning: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    metricsPrefix + "deprovisioning_time_seconds",
+			Help:    "Histogram of times spent from deleting a Machine to be removed from cluster and cloud provider",
+			Buckets: prometheus.ExponentialBuckets(32, 1.5, 10),
+		}),
 	}
 
 	// Set default values, so that these metrics always show up


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds 2 new buckets to the /metrics endpoint about provisioning

- machine_controller_provisioning_time_seconds
- machine_controller_deprovisioning_time_seconds

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1574 

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

`golang v1.18` does not have support for `.Abs()` which broke the backport to `release/v1.54` triggered in #1572 

This PR fixes this by using `time.Since()`

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added machine_controller_provisioning_time_seconds and machine_controller_deprovisioning_time_seconds metrics to the machine controller
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
