### PR TITLE
[release/v1.55] Fix cluster-exposer branch / AWS Account

### DIFF
--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -57,7 +57,7 @@ region: "eu-central-1"
 # avaiability zone for the instance
 availabilityZone: "eu-central-1a"
 # vpc id for the instance
-vpcId: "vpc-819f62e9"
+vpcId: "vpc-079f7648481a11e77"
 # subnet id for the instance
 subnetId: "subnet-2bff4f43"
 # enable public IP assignment, default is true

--- a/examples/aws-machinedeployment.yaml
+++ b/examples/aws-machinedeployment.yaml
@@ -52,7 +52,7 @@ spec:
                 key: secretAccessKey
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             subnetId: "subnet-2bff4f43"
             instanceType: "t2.micro"
             instanceProfile: "kubernetes-v1"

--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -260,7 +260,7 @@ spec:
           command:
             - /usr/local/bin/webhook
             - -logtostderr
-            - -v=6
+            - -v=4
             - -use-osm=true
             - -namespace=kube-system
             - -listen-address=0.0.0.0:9876

--- a/examples/operating-system-manager.yaml
+++ b/examples/operating-system-manager.yaml
@@ -1083,7 +1083,7 @@ spec:
           command:
             - /usr/local/bin/webhook
             - -logtostderr
-            - -v=6
+            - -v=4
             - -namespace=kube-system
           volumeMounts:
             - name: operating-system-manager-admission-cert
@@ -1385,7 +1385,7 @@ spec:
           command:
             - /usr/local/bin/osm-controller
             - -logtostderr
-            - -v=5
+            - -v=4
             - -worker-count=5
             - -cluster-dns=10.10.10.10
             - -metrics-address=0.0.0.0:8080

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -163,7 +163,7 @@ if [ -z "${DISABLE_CLUSTER_EXPOSER:-}" ]; then
     cd /tmp/kubermatic
     echodate "Cloning cluster exposer"
     KKP_REPO_URL="${KKP_REPO_URL:-https://github.com/kubermatic/kubermatic.git}"
-    KKP_REPO_TAG="${KKP_REPO_BRANCH:-master}"
+    KKP_REPO_TAG="${KKP_REPO_BRANCH:-main}"
     git clone --depth 1 --branch "${KKP_REPO_TAG}" "${KKP_REPO_URL}" .
 
     echodate "Building cluster exposer"

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/clusterv1alpha1machineWithProviderConfig/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/clusterv1alpha1machineWithProviderConfig/aws.yaml
@@ -27,7 +27,7 @@ spec:
         subnetId: subnet-2bff4f43
         tags:
           KubernetesCluster: 6qsm86c2d
-        vpcId: vpc-819f62e9
+        vpcId: vpc-079f7648481a11e77
       operatingSystem: flatcar
       operatingSystemSpec:
         disableAutoUpdate: true

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/machinesv1alpha1machine/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/machinesv1alpha1machine/aws.yaml
@@ -16,7 +16,7 @@ spec:
       secretAccessKey: "val"
       region: "eu-central-1"
       availabilityZone: "eu-central-1a"
-      vpcId: "vpc-819f62e9"
+      vpcId: "vpc-079f7648481a11e77"
       subnetId: "subnet-2bff4f43"
       instanceType: "t2.micro"
       diskSize: 50

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machine/aws.yaml
@@ -22,7 +22,7 @@ spec:
         subnetId: subnet-2bff4f43
         tags:
           KubernetesCluster: 6qsm86c2d
-        vpcId: vpc-819f62e9
+        vpcId: vpc-079f7648481a11e77
       operatingSystem: flatcar
       operatingSystemSpec:
         disableAutoUpdate: true

--- a/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machineWithProviderConfig/aws.yaml
+++ b/pkg/apis/cluster/v1alpha1/conversions/testdata/migrated_clusterv1alpha1machineWithProviderConfig/aws.yaml
@@ -30,7 +30,7 @@ spec:
         subnetId: subnet-2bff4f43
         tags:
           KubernetesCluster: 6qsm86c2d
