### PR TITLE
[release/v1.54] Anexia Provider: configure rpc-statd service as kubelet dependency

### DIFF
--- a/pkg/userdata/flatcar/provider.go
+++ b/pkg/userdata/flatcar/provider.go
@@ -637,6 +637,12 @@ coreos:
         [Unit]
         Requires=download-script.service
         After=download-script.service
+{{- if eq .CloudProviderName "anexia" }}
+    - name: 50-rpc-statd.conf
+      content: |
+        [Unit]
+        Wants=rpc-statd.service
+{{- end }}
     content: |
 {{ kubeletSystemdUnit .ContainerRuntimeName .KubeletVersion .KubeletCloudProviderName .MachineSpec.Name .DNSIPs .ExternalCloudProvider .ProviderSpec.Network.GetIPFamily .PauseImage .MachineSpec.Taints .ExtraKubeletFlags false | indent 6 }}
 

--- a/pkg/userdata/flatcar/testdata/cloud-init_v1.22.7.yaml
+++ b/pkg/userdata/flatcar/testdata/cloud-init_v1.22.7.yaml
@@ -97,6 +97,10 @@ coreos:
         [Unit]
         Requires=download-script.service
         After=download-script.service
+    - name: 50-rpc-statd.conf
+      content: |
+        [Unit]
+        Wants=rpc-statd.service
     content: |
       [Unit]
       After=docker.service

--- a/pkg/userdata/flatcar/testdata/cloud-init_v1.23.5.yaml
+++ b/pkg/userdata/flatcar/testdata/cloud-init_v1.23.5.yaml
@@ -97,6 +97,10 @@ coreos:
         [Unit]
         Requires=download-script.service
         After=download-script.service
+    - name: 50-rpc-statd.conf
+      content: |
+        [Unit]
+        Wants=rpc-statd.service
     content: |
       [Unit]
       After=docker.service

--- a/pkg/userdata/flatcar/testdata/cloud-init_v1.24.0.yaml
+++ b/pkg/userdata/flatcar/testdata/cloud-init_v1.24.0.yaml
@@ -97,6 +97,10 @@ coreos:
         [Unit]
         Requires=download-script.service
         After=download-script.service
+    - name: 50-rpc-statd.conf
+      content: |
+        [Unit]
+        Wants=rpc-statd.service
     content: |
       [Unit]
       After=containerd.service


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubermatic/machine-controller/pull/1553




**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enables "rpc-statd" service on new Anexia Machines using Flatcar with cloud-init to enable NFS functionality required by Anexia CSI driver.
```


