### PR TITLE
Fix E2E tests for VMware Cloud Director

### DIFF
--- a/test/e2e/provisioning/testdata/machinedeployment-vmware-cloud-director.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vmware-cloud-director.yaml
@@ -33,10 +33,10 @@ spec:
             organization: "<< VCD_ORG >>"
             vdc: "<< VCD_VDC >>"
             allowInsecure: false
-            vapp: "machine-controller-e2e"
+            vapp: "kubermatic-e2e"
             catalog: "kubermatic"
             template: "machine-controller-<< OS_NAME >>"
-            network: "machine-controller-e2e"
+            network: "kubermatic-e2e-routed-network"
             ipAllocationMode: "DHCP"
             cpus: 2
             cpuCores: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix E2E tests for VMware Cloud Director.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind failing-test

**Special notes for your reviewer**:
We would like to use the latest available image against main branch for OSM. We use image caching on our CI cluster which also caches the images with `latest` tag. This results in the actual latest image not being pulled and instead we end up using whatever is there in the cache.

To fix this issue, we determine the commit SHA for the last commit on main and then consume the image against it.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