-        vpcId: vpc-819f62e9
+        vpcId: vpc-079f7648481a11e77
       operatingSystem: flatcar
       operatingSystemSpec:
         disableAutoUpdate: true

--- a/pkg/cloudprovider/validationwrapper.go
+++ b/pkg/cloudprovider/validationwrapper.go
@@ -18,6 +18,7 @@ package cloudprovider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
@@ -55,9 +56,13 @@ func (w *cachingValidationWrapper) Validate(ctx context.Context, spec v1alpha1.M
 	}
 
 	klog.V(6).Infof("Got cache miss for validation")
-	err = w.actualProvider.Validate(ctx, spec)
-	if err := cache.Set(spec, err); err != nil {
-		return fmt.Errorf("failed to set cache after validation: %w", err)
+
+	// do not cache canceled contexts (e.g. the validation request was canceled client-side)
+	// and timeouts (assumed to be temporary)
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+		if err := cache.Set(spec, err); err != nil {
+			return fmt.Errorf("failed to set cache after validation: %w", err)
+		}
 	}
 
 	return err

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
@@ -28,7 +28,7 @@ spec:
             secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             instanceType: "a1.medium"
             instanceProfile: "kubernetes-v1"
             diskSize: 50
@@ -36,7 +36,7 @@ spec:
             ebsVolumeEncrypted: false
             ami: "<< AMI >>"
             securityGroupIDs:
-              - "sg-a2c195ca"
+              - "sg-0f1f62df28fb378b7"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-ebs-encryption-enabled.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-ebs-encryption-enabled.yaml
@@ -28,14 +28,14 @@ spec:
             secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             instanceType: "t2.medium"
             instanceProfile: "kubernetes-v1"
             diskSize: 50
             diskType: "gp2"
             ebsVolumeEncrypted: true
             securityGroupIDs:
-            - "sg-a2c195ca"
+            - "sg-0f1f62df28fb378b7"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
@@ -28,7 +28,7 @@ spec:
             secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
             region: "eu-central-1"
             availabilityZone: "eu-central-1b"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             instanceType: "t2.medium"
             instanceProfile: "kubernetes-v1"
             diskSize: 50
@@ -40,7 +40,7 @@ spec:
               maxPrice: "<< MAX_PRICE >>"
               persistentRequest: false
             securityGroupIDs:
-            - "sg-a2c195ca"
+            - "sg-0f1f62df28fb378b7"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
@@ -30,7 +30,7 @@ spec:
             assumeRoleExternalID: "<< AWS_ASSUME_ROLE_EXTERNAL_ID >>"
             region: "eu-central-1"
             availabilityZone: "eu-central-1a"
-            vpcId: "vpc-819f62e9"
+            vpcId: "vpc-079f7648481a11e77"
             instanceType: "t2.medium"
             instanceProfile: "kubernetes-v1"
             diskSize: 50
@@ -38,7 +38,7 @@ spec:
             ebsVolumeEncrypted: false
             ami: "<< AMI >>"
             securityGroupIDs:
-            - "sg-a2c195ca"
+            - "sg-0f1f62df28fb378b7"
             tags:
               # you have to set this flag to real clusterID when running against our dev or prod
               # otherwise you might have issues with your nodes not joining the cluster

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -31,7 +31,7 @@ spec:
             folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            datastore: alpha1
+            datastore: vsan
             cpus: 2
             MemoryMB: 2048
             allowInsecure: true

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -31,7 +31,7 @@ spec:
             folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            datastore: alpha1
+            datastore: vsan
             cpus: 2
             MemoryMB: 4096
             diskSizeGB: << DISK_SIZE >>


### PR DESCRIPTION
**What this PR does / why we need it**:
This unblocks the e2e tests in the 1.55 branch.

**What type of PR is this?**
/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
