### PR TITLE
Add vmware anti-affinity for machine sets

### DIFF
--- a/examples/vsphere-datastore-cluster-machinedeployment.yaml
+++ b/examples/vsphere-datastore-cluster-machinedeployment.yaml
@@ -57,6 +57,10 @@ spec:
             datastoreCluster: datastorecluster1
             # Can also be set via the env var 'VSPHERE_ALLOW_INSECURE' on the machine-controller
             allowInsecure: true
+            # vSphere Cluster
+            cluster: cl-1
+            # Automatically create anti affinity rules for machines
+            vmAntiAffinity: true
             cpus: 2
             memoryMB: 2048
             # Optional: Resize the root disk to this size. Must be bigger than the existing size

--- a/examples/vsphere-datastore-cluster-machinedeployment.yaml
+++ b/examples/vsphere-datastore-cluster-machinedeployment.yaml
@@ -57,7 +57,7 @@ spec:
             datastoreCluster: datastorecluster1
             # Can also be set via the env var 'VSPHERE_ALLOW_INSECURE' on the machine-controller
             allowInsecure: true
-            # vSphere Cluster
+            # Cluster to configure vm anti affinity rules
             cluster: cl-1
             # Automatically create anti affinity rules for machines
             vmAntiAffinity: true

--- a/examples/vsphere-machinedeployment.yaml
+++ b/examples/vsphere-machinedeployment.yaml
@@ -57,6 +57,10 @@ spec:
             datastore: datastore1
             # Can also be set via the env var 'VSPHERE_ALLOW_INSECURE' on the machine-controller
             allowInsecure: true
+            # vSphere Cluster
+            cluster: cl-1
+            # Automatically create anti affinity rules for machines
+            vmAntiAffinity: true
             cpus: 2
             memoryMB: 2048
             # Optional: Resize the root disk to this size. Must be bigger than the existing size

--- a/examples/vsphere-machinedeployment.yaml
+++ b/examples/vsphere-machinedeployment.yaml
@@ -57,7 +57,7 @@ spec:
             datastore: datastore1
             # Can also be set via the env var 'VSPHERE_ALLOW_INSECURE' on the machine-controller
             allowInsecure: true
-            # vSphere Cluster
+            # Cluster to configure vm anti affinity rules
             cluster: cl-1
             # Automatically create anti affinity rules for machines
             vmAntiAffinity: true

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -435,13 +435,6 @@ func (p *provider) Cleanup(ctx context.Context, log *zap.SugaredLogger, machine 
 		return false, fmt.Errorf("failed to delete tags: %w", err)
 	}
 
-	if config.VMAntiAffinity {
-		machineSetName := machine.Name[:strings.LastIndex(machine.Name, "-")]
-		if err := p.createOrUpdateVMAntiAffinityRule(ctx, session, machineSetName, config); err != nil {
-			return false, fmt.Errorf("failed to add VM to anti affinity rule: %w", err)
-		}
-	}
-
 	powerState, err := virtualMachine.PowerState(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to get virtual machine power state: %w", err)
@@ -495,6 +488,13 @@ func (p *provider) Cleanup(ctx context.Context, log *zap.SugaredLogger, machine 
 	}
 	if err := destroyTask.Wait(ctx); err != nil {
 		return false, fmt.Errorf("failed to destroy vm %s: %w", virtualMachine.Name(), err)
+	}
+
+	if config.VMAntiAffinity {
+		machineSetName := machine.Name[:strings.LastIndex(machine.Name, "-")]
+		if err := p.createOrUpdateVMAntiAffinityRule(ctx, session, machineSetName, config); err != nil {
+			return false, fmt.Errorf("failed to add VM to anti affinity rule: %w", err)
+		}
 	}
 
 	if pc.OperatingSystem != providerconfigtypes.OperatingSystemFlatcar {

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -300,8 +300,14 @@ func (p *provider) Validate(ctx context.Context, log *zap.SugaredLogger, spec cl
 		}
 	}
 
-	if config.VMAntiAffinity && config.Cluster == "" {
-		return fmt.Errorf("cluster is required for vm anti affinity")
+	if config.VMAntiAffinity {
+		if config.Cluster == "" {
+			return fmt.Errorf("cluster is required for vm anti affinity")
+		}
+		_, err = session.Finder.ClusterComputeResource(ctx, config.Cluster)
+		if err != nil {
+			return fmt.Errorf("failed to get cluster %q, %w", config.Cluster, err)
+		}
 	}
 
 	return nil

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -198,7 +198,7 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 		return nil, nil, nil, err
 	}
 
-	c.VMAntiAffinity, err = p.configVarResolver.GetConfigVarBoolValueOrEnv(rawConfig.VMAntiAffinity, "VSPHERE_ALLOW_INSECURE")
+	c.VMAntiAffinity, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.VMAntiAffinity)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -299,6 +299,11 @@ func (p *provider) Validate(ctx context.Context, log *zap.SugaredLogger, spec cl
 			return err
 		}
 	}
