### PR TITLE
Remove custom AMI from rhel os

### DIFF
--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -206,12 +206,10 @@ func testScenario(t *testing.T, testCase scenario, cloudProvider string, testPar
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< OS_DISK_SIZE >>=%v", 0))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DATA_DISK_SIZE >>=%v", 0))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< CUSTOM-IMAGE >>=%v", "rhel-8-1-custom"))
-		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", "ami-08b25fe3ad2fc9b18"))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< MAX_PRICE >>=%s", "0.08"))
 	} else {
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< OS_DISK_SIZE >>=%v", 30))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DATA_DISK_SIZE >>=%v", 30))
-		scenarioParams = append(scenarioParams, fmt.Sprintf("<< AMI >>=%s", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< DISK_SIZE >>=%v", 25))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< CUSTOM-IMAGE >>=%v", ""))
 		scenarioParams = append(scenarioParams, fmt.Sprintf("<< MAX_PRICE >>=%s", "0.03"))

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
@@ -36,7 +36,6 @@ spec:
             diskSize: 50
             diskType: "gp2"
             ebsVolumeEncrypted: false
-            ami: "<< AMI >>"
             securityGroupIDs:
               - "sg-0f1f62df28fb378b7"
             tags:

--- a/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-spot-instances.yaml
@@ -36,7 +36,6 @@ spec:
             diskSize: 50
             diskType: "gp2"
             ebsVolumeEncrypted: false
-            ami: "<< AMI >>"
             isSpotInstance: true
             spotInstanceConfig:
               maxPrice: "<< MAX_PRICE >>"

--- a/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws.yaml
@@ -38,7 +38,6 @@ spec:
             diskSize: 50
             diskType: "gp2"
             ebsVolumeEncrypted: false
-            ami: "<< AMI >>"
             securityGroupIDs:
               - "sg-0f1f62df28fb378b7"
             tags:


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we have enabled the GA images for RHEL, in addition of having a default RHEL image added as part of the cloud provider controller, we don't need to include a custom iam for RHEL machines. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
