### PR TITLE
[release/v1.54] pin cluster-exposer to a Go 1.18 compatible release

### DIFF
--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -157,7 +157,7 @@ if [ -z "${DISABLE_CLUSTER_EXPOSER:-}" ]; then
     cd /tmp/kubermatic
     echodate "Cloning cluster exposer"
     KKP_REPO_URL="${KKP_REPO_URL:-https://github.com/kubermatic/kubermatic.git}"
-    KKP_REPO_TAG="${KKP_REPO_BRANCH:-main}"
+    KKP_REPO_TAG="${KKP_REPO_BRANCH:-release/v2.21}"
     git clone --depth 1 --branch "${KKP_REPO_TAG}" "${KKP_REPO_URL}" .
 
     echodate "Building cluster exposer"


### PR DESCRIPTION
**What this PR does / why we need it**:
This ensures we do not accidentally get a more recent version than we can handle, as `k8s.io/kube-openapi` quickly required Go 1.19/generics. See for example the 2 different kube-openapi versions cloned in https://public-prow.loodse.com/view/gs/prow-dev-public-data/pr-logs/pull/kubermatic_machine-controller/1654/pull-machine-controller-e2e-kubevirt/1664813514599960576

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
