### PR TITLE
[release/v1.54] Fix CI job for license validation

### DIFF
--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -149,7 +149,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/wwhrd:0.4.0-1
+        - image: quay.io/kubermatic/build:go-1.18-node-16-kind-0.14-9
           command:
             - ./hack/verify-licenses.sh
           resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
The `pull-machine-controller-license-validation` was failing with:

```
go: downloading github.com/Azure/go-autorest/autorest/validation v0.3.1
github.com/kubermatic/machine-controller/pkg/admission imports
	golang.org/x/crypto/ssh imports
	golang.org/x/crypto/curve25519 imports
	crypto/ecdh: package crypto/ecdh is not in GOROOT (/usr/local/go/src/crypto/ecdh)
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
