### PR TITLE
fix not found check: errors.As for type match whereas errors.Is for value equality

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -764,7 +764,7 @@ func (p *provider) Cleanup(ctx context.Context, machine *clusterv1alpha1.Machine
 		return false, osErrorToTerminalError(err, "failed to get compute client")
 	}
 
-	if err := osservers.Delete(computeClient, instance.ID()).ExtractErr(); err != nil && !errors.Is(err, &gophercloud.ErrDefault404{}) {
+	if err := osservers.Delete(computeClient, instance.ID()).ExtractErr(); err != nil && !errors.As(err, &gophercloud.ErrDefault404{}) {
 		return false, osErrorToTerminalError(err, "failed to delete instance")
 	}
 
@@ -1035,7 +1035,7 @@ func (p *provider) cleanupFloatingIP(machine *clusterv1alpha1.Machine, updater c
 	if err != nil {
 		return fmt.Errorf("failed to create the networkv2 client for region %s: %w", c.Region, err)
 	}
-	if err := osfloatingips.Delete(netClient, floatingIPID).ExtractErr(); err != nil && !errors.Is(err, &gophercloud.ErrDefault404{}) {
+	if err := osfloatingips.Delete(netClient, floatingIPID).ExtractErr(); err != nil && !errors.As(err, &gophercloud.ErrDefault404{}) {
 		return fmt.Errorf("failed to delete floating ip %s: %w", floatingIPID, err)
 	}
 	if err := updater(machine, func(m *clusterv1alpha1.Machine) {


### PR DESCRIPTION
**What this PR does / why we need it**:  

My earlier RP #1526 did not fix the problem (details below).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1526

**What type of PR is this?** 

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

It seems I managed to fool myself (and others) by using errors.Is. From errors.Is doc - "An error is considered to match a target if it is equal to that target..." which means even if there is an error with matching type errors.Is will be false unless its the same error.

The errors.Is is good to use with globally defined (using const / var), exported errors whereas in machine controller default-not-found error is a struct that also wraps some request/response information. Hence for different requests default-not-found error's value is different.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
machine deletion does not get stuck if assigned floating ip is absent (e.g. deleted externally)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
