### PR TITLE
Refactor gcp client creating

### DIFF
--- a/examples/gce-machinedeployment.yaml
+++ b/examples/gce-machinedeployment.yaml
@@ -50,6 +50,10 @@ spec:
                 key: serviceAccount
             # See https://cloud.google.com/compute/docs/regions-zones/
             zone: "europe-west3-a"
+            # Is the id of the GCP project that can be used to create machines in. Usually this id is taken from the
+            # service account however, it should be possible to create a machine in another project, as long as the
+            # machine controller has the right permissions
+            projectID: ""
             # See https://cloud.google.com/compute/docs/machine-types
             machineType: "n1-standard-2"
             # In GB

--- a/pkg/cloudprovider/provider/gce/provider.go
+++ b/pkg/cloudprovider/provider/gce/provider.go
@@ -261,7 +261,7 @@ func (p *Provider) Create(ctx context.Context, machine *clusterv1alpha1.Machine,
 	if !cfg.disableMachineServiceAccount {
 		inst.ServiceAccounts = []*compute.ServiceAccount{
 			{
-				Email: cfg.jwtConfig.Email,
+				Email: cfg.clientConfig.ClientEmail,
 				Scopes: append(
 					monitoring.DefaultAuthScopes(),
 					compute.ComputeScope,

--- a/pkg/cloudprovider/provider/gce/service.go
+++ b/pkg/cloudprovider/provider/gce/service.go
@@ -22,6 +22,7 @@ package gce
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -55,12 +56,17 @@ type service struct {
 
 // connectComputeService establishes a service connection to the Compute Engine.
 func connectComputeService(cfg *config) (*service, error) {
-	client := oauth2.NewClient(context.Background(), cfg.clientConfig.TokenSource)
-	svc, err := compute.NewService(context.Background(), option.WithHTTPClient(client))
-	if err != nil {
-		return nil, fmt.Errorf("cannot connect to Google Cloud: %w", err)
+	if cfg.clientConfig != nil &&
+		cfg.clientConfig.TokenSource != nil {
+		client := oauth2.NewClient(context.Background(), cfg.clientConfig.TokenSource)
+		svc, err := compute.NewService(context.Background(), option.WithHTTPClient(client))
+		if err != nil {
+			return nil, fmt.Errorf("cannot connect to Google Cloud: %w", err)
+		}
+		return &service{svc}, nil
 	}
-	return &service{svc}, nil
+
+	return nil, errors.New("gcp token source was not found")
 }
 
 // networkInterfaces returns the configured network interfaces for an instance creation.

--- a/pkg/cloudprovider/provider/gce/service.go
+++ b/pkg/cloudprovider/provider/gce/service.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/oauth2"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 
@@ -54,7 +55,7 @@ type service struct {
 
 // connectComputeService establishes a service connection to the Compute Engine.
 func connectComputeService(cfg *config) (*service, error) {
-	client := cfg.jwtConfig.Client(context.Background())
+	client := oauth2.NewClient(context.Background(), cfg.clientConfig.TokenSource)
 	svc, err := compute.NewService(context.Background(), option.WithHTTPClient(client))
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to Google Cloud: %w", err)

--- a/pkg/cloudprovider/provider/gce/types/types.go
+++ b/pkg/cloudprovider/provider/gce/types/types.go
@@ -51,6 +51,7 @@ type CloudProviderSpec struct {
 	EnableNestedVirtualization   providerconfigtypes.ConfigVarBool    `json:"enableNestedVirtualization,omitempty"`
 	MinCPUPlatform               providerconfigtypes.ConfigVarString  `json:"minCPUPlatform,omitempty"`
 	GuestOSFeatures              []string                             `json:"guestOSFeatures,omitempty"`
+	ProjectID                    providerconfigtypes.ConfigVarString  `json:"projectID,omitempty"`
 }
 
 // UpdateProviderSpec updates the given provider spec with changed


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, it is not possible to create gce instances in a different gcp project than the one that is specified in the service token, as we derive the project id from it. This PR changes this behaviour so users can share a service account across different projects and explicitly specify in which project the machine should be created.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/machine-controller/issues/1082

**What type of PR is this?**
/kind feature
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
