### PR TITLE
WIP: Add notion of community providers to machine-controller

### DIFF
--- a/cmd/machine-controller/main.go
+++ b/cmd/machine-controller/main.go
@@ -33,6 +33,7 @@ import (
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1/migrations"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
 	clusterinfo "github.com/kubermatic/machine-controller/pkg/clusterinfo"
@@ -77,6 +78,8 @@ var (
 
 	useOSM               bool
 	useExternalBootstrap bool
+
+	enableCommunityProviders bool
 
 	nodeCSRApprover                   bool
 	nodeHTTPProxy                     string
@@ -188,12 +191,16 @@ func main() {
 	flag.BoolVar(&useOSM, "use-osm", false, "DEPRECATED: use osm controller for node bootstrap [use use-external-bootstrap instead]")
 	flag.BoolVar(&useExternalBootstrap, "use-external-bootstrap", false, "use an external bootstrap provider for instance user-data (e.g. operating-system-manager, also known as OSM)")
 	flag.StringVar(&overrideBootstrapKubeletAPIServer, "override-bootstrap-kubelet-apiserver", "", "Override for the API server address used in worker nodes bootstrap-kubelet.conf")
+	flag.BoolVar(&enableCommunityProviders, "enable-community-providers", false, "Enable community provider implementations that are disabled by default. Community providers are implemented by external contributors and not tested as part of the machine-controller development process")
 
 	flag.Parse()
 
 	if err := logFlags.Validate(); err != nil {
 		log.Fatalf("Invalid options: %v", err)
 	}
+
+	// enable/disable community provider support
+	cloudprovider.SetCommunityProviderSupport(enableCommunityProviders)
 
 	rawLog := machinecontrollerlog.New(logFlags.Debug, logFlags.Format)
 	log := rawLog.Sugar()

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kubermatic/machine-controller/pkg/admission"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
 	machinecontrollerlog "github.com/kubermatic/machine-controller/pkg/log"
 	"github.com/kubermatic/machine-controller/pkg/node"
@@ -36,17 +37,18 @@ import (
 )
 
 type options struct {
-	masterURL               string
-	kubeconfig              string
-	admissionListenAddress  string
-	admissionTLSCertPath    string
-	admissionTLSKeyPath     string
-	caBundleFile            string
-	useOSM                  bool
-	useExternalBootstrap    bool
-	namespace               string
-	workerClusterKubeconfig string
-	versionConstraint       string
+	masterURL                string
+	kubeconfig               string
+	admissionListenAddress   string
+	admissionTLSCertPath     string
+	admissionTLSKeyPath      string
+	caBundleFile             string
+	useOSM                   bool
+	useExternalBootstrap     bool
+	namespace                string
+	workerClusterKubeconfig  string
+	versionConstraint        string
+	enableCommunityProviders bool
 }
 
 func main() {
@@ -73,12 +75,16 @@ func main() {
 	// OSM specific flags
 	flag.BoolVar(&opt.useOSM, "use-osm", false, "DEPRECATED: osm controller is enabled for node bootstrap [use use-external-bootstrap instead]")
 	flag.BoolVar(&opt.useExternalBootstrap, "use-external-bootstrap", false, "user-data is provided by external bootstrap mechanism (e.g. operating-system-manager, also known as OSM)")
+	flag.BoolVar(&opt.enableCommunityProviders, "enable-community-providers", false, "Enable community provider implementations that are disabled by default. Community providers are implemented by external contributors and not tested as part of the machine-controller development process")
 
 	flag.Parse()
 
 	if err := logFlags.Validate(); err != nil {
 		log.Fatalf("Invalid options: %v", err)
 	}
+
+	// enable/disable community provider support
+	cloudprovider.SetCommunityProviderSupport(opt.enableCommunityProviders)
 
 	rawLog := machinecontrollerlog.New(logFlags.Debug, logFlags.Format)
 	log := rawLog.Sugar()

--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -195,6 +195,8 @@ labels:
 
 ## Linode
 
+Note: This is a [community provider](./community-providers.md).
+
 ### machine.spec.providerConfig.cloudProviderSpec
 ```yaml
 # your linode token
@@ -322,6 +324,8 @@ memory: "2048M"
 Refer to the [VSphere](./vsphere.md#provider-configuration) specific documentation.
 
 ## Vultr
+
+Note: This is a [community provider](./community-providers.md).
 
 ### machine.spec.providerConfig.cloudProviderSpec
 ```yaml

--- a/docs/community-providers.md
+++ b/docs/community-providers.md
@@ -1,0 +1,20 @@
+# Community Providers
+
+`machine-controller` implements various cloud providers to create machines on. Some of these implementations have been
+graciously provided by community members as external contributions. A huge thank you to all of them for improving `machine-controller`.
+
+Since the core development team does not have the ability to automatically (or manually) test most of these providers
+they are considered "community providers". The development team will keep them up to date to the best of their abilities
+(e.g. when interfaces change and need to adjusted in the provider implementation), but cannot make any guarantees towards
+bug fixes in a timely manner or their overall stability.
+
+Because of that, `machine-controller` has a special flag to enable community providers called `--enable-community-providers`.
+This flag needs to be configured both in the `machine-controller` and the `machine-controller-webhook` Deployments before
+the providers listed below can be used.
+
+## Provider List 
+
+Currently, the following providers are considered "community providers":
+
+- Linode
+- Vultr


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is both a WIP and a RFC, as we want to make clear that some providers (e.g. Vultr) were developed by external contributors and we cannot guarantee stability, functionality or ongoing maintenance for those provider implementations.

Please leave comments if you have any thoughts on the approach in this PR, the documentation or something else.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `--enable-community-providers` flag that needs to be enabled for using some providers not maintained by the machine-controller developers
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
