### PR TITLE
Support for configuring multiple NICs for vSphere

### DIFF
--- a/docs/vsphere.md
+++ b/docs/vsphere.md
@@ -226,7 +226,8 @@ datacenter: datacenter1
 # VM template name
 templateVMName: ubuntu-template
 # Optional. Sets the networks on the VM. If no network is specified, the template default will be used.
-vmNetName: network1
+networks:
+- network1
 # Optional
 folder: folder1
 # Optional: Force VMs to be provisoned to the specified resourcePool

--- a/examples/vsphere-datastore-cluster-machinedeployment.yaml
+++ b/examples/vsphere-datastore-cluster-machinedeployment.yaml
@@ -51,7 +51,8 @@ spec:
             datacenter: datacenter1
             templateVMName: ubuntu-template
             # Optional. Sets the networks on the VM. If no network is specified, the template default will be used.
-            vmNetName: network1
+            networks:
+              - network1
             # Optional
             folder: folder1
             datastoreCluster: datastorecluster1

--- a/examples/vsphere-machinedeployment.yaml
+++ b/examples/vsphere-machinedeployment.yaml
@@ -51,7 +51,8 @@ spec:
             datacenter: datacenter1
             templateVMName: ubuntu-template
             # Optional. Sets the networks on the VM. If no network is specified, the template default will be used.
-            vmNetName: network1
+            networks:
+              - network1
             # Optional
             folder: folder1
             datastore: datastore1

--- a/pkg/cloudprovider/provider/vsphere/helper.go
+++ b/pkg/cloudprovider/provider/vsphere/helper.go
@@ -192,8 +192,8 @@ func createClonedVM(ctx context.Context, log *zap.SugaredLogger, vmName string, 
 		deviceSpecs = append(deviceSpecs, diskspec)
 	}
 
-	if config.VMNetName != "" {
-		networkSpecs, err := GetNetworkSpecs(ctx, session, vmDevices, config.VMNetName)
+	if config.VMNetName != "" || len(config.Networks) > 0 {
+		networkSpecs, err := GetNetworkSpecs(ctx, session, vmDevices, config.VMNetName, config.Networks)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get network specifications: %w", err)
 		}

--- a/pkg/cloudprovider/provider/vsphere/provider_test.go
+++ b/pkg/cloudprovider/provider/vsphere/provider_test.go
@@ -64,7 +64,9 @@ func (v vsphereProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 		"password": "{{ .Password }}",
 		"templateVMName": "DC0_H0_VM0",
 		"username": "{{ .User }}",
-		"vmNetName": "",
+		"networks": [
+			""
+		],
 		"vsphereURL": "{{ .URL }}"
 	},
 	"operatingSystem": "flatcar",

--- a/pkg/cloudprovider/provider/vsphere/types/types.go
+++ b/pkg/cloudprovider/provider/vsphere/types/types.go
@@ -24,11 +24,13 @@ import (
 // RawConfig represents vsphere specific configuration.
 type RawConfig struct {
 	TemplateVMName providerconfigtypes.ConfigVarString `json:"templateVMName"`
-	VMNetName      providerconfigtypes.ConfigVarString `json:"vmNetName"`
-	Username       providerconfigtypes.ConfigVarString `json:"username"`
-	Password       providerconfigtypes.ConfigVarString `json:"password"`
-	VSphereURL     providerconfigtypes.ConfigVarString `json:"vsphereURL"`
-	Datacenter     providerconfigtypes.ConfigVarString `json:"datacenter"`
+	// Deprecated: use networks instead.
+	VMNetName  providerconfigtypes.ConfigVarString   `json:"vmNetName"`
+	Networks   []providerconfigtypes.ConfigVarString `json:"networks"`
+	Username   providerconfigtypes.ConfigVarString   `json:"username"`
+	Password   providerconfigtypes.ConfigVarString   `json:"password"`
+	VSphereURL providerconfigtypes.ConfigVarString   `json:"vsphereURL"`
+	Datacenter providerconfigtypes.ConfigVarString   `json:"datacenter"`
 
 	// Cluster defines the cluster to use in vcenter.
 	// Only needed for vm anti affinity.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for configuring multiple networks for VMs on vSphere. The field `vmNetName` is considered deprecated and `networks` should be used instead. In case both network and vmNetName are specified, the validating webhooks will reject the machine deployment.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1671

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Support for configuring multiple networks for vSphere.
* [Action Required] The field `vmNetName` is considered deprecated for vSphere and `networks` should be used instead.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
