### PR TITLE
Deprecate user data plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kubermatic machine-controller
 
+**Important Note: User data plugins for machine-controller are deprecated and will soon be removed. [Operating System Manager](https://github.com/kubermatic/operating-system-manager) is the successor of user data plugins. It's responsible for creating and managing the required configurations for worker nodes in a Kubernetes cluster with better modularity and extensibility. Please refer to [Operating System Manager][8] for more details.**
+
 ## Table of Contents
 
 - [Kubermatic machine-controller](#kubermatic-machine-controller)
@@ -53,7 +55,14 @@ Currently supported K8S versions are:
 
 ### Deploy the machine-controller
 
-`make deploy`
+- Install [cert-manager](https://cert-manager.io/) for generating certificates used by webhooks since they serve using HTTPS
+
+```terminal
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.2/cert-manager.yaml
+```
+
+- Run `kubectl apply -f examples/operating-system-manager.yaml` to deploy the operating-system-manager which is responsible for managing user data for worker machines.
+- Run `kubectl apply -f examples/machine-controller.yaml` to deploy the machine-controller.
 
 ### Creating a machineDeployment
 
@@ -147,3 +156,4 @@ See [the list of releases][7] to find out about feature changes.
 [5]: CONTRIBUTING.md
 [6]: Zenhub.md
 [7]: https://github.com/kubermatic/machine-controller/releases
+[8]: https://docs.kubermatic.com/operatingsystemmanager

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 ```
 
 - Run `kubectl apply -f examples/operating-system-manager.yaml` to deploy the operating-system-manager which is responsible for managing user data for worker machines.
-- Run `kubectl apply -f examples/machine-controller.yaml` to deploy the machine-controller.
+- Run `make deploy` to deploy the machine-controller.
 
 ### Creating a machineDeployment
 


### PR DESCRIPTION
## User data plugins from machine-controller have been deprecated and will soon be removed in favor of OSM.

**What this PR does / why we need it**:

Historically, machine-controller relied on user data plugins to generate configurations(cloud-config) for worker machines. Each operating system requires its own user-data plugin. These configs are then injected into the worker nodes using provisioning utilities such as [cloud-init](https://cloud-init.io) or [ignition](https://coreos.github.io/ignition). Eventually, the nodes are bootstrapped.

Over time, it has been observed that this workflow has certain limitations.

- Machine Controller expects **ALL** the supported user-data plugins to exist and be ready. User might only be interested in a subset of the available operating systems. For example, user might only want to work with `ubuntu`.
- The user-data plugins have templates defined [in-code](https://github.com/kubermatic/machine-controller/blob/v1.53.0/pkg/userdata/ubuntu/provider.go#L136). Which is not ideal since code changes are required to update those templates. Then those code changes need to become a part of the subsequent releases for machine-controller and KubeOne. So we need a complete release cycle to ship those changes to customers.
- Managing configs for multiple cloud providers, OS flavors and OS versions, adds a lot of complexity and redundancy in machine-controller.
- Since the templates are defined in-code, there is no way for an end user to customize them to suit their use-cases.
- Each cloud provider sets some sort of limits for the size of `user-data`, machine won't be created in case of non-compliance. For example, at the time of writing this, AWS has set a [hard limit of 16KB](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html).
- Better support for air-gapped environments is required.

**To overcome these limitations; Kubermatic built [Operating System Manager](https://github.com/kubermatic/operating-system-manager)**. Please refer to [Operating System Manager](https://docs.kubermatic.com/operatingsystemmanager) for more details.

User data plugins from machine-controller have thus been deprecated and will soon be removed in favor of OSM.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1544

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind deprecation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[ACTION REQUIRED] User data plugins for machine-controller are deprecated and will soon be removed. [Operating System Manager](https://github.com/kubermatic/operating-system-manager) is the successor of user data plugins. It's responsible for creating and managing the required configurations for worker nodes in a Kubernetes cluster with better modularity and extensibility. Please refer to [Operating System Manager](https://github.com/kubermatic/operating-system-manager#kubermatic-operating-system-manager) for more details.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
