### PR TITLE
Add documentation for community providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ### What Works
 
 - Creation of worker nodes on AWS, Digitalocean, Openstack, Azure, Google Cloud Platform, Nutanix, VMWare Cloud Director, VMWare vSphere, Hetzner Cloud and Kubevirt
-- Using Ubuntu, Flatcar or CentOS 8 distributions ([not all distributions work on all providers](/docs/operating-system.md))
+- Using Ubuntu, Flatcar, CentOS 7 or Rocky Linux 8 distributions ([not all distributions work on all providers](/docs/operating-system.md))
 
 ### Supported Kubernetes Versions
 

--- a/README.md
+++ b/README.md
@@ -5,35 +5,36 @@
 - [Kubermatic machine-controller](#kubermatic-machine-controller)
   - [Table of Contents](#table-of-contents)
   - [Features](#features)
-    - [What works](#what-works)
-    - [Supported Kubernetes versions](#supported-kubernetes-versions)
-  - [What does not work](#what-does-not-work)
+    - [What Works](#what-works)
+    - [Supported Kubernetes Versions](#supported-kubernetes-versions)
+    - [Community Providers](#community-providers)
+  - [What doesn't Work](#what-doesnt-work)
   - [Quickstart](#quickstart)
-    - [Deploy the machine-controller](#deploy-the-machine-controller)
-    - [Creating a machineDeployment](#creating-a-machinedeployment)
-  - [Advanced usage](#advanced-usage)
-    - [Specifying the apiserver endpoint](#specifying-the-apiserver-endpoint)
-    - [CA-data](#ca-data)
-    - [Apiserver endpoint](#apiserver-endpoint)
+    - [Deploy machine-controller](#deploy-the-machine-controller)
+    - [Creating a MachineDeployment](#creating-a-machinedeployment)
+  - [Advanced Usage](#advanced-usage)
+    - [Specifying the Apiserver Endpoint](#specifying-the-apiserver-endpoint)
+    - [CA Data](#ca-data)
+    - [Apiserver Endpoint](#apiserver-endpoint)
       - [Example cluster-info ConfigMap](#example-cluster-info-configmap)
   - [Development](#development)
     - [Testing](#testing)
-      - [Unittests](#unittests)
-      - [End-to-End locally](#end-to-end-locally)
+      - [Unit Tests](#unit-tests)
+      - [End-to-End Locally](#end-to-end-locally)
   - [Troubleshooting](#troubleshooting)
   - [Contributing](#contributing)
-    - [Before you start](#before-you-start)
-    - [Pull requests](#pull-requests)
+    - [Before You Start](#before-you-start)
+    - [Pull Requests](#pull-requests)
   - [Changelog](#changelog)
 
 ## Features
 
-### What works
+### What Works
 
-- Creation of worker nodes on AWS, Digitalocean, Openstack, Azure, Google Cloud Platform, Nutanix, VMWare Cloud Director, VMWare Vsphere, Linode, Hetzner cloud and Kubevirt (experimental)
-- Using Ubuntu, Flatcar or CentOS 7 distributions ([not all distributions work on all providers](/docs/operating-system.md))
+- Creation of worker nodes on AWS, Digitalocean, Openstack, Azure, Google Cloud Platform, Nutanix, VMWare Cloud Director, VMWare vSphere, Hetzner Cloud and Kubevirt
+- Using Ubuntu, Flatcar or CentOS 8 distributions ([not all distributions work on all providers](/docs/operating-system.md))
 
-### Supported Kubernetes versions
+### Supported Kubernetes Versions
 
 machine-controller tries to follow the Kubernetes version
 [support policy](https://kubernetes.io/docs/setup/release/version-skew-policy/) as close as possible.
@@ -45,26 +46,38 @@ Currently supported K8S versions are:
 - 1.25
 - 1.24
 
-## What does not work
+### Community Providers
+
+Some cloud providers implemented in machine-controller have been graciously contributed by community members. Those cloud providers are not part of the automated end-to-end
+tests run by the machine-controller developers and thus, their status cannot be guaranteed. The machine-controller developers assume that they are functional, but can only
+offer limited support for new features or bugfixes in those providers.
+
+The current list of community providers is:
+
+- Linode
+- Vultr
+- OpenNebula
+
+## What Doesn't Work
 
 - Master creation (Not planned at the moment)
 
 ## Quickstart
 
-### Deploy the machine-controller
+### Deploy machine-controller
 
 `make deploy`
 
-### Creating a machineDeployment
+### Creating a `MachineDeployment`
 
 ```bash
 # edit examples/$cloudprovider-machinedeployment.yaml & create the machineDeployment
 kubectl create -f examples/$cloudprovider-machinedeployment.yaml
 ```
 
-## Advanced usage
+## Advanced Usage
 
-### Specifying the apiserver endpoint
+### Specifying the Apiserver Endpoint
 
 By default the controller looks for a `cluster-info` ConfigMap within the `kube-public` Namespace.
 If one is found which contains a minimal kubeconfig (kubeadm cluster have them by default), this kubeconfig will be used for the node bootstrapping.
@@ -75,11 +88,11 @@ The kubeconfig only needs to contain two things:
 
 If no ConfigMap can be found:
 
-### CA-data
+### CA Data
 
-The CA will be loaded from the passed kubeconfig when running outside the cluster or from `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` when running inside the cluster.
+The Certificate Authority (CA) will be loaded from the passed kubeconfig when running outside the cluster or from `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` when running inside the cluster.
 
-### Apiserver endpoint
+### Apiserver Endpoint
 
 The first endpoint from the kubernetes endpoints will be taken. `kubectl get endpoints kubernetes -o yaml`
 
@@ -110,11 +123,11 @@ data:
 
 ### Testing
 
-#### Unittests
+#### Unit Tests
 
 Simply run `make test-unit`
 
-#### End-to-End locally
+#### End-to-End Locally
 
 **_[WIP]_**
 
@@ -126,13 +139,13 @@ If you encounter issues [file an issue][1] or talk to us on the [#kubermatic cha
 
 Thanks for taking the time to join our community and start contributing!
 
-### Before you start
+### Before You Start
 
 - Please familiarize yourself with the [Code of Conduct][4] before contributing.
 - See [CONTRIBUTING.md][5] for instructions on the developer certificate of origin that we require.
 - Read how [we're using ZenHub][6] for project and roadmap planning
 
-### Pull requests
+### Pull Requests
 
 - We welcome pull requests. Feel free to dig through the [issues][1] and jump in.
 

--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -148,6 +148,8 @@ tags:
 
 ## OpenNebula
 
+**Note:** This is a [community provider](../README.md#community-providers).
+
 ### machine.spec.providerConfig.cloudProviderSpec
 
 ```yaml
@@ -232,6 +234,8 @@ labels:
 ```
 
 ## Linode
+
+**Note:** This is a [community provider](../README.md#community-providers).
 
 ### machine.spec.providerConfig.cloudProviderSpec
 ```yaml
@@ -360,6 +364,8 @@ memory: "2048M"
 Refer to the [VSphere](./vsphere.md#provider-configuration) specific documentation.
 
 ## Vultr
+
+**Note:** This is a [community provider](../README.md#community-providers).
 
 ### machine.spec.providerConfig.cloudProviderSpec
 ```yaml

--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -66,9 +66,6 @@ var (
 		providerconfigtypes.CloudProviderHetzner: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
 			return hetzner.New(cvr)
 		},
-		providerconfigtypes.CloudProviderLinode: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
-			return linode.New(cvr)
-		},
 		providerconfigtypes.CloudProviderVsphere: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
 			return vsphere.New(cvr)
 		},
@@ -77,9 +74,6 @@ var (
 		},
 		providerconfigtypes.CloudProviderEquinixMetal: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
 			return equinixmetal.New(cvr)
-		},
-		providerconfigtypes.CloudProviderVultr: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
-			return vultr.New(cvr)
 		},
 		// NB: This is explicitly left to allow old Packet machines to be deleted.
 		// We can handle those machines in the same way as Equinix Metal machines
@@ -113,6 +107,17 @@ var (
 		providerconfigtypes.CloudProviderVMwareCloudDirector: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
 			return vcd.New(cvr)
 		},
+	}
+
+	// communityProviders holds a map of cloud providers that have been implemented by community members and
+	// contributed to machine-controller. They are not end-to-end tested by the machine-controller development team.
+	communityProviders = map[providerconfigtypes.CloudProvider]func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider{
+		providerconfigtypes.CloudProviderLinode: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
+			return linode.New(cvr)
+		},
+		providerconfigtypes.CloudProviderVultr: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
+			return vultr.New(cvr)
+		},
 		providerconfigtypes.CloudProviderOpenNebula: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
 			return opennebula.New(cvr)
 		},
@@ -122,6 +127,9 @@ var (
 // ForProvider returns a CloudProvider actuator for the requested provider.
 func ForProvider(p providerconfigtypes.CloudProvider, cvr *providerconfig.ConfigVarResolver) (cloudprovidertypes.Provider, error) {
 	if p, found := providers[p]; found {
+		return NewValidationCacheWrappingCloudProvider(p(cvr)), nil
+	}
+	if p, found := communityProviders[p]; found {
 		return NewValidationCacheWrappingCloudProvider(p(cvr)), nil
 	}
 	return nil, ErrProviderNotFound


### PR DESCRIPTION
**What this PR does / why we need it**:
After discussions on SIG Cluster Management, this is the short-term change we have come up with to clarify that some providers have been contributed by the community and don't get the same maintenance care from the development team as others (because we cannot test them).

This PR also moves the providers into a dedicated `communityProviders` map to codify the distinction, but from a user perspective, nothing changes.

It's a follow-up to #1622.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Clarify provider status for Linode, Vultr and OpenNebula as community providers
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