+
+	if config.VMAntiAffinity && config.Cluster == "" {
+		return fmt.Errorf("cluster is required for vm anti affinity")
+	}
+
 	return nil
 }
 

--- a/pkg/cloudprovider/provider/vsphere/provider_test.go
+++ b/pkg/cloudprovider/provider/vsphere/provider_test.go
@@ -48,6 +48,8 @@ func (v vsphereProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 	"cloudProvider": "vsphere",
 	"cloudProviderSpec": {
 		"allowInsecure": false,
+		"vmAntiAffinity": true,
+        "cluster": "Kubermatic",
 		"cpus": 1,
 		"datacenter": "DC0",
 		{{- if .Datastore }}

--- a/pkg/cloudprovider/provider/vsphere/provider_test.go
+++ b/pkg/cloudprovider/provider/vsphere/provider_test.go
@@ -49,7 +49,7 @@ func (v vsphereProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 	"cloudProviderSpec": {
 		"allowInsecure": false,
 		"vmAntiAffinity": true,
-        "cluster": "Kubermatic",
+        "cluster": "DC0_C0",
 		"cpus": 1,
 		"datacenter": "DC0",
 		{{- if .Datastore }}

--- a/pkg/cloudprovider/provider/vsphere/rule.go
+++ b/pkg/cloudprovider/provider/vsphere/rule.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2023 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/aws/smithy-go/ptr"
+	"github.com/vmware/govmomi/find"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// createOrUpdateVMAntiAffinityRule creates or updates an anti affinity rule with the name in the given cluster.
+// VMs are attached to the rule based on their folder path and name prefix in vsphere.
+// A minimum of two VMs is required.
+func (p *provider) createOrUpdateVMAntiAffinityRule(ctx context.Context, session *Session, name string, config *Config) error {
+
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+
+	cluster, err := session.Finder.ClusterComputeResource(ctx, config.Cluster)
+	if err != nil {
+		return err
+	}
+
+	vmsInFolder, err := session.Finder.VirtualMachineList(ctx, strings.Join([]string{config.Folder, "*"}, "/"))
+	if err != nil {
+		if errors.Is(err, &find.NotFoundError{}) {
+			return removeVMAntiAffinityRule(ctx, session, config.Cluster, name)
+		} else {
+			return err
+		}
+	}
+
+	var ruleVMRef []types.ManagedObjectReference
+	for _, vm := range vmsInFolder {
+		if strings.HasPrefix(vm.Name(), name) {
+			ruleVMRef = append(ruleVMRef, vm.Reference())
+		}
+	}
+
+	// minimum of two vms required
+	if len(ruleVMRef) < 2 {
+		return removeVMAntiAffinityRule(ctx, session, config.Cluster, name)
+	}
+
+	info, err := findClusterAntiAffinityRuleByName(ctx, cluster, name)
+	if err != nil {
+		return err
+	}
+
+	operation := types.ArrayUpdateOperationEdit
+
+	//create new rule
+	if info == nil {
+		info = &types.ClusterAntiAffinityRuleSpec{
+			ClusterRuleInfo: types.ClusterRuleInfo{
+				Enabled:     ptr.Bool(true),
+				Mandatory:   ptr.Bool(false),
+				Name:        name,
+				UserCreated: ptr.Bool(true),
+			},
+		}
+
+		operation = types.ArrayUpdateOperationAdd
+
+	}
+
+	info.Vm = ruleVMRef
+	spec := &types.ClusterConfigSpecEx{
+		RulesSpec: []types.ClusterRuleSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: operation,
+				},
+				Info: info,
+			},
+		},
+	}
+
+	task, err := cluster.Reconfigure(ctx, spec, true)
+	if err != nil {
+		return err
+	}
+
+	err = task.Wait(ctx)
+	if err != nil {
+		return err
+	}
+
+	return waitForRule(ctx, cluster, info)
+}
+
+// waitForRule checks periodically the vsphere api for the ClusterAntiAffinityRule and returns error if the rule was not found after a timeout.
+func waitForRule(ctx context.Context, cluster *object.ClusterComputeResource, rule *types.ClusterAntiAffinityRuleSpec) error {
+
+	timeout := time.NewTimer(5 * time.Second)
+	ticker := time.NewTicker(500 * time.Millisecond)
+
+	defer timeout.Stop()
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout.C:
+
+			info, err := findClusterAntiAffinityRuleByName(ctx, cluster, rule.Name)
+			if err != nil {
+				return err
+			}
+
+			if !reflect.DeepEqual(rule, info) {
+				return fmt.Errorf("expected anti affinity changes not found in vsphere")
+			}
+
+		case <-ticker.C:
+			info, err := findClusterAntiAffinityRuleByName(ctx, cluster, rule.Name)
+			if err != nil {
+				return err
+			}
+
+			if reflect.DeepEqual(rule, info) {
+				return nil
+			}
+		}
+	}
+
+}
+
+// removeVMAntiAffinityRule removes an anti affinity rule with the name in the given cluster.
+func removeVMAntiAffinityRule(ctx context.Context, session *Session, clusterPath string, name string) error {
+	cluster, err := session.Finder.ClusterComputeResource(ctx, clusterPath)
+	if err != nil {
+		return err
+	}
+
+	info, err := findClusterAntiAffinityRuleByName(ctx, cluster, name)
+	if err != nil {
+		return err
+	}
+
+	// no rule found
+	if info == nil {
+		return nil
+	}
+
+	spec := &types.ClusterConfigSpecEx{
+		RulesSpec: []types.ClusterRuleSpec{
+			{
+				ArrayUpdateSpec: types.ArrayUpdateSpec{
+					Operation: types.ArrayUpdateOperationRemove,
+					RemoveKey: info.Key,
+				},
+			},
+		},
+	}
+
+	task, err := cluster.Reconfigure(ctx, spec, true)
+	if err != nil {
+		return err
+	}
+	return task.Wait(ctx)
+}
+
+func findClusterAntiAffinityRuleByName(ctx context.Context, cluster *object.ClusterComputeResource, name string) (*types.ClusterAntiAffinityRuleSpec, error) {
+	var props mo.ClusterComputeResource
+	if err := cluster.Properties(ctx, cluster.Reference(), nil, &props); err != nil {
+		return nil, err
+	}
+
+	var info *types.ClusterAntiAffinityRuleSpec
+	for _, clusterRuleInfo := range props.ConfigurationEx.(*types.ClusterConfigInfoEx).Rule {
+		if clusterRuleInfo.GetClusterRuleInfo().Name == name {
+			if vmAffinityRuleInfo, ok := clusterRuleInfo.(*types.ClusterAntiAffinityRuleSpec); ok {
+				info = vmAffinityRuleInfo
+				break
+			}
+			return nil, fmt.Errorf("rule name %s in cluster %q is not a VM anti-affinity rule", name, cluster.Name())
+		}
+	}
+
+	return info, nil
+}

