### PR TITLE
reduce default log level to prevent credentials from leaking

### DIFF
--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -260,7 +260,8 @@ spec:
           command:
             - /usr/local/bin/webhook
             - -logtostderr
-            - -v=6
+            # Starting with v=6, full Machine objects with inline credentials are logged, beware!
+            - -v=4
             - -use-osm=true
             - -namespace=kube-system
             - -listen-address=0.0.0.0:9876

--- a/examples/operating-system-manager.yaml
+++ b/examples/operating-system-manager.yaml
@@ -980,7 +980,7 @@ spec:
           command:
             - /usr/local/bin/webhook
             - -logtostderr
-            - -v=6
+            - -v=4
             - -namespace=kube-system
           volumeMounts:
             - name: operating-system-manager-admission-cert
@@ -1308,7 +1308,7 @@ spec:
           command:
             - /usr/local/bin/osm-controller
             - -logtostderr
-            - -v=5
+            - -v=4
             - -worker-count=5
             - -cluster-dns=10.10.10.10
             - -metrics-address=0.0.0.0:8080

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -125,7 +125,7 @@ func createAdmissionResponse(original, mutated runtime.Object) (*admissionv1.Adm
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal json patch: %w", err)
 		}
-		klog.V(3).Infof("Produced jsonpatch: %s", string(patchRaw))
+		klog.V(6).Infof("Produced jsonpatch: %s", string(patchRaw))
 
 		response.Patch = patchRaw
 		response.PatchType = &jsonPatch


### PR DESCRIPTION
**What this PR does / why we need it**:
The default manifests for the MC/OSM enabled a log level so verbose, it would log entire admission requests and responses to stdout, which contain potentially inline cloud provider credentials. That is, except for development, never intended and so we should not ship "bad" manifests.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Reduce default log verbosity from 6 to 4.
```

**Documentation**:
```documentation
NONE
```
