### PR TITLE
Support Private IP for Hetzner Cloud

### DIFF
--- a/examples/hetzner-machinedeployment.yaml
+++ b/examples/hetzner-machinedeployment.yaml
@@ -53,6 +53,10 @@ spec:
             # Optional: network IDs or names
             networks:
               - "<< YOUR_NETWORK >>"
+            # Optional: assignPublicIPv4 whether a public ipv4 should be assigned or not
+            assignPublicIPv4: true
+            # Optional: assignPublicIPv4 whether an ipv6 should be assigned or not
+            assignPublicIPv6: true
             # Optional: firewall IDs or names
             firewalls:
               - "<< YOUR_FIREWALL >>"

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -249,7 +249,7 @@ func (p *provider) Validate(ctx context.Context, spec clusterv1alpha1.MachineSpe
 		}
 	}
 
-	if c.AssignIPv4 == false && c.AssignIPv6 == false && len(c.Networks) < 1 {
+	if !c.AssignIPv4 && !c.AssignIPv6 && len(c.Networks) < 1 {
 		return errors.New("server should have either a public ipv4, ipv6 or dedicated network")
 	}
 

--- a/pkg/cloudprovider/provider/hetzner/types/types.go
+++ b/pkg/cloudprovider/provider/hetzner/types/types.go
@@ -31,6 +31,8 @@ type RawConfig struct {
 	Networks             []providerconfigtypes.ConfigVarString `json:"networks"`
 	Firewalls            []providerconfigtypes.ConfigVarString `json:"firewalls"`
 	Labels               map[string]string                     `json:"labels,omitempty"`
+	AssignPublicIPv4     providerconfigtypes.ConfigVarBool     `json:"assignPublicIPv4,omitempty"`
+	AssignPublicIPv6     providerconfigtypes.ConfigVarBool     `json:"assignPublicIPv6,omitempty"`
 }
 
 func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for disabling the allocation and assignment of public IPv4 and IPv6 by default. Two new fields are introduced(`assignPublicIPv4` and `assignPublicIPv6`) when set, the values are gonna be set and propagated to the hetzner vms. If those are not set, the default behaviour is assigning public IPs. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support Public IPs assignments for Hetzner cloud 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
