### PR TITLE
store MC/OSM logs as artifacts during E2E tests

### DIFF
--- a/hack/ci/setup-machine-controller-in-kind.sh
+++ b/hack/ci/setup-machine-controller-in-kind.sh
@@ -54,6 +54,8 @@ if [ ! -f machine-controller-deployed ]; then
 
   make deploy
   touch machine-controller-deployed
+
+  protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs" --namespace kube-system 'machine-controller-*' > /dev/null 2>&1 &
 fi
 
 if [[ "$OPERATING_SYSTEM_MANAGER" == "true" ]]; then
@@ -75,6 +77,8 @@ if [[ "$OPERATING_SYSTEM_MANAGER" == "true" ]]; then
     sed -i -e 's/-worker-count=5/-worker-count=50/g' examples/operating-system-manager.yaml
     kubectl apply -f examples/operating-system-manager.yaml
   )
+
+  protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs" --namespace kube-system 'operating-system-manager-*' > /dev/null 2>&1 &
 fi
 
 sleep 10


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes use of https://github.com/xrstf/protokol to dump the logs of machine-controller and OSM during the e2e tests, making them available as build artifacts. I presume this is safe as neither component should log credentials :crossed_fingers: 

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
