### PR TITLE
KubeVirt: support for OCI VM image source

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -64,6 +64,7 @@ type kubevirtProviderSpecConf struct {
 	AffinityValues           bool
 	SecondaryDisks           bool
 	OsImageSource            imageSource
+	OsImageSourceURL         string
 }
 
 func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
@@ -123,7 +124,7 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 					{{- if .OsImageDV }}
 					"osImage": "{{ .OsImageDV }}",
 					{{- else }}
-					"osImage": "http://x.y.z.t/ubuntu.img",
+					"osImage": "{{ if .OsImageSourceURL }}{{ .OsImageSourceURL }}{{ else }}http://x.y.z.t/ubuntu.img{{ end }}",
 					{{- end }}
 					"size": "10Gi",
 					{{- if .OsImageSource }}
@@ -215,6 +216,10 @@ func TestNewVirtualMachine(t *testing.T) {
 		{
 			name:     "http-image-source",
 			specConf: kubevirtProviderSpecConf{OsImageSource: httpSource},
+		},
+		{
+			name:     "registry-image-source",
+			specConf: kubevirtProviderSpecConf{OsImageSource: registrySource, OsImageSourceURL: "docker://x.y.z.t/ubuntu.img:latest"},
 		},
 		{
 			name:     "pvc-image-source",

--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	cloudprovidertesting "github.com/kubermatic/machine-controller/pkg/cloudprovider/testing"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
@@ -65,6 +66,7 @@ type kubevirtProviderSpecConf struct {
 	SecondaryDisks           bool
 	OsImageSource            imageSource
 	OsImageSourceURL         string
+	PullMethod               cdiv1beta1.RegistryPullMethod
 }
 
 func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
@@ -126,6 +128,9 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 					{{- else }}
 					"osImage": "{{ if .OsImageSourceURL }}{{ .OsImageSourceURL }}{{ else }}http://x.y.z.t/ubuntu.img{{ end }}",
 					{{- end }}
+					{{- if .PullMethod }}
+					"pullMethod": "{{ .PullMethod }}",
+					{{- end}}
 					"size": "10Gi",
 					{{- if .OsImageSource }}
 					"source": "{{ .OsImageSource }}",
@@ -220,6 +225,10 @@ func TestNewVirtualMachine(t *testing.T) {
 		{
 			name:     "registry-image-source",
 			specConf: kubevirtProviderSpecConf{OsImageSource: registrySource, OsImageSourceURL: "docker://x.y.z.t/ubuntu.img:latest"},
+		},
+		{
+			name:     "registry-image-source-pod",
+			specConf: kubevirtProviderSpecConf{OsImageSource: registrySource, OsImageSourceURL: "docker://x.y.z.t/ubuntu.img:latest", PullMethod: cdiv1beta1.RegistryPullPod},
 		},
 		{
 			name:     "pvc-image-source",

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
@@ -1,0 +1,78 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  labels:
+    kubevirt.io/vm: registry-image-source-pod
+    cluster.x-k8s.io/cluster-name: cluster-name
+    cluster.x-k8s.io/role: worker
+    md: md-name
+  name: registry-image-source-pod
+  namespace: test-namespace
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: registry-image-source-pod
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+          storageClassName: longhorn
+        source:
+          registry:
+            url: docker://x.y.z.t/ubuntu.img:latest
+            pullMethod: pod
+  runStrategy: Once
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        kubevirt.io/vm: registry-image-source-pod
+        cluster.x-k8s.io/cluster-name: cluster-name
+        cluster.x-k8s.io/role: worker
+        md: md-name
+    spec:
+      affinity: {}
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: datavolumedisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - macAddress: b6:f5:b4:fe:45:1d
+              name: default
+              bridge: {}
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 30
+      topologyspreadconstraints:
+        - maxskew: 1
+          topologykey: kubernetes.io/hostname
+          whenunsatisfiable: ScheduleAnyway
+          labelselector:
+            matchlabels:
+              md: md-name
+      volumes:
+        - dataVolume:
+            name: registry-image-source-pod
+          name: datavolumedisk
+        - cloudInitNoCloud:
+            secretRef:
+              name: udsn
+          name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
@@ -1,0 +1,78 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  labels:
+    kubevirt.io/vm: registry-image-source
+    cluster.x-k8s.io/cluster-name: cluster-name
+    cluster.x-k8s.io/role: worker
+    md: md-name
+  name: registry-image-source
+  namespace: test-namespace
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: registry-image-source
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+          storageClassName: longhorn
+        source:
+          registry:
+            url: docker://x.y.z.t/ubuntu.img:latest
+            pullMethod: node
+  runStrategy: Once
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        kubevirt.io/vm: registry-image-source
+        cluster.x-k8s.io/cluster-name: cluster-name
+        cluster.x-k8s.io/role: worker
+        md: md-name
+    spec:
+      affinity: {}
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: datavolumedisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - macAddress: b6:f5:b4:fe:45:1d
+              name: default
+              bridge: {}
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 30
+      topologyspreadconstraints:
+        - maxskew: 1
+          topologykey: kubernetes.io/hostname
+          whenunsatisfiable: ScheduleAnyway
+          labelselector:
+            matchlabels:
+              md: md-name
+      volumes:
+        - dataVolume:
+            name: registry-image-source
+          name: datavolumedisk
+        - cloudInitNoCloud:
+            secretRef:
+              name: udsn
+          name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -79,6 +79,8 @@ type PrimaryDisk struct {
 	OsImage providerconfigtypes.ConfigVarString `json:"osImage,omitempty"`
 	// Source describes the VM Disk Image source.
 	Source providerconfigtypes.ConfigVarString `json:"source,omitempty"`
+	// PullMethod describes the VM Disk Image source optional pull method for registry source. Defaults to 'node'.
+	PullMethod providerconfigtypes.ConfigVarString `json:"pullMethod,omitempty"`
 }
 
 // SecondaryDisks.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for OCI VM image source for `docker` and `oci-archive` implemented by [CDI](https://github.com/kubevirt/containerized-data-importer/blob/v1.55.2/staging/src/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/types.go#L174-L177).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
see also: https://github.com/kubermatic/kubermatic/issues/12341

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubevirt: support OCI VM image source
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```