### PR TITLE
Use eu-central-1b for AWS arm tests

### DIFF
--- a/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-aws-arm-machines.yaml
@@ -29,7 +29,7 @@ spec:
             accessKeyId: << AWS_ACCESS_KEY_ID >>
             secretAccessKey: << AWS_SECRET_ACCESS_KEY >>
             region: "eu-central-1"
-            availabilityZone: "eu-central-1a"
+            availabilityZone: "eu-central-1b"
             vpcId: "vpc-079f7648481a11e77"
             instanceType: "a1.medium"
             instanceProfile: "kubernetes-v1"


### PR DESCRIPTION
**What this PR does / why we need it**:
The ARM tests complain about `eu-central-1a` and suggest to use `eu-central-1b`. Let's give it a try.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
