### PR TITLE
Fix empty network config handling

### DIFF
--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -166,16 +166,19 @@ func provisionVM(ctx context.Context, log *zap.SugaredLogger, client anxclient.C
 
 		vm.Script = base64.StdEncoding.EncodeToString([]byte(reconcileContext.UserData))
 
-		for index, dnsServer := range reconcileContext.ProviderConfig.Network.DNS.Servers {
-			switch index {
-			case 0:
-				vm.DNS1 = dnsServer
-			case 1:
-				vm.DNS2 = dnsServer
-			case 2:
-				vm.DNS3 = dnsServer
-			case 3:
-				vm.DNS4 = dnsServer
+		providerCfg := reconcileContext.ProviderConfig
+		if providerCfg.Network != nil {
+			for index, dnsServer := range providerCfg.Network.DNS.Servers {
+				switch index {
+				case 0:
+					vm.DNS1 = dnsServer
+				case 1:
+					vm.DNS2 = dnsServer
+				case 2:
+					vm.DNS3 = dnsServer
+				case 3:
+					vm.DNS4 = dnsServer
+				}
 			}
 		}
 

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -41,7 +42,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
-	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	cloudprovidererrors "github.com/kubermatic/machine-controller/pkg/cloudprovider/errors"
 	anxtypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
 	cloudprovidertypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/types"
@@ -68,18 +68,6 @@ func TestAnexiaProvider(t *testing.T) {
 	a.FakeExisting(&vspherev1.Template{Identifier: "WRONG-TEMPLATE-NAME", Name: "Wrong Template Name", Build: "b02"})
 	a.FakeExisting(&vspherev1.Template{Identifier: "TEMPLATE-ID-NO-NETWORK-CONFIG", Name: "no-network-config", Build: "b03"})
 
-	testhelper.Mux.HandleFunc("/api/ipam/v1/address/reserve/ip/count.json", func(writer http.ResponseWriter, request *http.Request) {
-		err := json.NewEncoder(writer).Encode(address.ReserveRandomSummary{
-			Data: []address.ReservedIP{
-				{
-					ID:      "IP-ID",
-					Address: "8.8.8.8",
-				},
-			},
-		})
-		testhelper.AssertNoErr(t, err)
-	})
-
 	t.Cleanup(func() {
 		testhelper.TeardownHTTP()
 		server.Close()
@@ -88,181 +76,112 @@ func TestAnexiaProvider(t *testing.T) {
 	t.Run("Test provision VM", func(t *testing.T) {
 		t.Parallel()
 
-		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/vm.json/LOCATION-ID/templates/TEMPLATE-ID", func(writer http.ResponseWriter, request *http.Request) {
-			testhelper.TestMethod(t, request, http.MethodPost)
-			type jsonObject = map[string]interface{}
-			expectedJSON := map[string]interface{}{
-				"cpu_performance_type": "performance",
-				"hostname":             "TestMachine",
-				"memory_mb":            json.Number("5"),
-				"network": []jsonObject{
-					{
-						"vlan":     "VLAN-ID",
-						"nic_type": "vmxnet3",
-						"ips":      []interface{}{"8.8.8.8"},
-					},
-				},
-			}
-			var jsonBody jsonObject
-			decoder := json.NewDecoder(request.Body)
-			decoder.UseNumber()
-			testhelper.AssertNoErr(t, decoder.Decode(&jsonBody))
-			testhelper.AssertEquals(t, expectedJSON["cpu_performance_type"], jsonBody["cpu_performance_type"])
-			testhelper.AssertEquals(t, expectedJSON["hostname"], jsonBody["hostname"])
-			testhelper.AssertEquals(t, expectedJSON["memory_mb"], jsonBody["memory_mb"])
-
-			testhelper.AssertEquals(t, jsonBody["dns1"], "1.1.1.1")
-			testhelper.AssertEquals(t, jsonBody["dns2"], nil)
-			testhelper.AssertEquals(t, jsonBody["dns3"], "192.168.0.1")
-			testhelper.AssertEquals(t, jsonBody["dns4"], "192.168.0.2")
-			testhelper.AssertEquals(t, expectedJSON["count"], jsonBody["count"])
-
-			expectedNetwork := expectedJSON["network"].([]jsonObject)[0]
-			bodyNetwork := jsonBody["network"].([]interface{})[0].(jsonObject)
-			testhelper.AssertEquals(t, expectedNetwork["vlan"], bodyNetwork["vlan"])
-			testhelper.AssertEquals(t, expectedNetwork["nic_type"], bodyNetwork["nic_type"])
-			testhelper.AssertEquals(t, expectedNetwork["ips"].([]interface{})[0], bodyNetwork["ips"].([]interface{})[0])
-
-			err := json.NewEncoder(writer).Encode(vm.ProvisioningResponse{
-				Progress:   100,
-				Errors:     nil,
-				Identifier: "TEST-IDENTIFIER",
-				Queued:     false,
-			})
-			testhelper.AssertNoErr(t, err)
-		})
-
-		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/progress.json/TEST-IDENTIFIER", func(writer http.ResponseWriter, request *http.Request) {
-			testhelper.TestMethod(t, request, http.MethodGet)
-
-			err := json.NewEncoder(writer).Encode(progress.Progress{
-				TaskIdentifier: "TEST-IDENTIFIER",
-				Queued:         false,
-				Progress:       100,
-				VMIdentifier:   "VM-IDENTIFIER",
-				Errors:         nil,
-			})
-			testhelper.AssertNoErr(t, err)
-		})
-
-		providerStatus := anxtypes.ProviderStatus{}
-		ctx := createReconcileContext(context.Background(), reconcileContext{
-			Machine: &v1alpha1.Machine{
-				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
-			},
-			Status:   &providerStatus,
-			UserData: "",
-			Config: resolvedConfig{
-				VlanID:     "VLAN-ID",
-				LocationID: "LOCATION-ID",
-				TemplateID: "TEMPLATE-ID",
-				Disks: []resolvedDisk{
-					{
-						RawDisk: anxtypes.RawDisk{
-							Size: 5,
+		testCases := []ProvisionVMTestCase{
+			{
+				// Provision a generic VM with some custom dns entries
+				ReconcileContext: hookableReconcileContext("LOCATION-ID", "TEMPLATE-ID", func(rc *reconcileContext) {
+					rc.ProviderConfig = &providerconfigtypes.Config{
+						Network: &providerconfigtypes.NetworkConfig{
+							DNS: providerconfigtypes.DNSConfig{
+								Servers: []string{
+									"1.1.1.1",
+									"",
+									"192.168.0.1",
+									"192.168.0.2",
+									"192.168.0.3",
+								},
+							},
 						},
-					},
-				},
-				RawConfig: anxtypes.RawConfig{
-					CPUs:   5,
-					Memory: 5,
-				},
-			},
-			ProviderData: &cloudprovidertypes.ProviderData{
-				Update: func(m *clusterv1alpha1.Machine, mods ...cloudprovidertypes.MachineModifier) error {
-					return nil
-				},
-			},
-			ProviderConfig: &providerconfigtypes.Config{
-				Network: &providerconfigtypes.NetworkConfig{
-					DNS: providerconfigtypes.DNSConfig{
-						Servers: []string{
-							"1.1.1.1",
-							"",
-							"192.168.0.1",
-							"192.168.0.2",
-							"192.168.0.3",
-						},
-					},
+					}
+				}),
+				AssertJSONBody: func(jsonBody jsonObject) {
+					testhelper.AssertEquals(t, jsonBody["cpu_performance_type"], "performance")
+					testhelper.AssertEquals(t, jsonBody["hostname"], "TestMachine")
+					testhelper.AssertEquals(t, jsonBody["memory_mb"], json.Number("5"))
+
+					testhelper.AssertEquals(t, jsonBody["dns1"], "1.1.1.1")
+					_, exists := jsonBody["dns2"]
+					testhelper.AssertEquals(t, exists, false)
+					testhelper.AssertEquals(t, jsonBody["dns3"], "192.168.0.1")
+					testhelper.AssertEquals(t, jsonBody["dns4"], "192.168.0.2")
+
+					networkArray := jsonBody["network"].([]interface{})
+					networkObject := networkArray[0].(jsonObject)
+					testhelper.AssertEquals(t, networkObject["vlan"], "VLAN-ID")
+					testhelper.AssertEquals(t, networkObject["nic_type"], "vmxnet3")
+					testhelper.AssertEquals(t, networkObject["ips"].([]interface{})[0], "8.8.8.8")
 				},
 			},
-		})
-
-		err := provisionVM(ctx, log, client)
-		testhelper.AssertNoErr(t, err)
-	})
-
-	t.Run("Test provision VM without network config", func(t *testing.T) {
-		t.Parallel()
-
-		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/vm.json/LOCATION-ID/templates/TEMPLATE-ID-NO-NETWORK-CONFIG", func(writer http.ResponseWriter, request *http.Request) {
-			testhelper.TestMethod(t, request, http.MethodPost)
-			type jsonObject = map[string]interface{}
-			var jsonBody jsonObject
-			decoder := json.NewDecoder(request.Body)
-			decoder.UseNumber()
-			testhelper.AssertNoErr(t, decoder.Decode(&jsonBody))
-
-			testhelper.AssertEquals(t, jsonBody["dns1"], nil)
-			testhelper.AssertEquals(t, jsonBody["dns2"], nil)
-			testhelper.AssertEquals(t, jsonBody["dns3"], nil)
-			testhelper.AssertEquals(t, jsonBody["dns4"], nil)
-
-			err := json.NewEncoder(writer).Encode(vm.ProvisioningResponse{
-				Progress:   100,
-				Errors:     nil,
-				Identifier: "TEMPLATE-ID-NO-NETWORK-CONFIG",
-				Queued:     false,
-			})
-			testhelper.AssertNoErr(t, err)
-		})
-
-		testhelper.Mux.HandleFunc("/api/vsphere/v1/provisioning/progress.json/TEMPLATE-ID-NO-NETWORK-CONFIG", func(writer http.ResponseWriter, request *http.Request) {
-			testhelper.TestMethod(t, request, http.MethodGet)
-
-			err := json.NewEncoder(writer).Encode(progress.Progress{
-				TaskIdentifier: "TEMPLATE-ID-NO-NETWORK-CONFIG",
-				Queued:         false,
-				Progress:       100,
-				VMIdentifier:   "VM-IDENTIFIER",
-				Errors:         nil,
-			})
-			testhelper.AssertNoErr(t, err)
-		})
-
-		providerStatus := anxtypes.ProviderStatus{}
-		ctx := createReconcileContext(context.Background(), reconcileContext{
-			Machine: &v1alpha1.Machine{
-				ObjectMeta: metav1.ObjectMeta{Name: "TestMachine"},
+			{
+				// Provision a VM without any ProviderConfig
+				ReconcileContext: hookableReconcileContext("LOCATION-ID", "TEMPLATE-ID-NO-NETWORK-CONFIG", func(rc *reconcileContext) {
+					rc.ProviderConfig = &providerconfigtypes.Config{}
+				}),
+				AssertJSONBody: func(jsonBody jsonObject) {
+					_, exists := jsonBody["dns1"]
+					testhelper.AssertEquals(t, exists, false)
+					_, exists = jsonBody["dns2"]
+					testhelper.AssertEquals(t, exists, false)
+					_, exists = jsonBody["dns3"]
+					testhelper.AssertEquals(t, exists, false)
+					_, exists = jsonBody["dns4"]
+					testhelper.AssertEquals(t, exists, false)
+				},
 			},
-			Status:   &providerStatus,
-			UserData: "",
-			Config: resolvedConfig{
-				VlanID:     "VLAN-ID",
-				LocationID: "LOCATION-ID",
-				TemplateID: "TEMPLATE-ID-NO-NETWORK-CONFIG",
-				Disks: []resolvedDisk{
+		}
+
+		testhelper.Mux.HandleFunc("/api/ipam/v1/address/reserve/ip/count.json", func(writer http.ResponseWriter, request *http.Request) {
+			err := json.NewEncoder(writer).Encode(address.ReserveRandomSummary{
+				Data: []address.ReservedIP{
 					{
-						RawDisk: anxtypes.RawDisk{
-							Size: 5,
-						},
+						ID:      "IP-ID",
+						Address: "8.8.8.8",
 					},
 				},
-				RawConfig: anxtypes.RawConfig{
-					CPUs:   5,
-					Memory: 5,
-				},
-			},
-			ProviderData: &cloudprovidertypes.ProviderData{
-				Update: func(m *clusterv1alpha1.Machine, mods ...cloudprovidertypes.MachineModifier) error {
-					return nil
-				},
-			},
-			ProviderConfig: &providerconfigtypes.Config{},
+			})
+			testhelper.AssertNoErr(t, err)
 		})
 
-		err := provisionVM(ctx, log, client)
-		testhelper.AssertNoErr(t, err)
+		for _, testCase := range testCases {
+			templateID := testCase.ReconcileContext.Config.TemplateID
+			locationID := testCase.ReconcileContext.Config.LocationID
+
+			testhelper.Mux.HandleFunc(fmt.Sprintf("/api/vsphere/v1/provisioning/vm.json/%s/templates/%s", locationID, templateID), func(writer http.ResponseWriter, request *http.Request) {
+				testhelper.TestMethod(t, request, http.MethodPost)
+				var jsonBody jsonObject
+				decoder := json.NewDecoder(request.Body)
+				decoder.UseNumber()
+				testhelper.AssertNoErr(t, decoder.Decode(&jsonBody))
+
+				testCase.AssertJSONBody(jsonBody)
+
+				err := json.NewEncoder(writer).Encode(vm.ProvisioningResponse{
+					Progress:   100,
+					Errors:     nil,
+					Identifier: templateID,
+					Queued:     false,
+				})
+				testhelper.AssertNoErr(t, err)
+			})
+
+			testhelper.Mux.HandleFunc(fmt.Sprintf("/api/vsphere/v1/provisioning/progress.json/%s", templateID), func(writer http.ResponseWriter, request *http.Request) {
+				testhelper.TestMethod(t, request, http.MethodGet)
+
+				err := json.NewEncoder(writer).Encode(progress.Progress{
+					TaskIdentifier: templateID,
+					Queued:         false,
+					Progress:       100,
+					VMIdentifier:   "VM-IDENTIFIER",
+					Errors:         nil,
+				})
+				testhelper.AssertNoErr(t, err)
+			})
+
+			ctx := createReconcileContext(context.Background(), testCase.ReconcileContext)
+
+			err := provisionVM(ctx, log, client)
+			testhelper.AssertNoErr(t, err)
+		}
 	})
 
 	t.Run("Test resolve template", func(t *testing.T) {
@@ -371,30 +290,6 @@ func TestAnexiaProvider(t *testing.T) {
 			testhelper.AssertEquals(t, expectedIP, reservedIP)
 		})
 	})
-}
-
-// this generates a full config and allows hooking into it to e.g. remove a value.
-func hookableConfig(hook func(*anxtypes.RawConfig)) anxtypes.RawConfig {
-	config := anxtypes.RawConfig{
-		CPUs: 1,
-
-		Memory: 2,
-
-		Disks: []anxtypes.RawDisk{
-			{Size: 5, PerformanceType: newConfigVarString("ENT6")},
-		},
-
-		Token:      newConfigVarString("test-token"),
-		VlanID:     newConfigVarString("test-vlan"),
-		LocationID: newConfigVarString("test-location"),
-		TemplateID: newConfigVarString("test-template-id"),
-	}
-
-	if hook != nil {
-		hook(&config)
-	}
-
-	return config
 }
 
 func TestValidate(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Provisioning a VM without defining a `Network` in the `providerConfig` object results in a nil pointer exception. This bug got introduced by https://github.com/kubermatic/machine-controller/pull/1637

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

We'd love to get a backport of these changes in v1.54

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anexia Provider: Fix nil pointer exception when providing no network configuration
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
