### PR TITLE
Remove DisableStrictZoneCheck from AWS 1.27 cloud-config

### DIFF
--- a/pkg/cloudprovider/provider/aws/types/cloudconfig.go
+++ b/pkg/cloudprovider/provider/aws/types/cloudconfig.go
@@ -36,7 +36,9 @@ RoleARN={{ .Global.RoleARN | iniEscape }}
 KubernetesClusterID={{ .Global.KubernetesClusterID | iniEscape }}
 DisableSecurityGroupIngress={{ .Global.DisableSecurityGroupIngress }}
 ElbSecurityGroup={{ .Global.ElbSecurityGroup | iniEscape }}
-DisableStrictZoneCheck={{ .Global.DisableStrictZoneCheck }}
+{{- if .Global.DisableStrictZoneCheck }}
+DisableStrictZoneCheck=true
+{{- end }}
 {{- range .Global.NodeIPFamilies }}
 NodeIPFamilies={{ . | iniEscape}}
 {{- end }}
@@ -57,8 +59,10 @@ type GlobalOpts struct {
 	KubernetesClusterID         string
 	ElbSecurityGroup            string
 	DisableSecurityGroupIngress bool
-	DisableStrictZoneCheck      bool
-	NodeIPFamilies              []string
+	// DisableStrictZoneCheck has been removed in Kubernetes 1.27+.
+	// See https://github.com/kubernetes/cloud-provider-aws/pull/573 for more information.
+	DisableStrictZoneCheck bool
+	NodeIPFamilies         []string
 }
 
 func CloudConfigToString(c *CloudConfig) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes/cloud-provider-aws/pull/573 removed the `DisableStrictZoneCheck` field alltogether from the cloud-config. The new CCM will reject and fail to load an old cloud-config, so we must ensure that the field is not part of the cloud-config at all.

This PR achieves this by only rendering the field if it's enabled, shifting the burden to set it properly onto our consumers.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
For generating cloud-config for Kubernetes 1.27 machines on AWS, make sure to set `DisableStrictZoneCheck` to `false`, as the flag is not supported in 1.27+ anymore.
```

**Documentation**:
```documentation
NONE
```
