### PR TITLE
Switch to cert-manager for certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/
 ```
 
 - Run `kubectl apply -f examples/operating-system-manager.yaml` to deploy the operating-system-manager which is responsible for managing user data for worker machines.
-- Run `make deploy` to deploy the machine-controller.
+- Run `kubectl apply -f examples/machine-controller.yaml` to deploy the machine-controller.
 
 ### Creating a machineDeployment
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -63,8 +63,8 @@ func main() {
 		flag.StringVar(&opt.masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	}
 	flag.StringVar(&opt.admissionListenAddress, "listen-address", ":9876", "The address on which the MutatingWebhook will listen on")
-	flag.StringVar(&opt.admissionTLSCertPath, "tls-cert-path", "/tmp/cert/cert.pem", "The path of the TLS cert for the MutatingWebhook")
-	flag.StringVar(&opt.admissionTLSKeyPath, "tls-key-path", "/tmp/cert/key.pem", "The path of the TLS key for the MutatingWebhook")
+	flag.StringVar(&opt.admissionTLSCertPath, "tls-cert-path", "/tmp/cert/tls.crt", "The path of the TLS cert for the MutatingWebhook")
+	flag.StringVar(&opt.admissionTLSKeyPath, "tls-key-path", "/tmp/cert/tls.key", "The path of the TLS key for the MutatingWebhook")
 	flag.StringVar(&opt.caBundleFile, "ca-bundle", "", "path to a file containing all PEM-encoded CA certificates (will be used instead of the host's certificates if set)")
 	flag.StringVar(&opt.namespace, "namespace", "kubermatic", "The namespace where the webhooks will run")
 	flag.StringVar(&opt.workerClusterKubeconfig, "worker-cluster-kubeconfig", "", "Path to kubeconfig of worker/user cluster where machines and machinedeployments exist. If not specified, value from --kubeconfig or in-cluster config will be used")

--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -155,6 +155,28 @@ spec:
           jsonPath: .metadata.deletionTimestamp
           priority: 1
 ---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: machine-controller-selfsigned-issuer
+  namespace: kube-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: machine-controller-serving-cert
+  namespace: kube-system
+spec:
+  dnsNames:
+    - "machine-controller-webhook.kube-system.svc"
+    - "machine-controller-webhook.kube-system.svc.cluster.local"
+  issuerRef:
+    kind: Issuer
+    name: machine-controller-selfsigned-issuer
+  secretName: machine-controller-webhook-server-cert
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -267,7 +289,8 @@ spec:
             - -listen-address=0.0.0.0:9876
           volumeMounts:
             - name: machine-controller-admission-cert
-              mountPath: /tmp/cert
+              mountPath: /tmp/cert/
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -284,16 +307,8 @@ spec:
       volumes:
         - name: machine-controller-admission-cert
           secret:
-            secretName: machine-controller-admission-cert
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: machine-controller-admission-cert
-  namespace: kube-system
-data:
-  "cert.pem": __admission_cert__
-  "key.pem": __admission_key__
+            defaultMode: 420
+            secretName: machine-controller-webhook-server-cert
 ---
 apiVersion: v1
 kind: Service
@@ -602,6 +617,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: machinedeployments.machine-controller.kubermatic.io
+  annotations:
+    cert-manager.io/inject-ca-from: kube-system/machine-controller-serving-cert
 webhooks:
 - name: machinedeployments.machine-controller.kubermatic.io
   failurePolicy: Fail
@@ -622,7 +639,6 @@ webhooks:
       namespace: kube-system
       name: machine-controller-webhook
       path: /machinedeployments
-    caBundle: __admission_ca_cert__
 - name: machines.machine-controller.kubermatic.io
   failurePolicy: Fail
   sideEffects: None
@@ -642,4 +658,3 @@ webhooks:
       namespace: kube-system
       name: machine-controller-webhook
       path: /machines
-    caBundle: __admission_ca_cert__


### PR DESCRIPTION
**What this PR does / why we need it**:
Use cert-manager for certificates for machine-controller webhooks.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[ACTION REQUIRED] The default values for webhook flags `tls-cert-path` and `tls-key-path` have been changed to `/tmp/cert/tls.crt` and `/tmp/cert/tls.key` respectively. This is a result of updating it to use certificates generated from cert-manager. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
