### PR TITLE
relax CSR validation to support Kubernetes 1.27

### DIFF
--- a/pkg/controller/nodecsrapprover/controller.go
+++ b/pkg/controller/nodecsrapprover/controller.go
@@ -199,10 +199,7 @@ func (r *reconciler) validateCSRObject(csr *certificatesv1.CertificateSigningReq
 		return "", fmt.Errorf("'%s' and/or '%s' are not in its groups", nodeGroup, authenticatedGroup)
 	}
 
-	// Check are present usages matching allowed usages
-	if len(csr.Spec.Usages) != 3 {
-		return "", fmt.Errorf("there are no exactly three usages defined")
-	}
+	// Check that present usages matching allowed usages
 	for _, usage := range csr.Spec.Usages {
 		if !isUsageInUsageList(usage, allowedUsages) {
 			return "", fmt.Errorf("usage %v is not in the list of allowed usages (%v)", usage, allowedUsages)

--- a/pkg/controller/nodecsrapprover/controller_test.go
+++ b/pkg/controller/nodecsrapprover/controller_test.go
@@ -290,54 +290,6 @@ func TestValidateCSRObject(t *testing.T) {
 			err:      fmt.Errorf("'%s' and/or '%s' are not in its groups", nodeGroup, authenticatedGroup),
 		},
 		{
-			name: "validate csr with less than 3 usages",
-			csr: &certificatesv1.CertificateSigningRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "csr",
-					Namespace: metav1.NamespaceSystem,
-				},
-				Spec: certificatesv1.CertificateSigningRequestSpec{
-					Request: []byte(testValidCSR),
-					Usages: []certificatesv1.KeyUsage{
-						certificatesv1.UsageDigitalSignature,
-						certificatesv1.UsageKeyEncipherment,
-					},
-					Username: "system:node:ip-172-31-114-48.eu-west-3.compute.internal",
-					Groups: []string{
-						"system:nodes",
-						"system:authenticated",
-					},
-				},
-			},
-			nodeName: "",
-			err:      fmt.Errorf("there are no exactly three usages defined"),
-		},
-		{
-			name: "validate csr with more than 3 usages",
-			csr: &certificatesv1.CertificateSigningRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "csr",
-					Namespace: metav1.NamespaceSystem,
-				},
-				Spec: certificatesv1.CertificateSigningRequestSpec{
-					Request: []byte(testValidCSR),
-					Usages: []certificatesv1.KeyUsage{
-						certificatesv1.UsageDigitalSignature,
-						certificatesv1.UsageKeyEncipherment,
-						certificatesv1.UsageServerAuth,
-						certificatesv1.UsageClientAuth,
-					},
-					Username: "system:node:ip-172-31-114-48.eu-west-3.compute.internal",
-					Groups: []string{
-						"system:nodes",
-						"system:authenticated",
-					},
-				},
-			},
-			nodeName: "",
-			err:      fmt.Errorf("there are no exactly three usages defined"),
-		},
-		{
 			name: "validate csr with usages not matching expected usages",
 			csr: &certificatesv1.CertificateSigningRequest{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
Since Kubernetes 1.27, CSRs do not necessarily contain `key encipherment` usage anymore (see https://github.com/kubernetes/kubernetes/issues/109077). This PR makes it so that the machine-controller does not refuse to approve those CSRs.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