--- a/pkg/cloudprovider/provider/vsphere/rule.go
+++ b/pkg/cloudprovider/provider/vsphere/rule.go
@@ -35,7 +35,6 @@ import (
 // VMs are attached to the rule based on their folder path and name prefix in vsphere.
 // A minimum of two VMs is required.
 func (p *provider) createOrUpdateVMAntiAffinityRule(ctx context.Context, session *Session, name string, config *Config) error {
-
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
@@ -48,9 +47,8 @@ func (p *provider) createOrUpdateVMAntiAffinityRule(ctx context.Context, session
 	if err != nil {
 		if errors.Is(err, &find.NotFoundError{}) {
 			return removeVMAntiAffinityRule(ctx, session, config.Cluster, name)
-		} else {
-			return err
 		}
+		return err
 	}
 
 	var ruleVMRef []types.ManagedObjectReference
@@ -82,9 +80,7 @@ func (p *provider) createOrUpdateVMAntiAffinityRule(ctx context.Context, session
 				UserCreated: ptr.Bool(true),
 			},
 		}
-
 		operation = types.ArrayUpdateOperationAdd
-
 	}
 
 	info.Vm = ruleVMRef
@@ -114,10 +110,8 @@ func (p *provider) createOrUpdateVMAntiAffinityRule(ctx context.Context, session
 
 // waitForRule checks periodically the vsphere api for the ClusterAntiAffinityRule and returns error if the rule was not found after a timeout.
 func waitForRule(ctx context.Context, cluster *object.ClusterComputeResource, rule *types.ClusterAntiAffinityRuleSpec) error {
-
 	timeout := time.NewTimer(5 * time.Second)
 	ticker := time.NewTicker(500 * time.Millisecond)
-
 	defer timeout.Stop()
 	defer ticker.Stop()
 
@@ -133,7 +127,6 @@ func waitForRule(ctx context.Context, cluster *object.ClusterComputeResource, ru
 			if !reflect.DeepEqual(rule, info) {
 				return fmt.Errorf("expected anti affinity changes not found in vsphere")
 			}
-
 		case <-ticker.C:
 			info, err := findClusterAntiAffinityRuleByName(ctx, cluster, rule.Name)
 			if err != nil {
@@ -145,7 +138,6 @@ func waitForRule(ctx context.Context, cluster *object.ClusterComputeResource, ru
 			}
 		}
 	}
-
 }
 
 // removeVMAntiAffinityRule removes an anti affinity rule with the name in the given cluster.

--- a/pkg/cloudprovider/provider/vsphere/rule.go
+++ b/pkg/cloudprovider/provider/vsphere/rule.go
@@ -110,7 +110,7 @@ func (p *provider) createOrUpdateVMAntiAffinityRule(ctx context.Context, session
 
 // waitForRule checks periodically the vsphere api for the ClusterAntiAffinityRule and returns error if the rule was not found after a timeout.
 func waitForRule(ctx context.Context, cluster *object.ClusterComputeResource, rule *types.ClusterAntiAffinityRuleSpec) error {
-	timeout := time.NewTimer(5 * time.Second)
+	timeout := time.NewTimer(10 * time.Second)
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer timeout.Stop()
 	defer ticker.Stop()

--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -40,11 +40,12 @@ type RawConfig struct {
 	DatastoreCluster providerconfigtypes.ConfigVarString `json:"datastoreCluster"`
 	Datastore        providerconfigtypes.ConfigVarString `json:"datastore"`
 
-	CPUs          int32                             `json:"cpus"`
-	MemoryMB      int64                             `json:"memoryMB"`
-	DiskSizeGB    *int64                            `json:"diskSizeGB,omitempty"`
-	Tags          []Tag                             `json:"tags,omitempty"`
-	AllowInsecure providerconfigtypes.ConfigVarBool `json:"allowInsecure"`
+	CPUs           int32                             `json:"cpus"`
+	MemoryMB       int64                             `json:"memoryMB"`
+	DiskSizeGB     *int64                            `json:"diskSizeGB,omitempty"`
+	Tags           []Tag                             `json:"tags,omitempty"`
+	AllowInsecure  providerconfigtypes.ConfigVarBool `json:"allowInsecure"`
+	VMAntiAffinity providerconfigtypes.ConfigVarBool `json:"vmAntiAffinity"`
 }
 
 // Tag represents vsphere tag.

--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -30,7 +30,8 @@ type RawConfig struct {
 	VSphereURL     providerconfigtypes.ConfigVarString `json:"vsphereURL"`
 	Datacenter     providerconfigtypes.ConfigVarString `json:"datacenter"`
 
-	// Cluster is a noop field, it's not used anywhere but left here intentionally for backward compatibility purposes
+	// Cluster defines the cluster to use in vcenter.
+	// Only needed for vm anti affinity.
 	Cluster providerconfigtypes.ConfigVarString `json:"cluster"`
 
 	Folder       providerconfigtypes.ConfigVarString `json:"folder"`

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-datastore-cluster.yaml
@@ -33,6 +33,8 @@ spec:
             folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
+            cluster: Kubermatic
+            vmAntiAffinity: true
             datastoreCluster: 'dsc-1'
             cpus: 2
             MemoryMB: 2048

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-resource-pool.yaml
@@ -34,6 +34,8 @@ spec:
             password: << VSPHERE_PASSWORD >>
             datastore: 'vsan'
             resourcePool: 'e2e-resource-pool'
+            cluster: Kubermatic
+            vmAntiAffinity: true
             cpus: 2
             MemoryMB: 2048
             diskSizeGB: << DISK_SIZE >>

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere-static-ip.yaml
@@ -32,7 +32,9 @@ spec:
             datacenter: 'Hamburg'
             folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
-            # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
+            # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically3
+            cluster: Kubermatic
+            vmAntiAffinity: true
             datastore: vsan
             cpus: 2
             MemoryMB: 2048

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -33,6 +33,8 @@ spec:
             folder: '/Hamburg/vm/Kubermatic-ci'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
+            cluster: Kubermatic
+            vmAntiAffinity: true
             datastore: vsan
             cpus: 2
             MemoryMB: 4096


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces vmware anti affinity rule creation, per machine.

To ensure a concurrent safe usage of the vsphere api, the create or update operation are synced via mutex which is only unlocked if the api returns the desired change or a timeout appears. 

This feature can be enabled/disabled by setting: `vmAntiAffinity: true` in the cloud provider spec.

Required Permissions:

AutoDeploy:

- Rule:
  - Create
  - Delete
  - Edit

Host:
- Inventory:
  -  Modify cluster

Docs required for the updated permissions.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1340 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add VMs to an Anti-Affinity rule (vSphere only)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1455
```
