### PR TITLE
adjust VPC to the new one after we recently switched AWS accounts

### DIFF
--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -80,8 +80,7 @@ ami: ""
 # When not set a 'kubernetes-v1' security group will get created
 securityGroupIDs:
 - ""
-# name of the instance profile to use.
-# When not set a 'kubernetes-v1' instance profile will get created
+# name of the instance profile to use, required.
 instanceProfile : ""
 
 # instance tags ("KubernetesCluster": "my-cluster" is a required tag.

--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -57,7 +57,7 @@ region: "eu-central-1"
 # avaiability zone for the instance
 availabilityZone: "eu-central-1a"
 # vpc id for the instance
-vpcId: "vpc-819f62e9"
+vpcId: "vpc-079f7648481a11e77"
 # subnet id for the instance
 subnetId: "subnet-2bff4f43"
 # enable public IP assignment, default is true

--- a/examples/aws-machinedeployment.yaml
+++ b/examples/aws-machinedeployment.yaml
@@ -52,7 +52,7 @@ spec:
                 key: secretAccessKey
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             subnetId: "subnet-2bff4f43"
             instanceType: "t2.micro"
             instanceProfile: "kubernetes-v1"

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/clusterv1alpha1machineWithProviderConfig/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/clusterv1alpha1machineWithProviderConfig/aws.yaml
@@ -27,7 +27,7 @@ spec:
         subnetId: subnet-2bff4f43
         tags:
           KubernetesCluster: 6qsm86c2d
-        vpcId: vpc-819f62e9
+        vpcId: vpc-079f7648481a11e77
       operatingSystem: flatcar
       operatingSystemSpec:
         disableAutoUpdate: true

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/machinesv1alpha1machine/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/machinesv1alpha1machine/aws.yaml
@@ -16,7 +16,7 @@ spec:
       secretAccessKey: "val"
       region: "eu-central-1"
       availabilityZone: "eu-central-1a"
-      vpcId: "vpc-819f62e9"
+      vpcId: "vpc-079f7648481a11e77"
       subnetId: "subnet-2bff4f43"
       instanceType: "t2.micro"
       diskSize: 50

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/aws.yaml
@@ -22,7 +22,7 @@ spec:
         subnetId: subnet-2bff4f43
         tags:
           KubernetesCluster: 6qsm86c2d
-        vpcId: vpc-819f62e9
+        vpcId: vpc-079f7648481a11e77
       operatingSystem: flatcar
       operatingSystemSpec:
         disableAutoUpdate: true

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machineWithProviderConfig/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machineWithProviderConfig/aws.yaml
@@ -30,7 +30,7 @@ spec:
         subnetId: subnet-2bff4f43
         tags:
           KubernetesCluster: 6qsm86c2d
-        vpcId: vpc-819f62e9
+        vpcId: vpc-079f7648481a11e77
       operatingSystem: flatcar
       operatingSystemSpec:
         disableAutoUpdate: true

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
@@ -30,7 +30,7 @@ spec:
             secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             instanceType: "a1.medium"
             instanceProfile: "kubernetes-v1"
             diskSize: 50
@@ -38,7 +38,7 @@ spec:
             ebsVolumeEncrypted: false
             ami: "<< AMI >>"
             securityGroupIDs:
-              - "sg-a2c195ca"
+              - "sg-0f1f62df28fb378b7"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-ebs-encryption-enabled.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-ebs-encryption-enabled.yaml
@@ -30,14 +30,14 @@ spec:
             secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             instanceType: "t2.medium"
             instanceProfile: "kubernetes-v1"
             diskSize: 50
             diskType: "gp2"
             ebsVolumeEncrypted: true
             securityGroupIDs:
-              - "sg-a2c195ca"
+              - "sg-0f1f62df28fb378b7"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
@@ -30,7 +30,7 @@ spec:
             secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             instanceType: "t2.medium"
             instanceProfile: "kubernetes-v1"
             diskSize: 50
@@ -42,7 +42,7 @@ spec:
               maxPrice: "<< MAX_PRICE >>"
               persistentRequest: false
             securityGroupIDs:
-              - "sg-a2c195ca"
+              - "sg-0f1f62df28fb378b7"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
@@ -32,7 +32,7 @@ spec:
             assumeRoleExternalID: "<< AWS_ASSUME_ROLE_EXTERNAL_ID >>"
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             instanceType: "t2.medium"
             instanceProfile: "kubernetes-v1"
             diskSize: 50
@@ -40,7 +40,7 @@ spec:
             ebsVolumeEncrypted: false
             ami: "<< AMI >>"
             securityGroupIDs:
-              - "sg-a2c195ca"
+              - "sg-0f1f62df28fb378b7"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently changed the AWS account in which E2E tests are executed, so we need to adjust the VPC ID as well.

The documentation for the instance profile was wrong, since #412 we do not create it automatically anymore. So I had to manually create it by

* creating an IAM role as shown in the deleted code of  #412
* add the two AWS managed policies to that role
* then, because I could not figure out how to do it via the web console, create the instance profile and attach the role to it:
    ```
    aws iam create-instance-profile --instance-profile-name kubernetes-v1
    aws iam add-role-to-instance-profile --instance-profile-name kubernetes-v1 --role-name kubernetes-v1
    ```

**What type of PR is this?**
/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
