### PR TITLE
Anexia Provider: fix cleanup of failed machines

### DIFF
--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -514,6 +514,10 @@ func (p *provider) GetCloudConfig(_ clusterv1alpha1.MachineSpec) (string, string
 
 func (p *provider) Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData) (isDeleted bool, retErr error) {
 	if inst, err := p.Get(ctx, machine, data); err != nil {
+		if cloudprovidererrors.IsNotFound(err) {
+			return true, nil
+		}
+
 		return false, err
 	} else if inst.Status() == instance.StatusCreating {
 		klog.Warningf("Unable to cleanup machine %q. Instance is still creating", machine.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it possible to `Cleanup` Machines which have no instance (because they failed creation e.g. due to invalid configuration).


**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anexia Provider: fix cleanup of failed machines
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
