### PR TITLE
Propagate datastore cluster for vSphere to cloud-config

### DIFF
--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -618,6 +618,11 @@ func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config stri
 		workingDir = fmt.Sprintf("/%s/vm", c.Datacenter)
 	}
 
+	datastore := c.Datastore
+	if datastore == "" {
+		datastore = c.DatastoreCluster
+	}
+
 	cc := &vspheretypes.CloudConfig{
 		Global: vspheretypes.GlobalOpts{
 			User:         c.Username,
@@ -631,7 +636,7 @@ func (p *provider) GetCloudConfig(spec clusterv1alpha1.MachineSpec) (config stri
 		Workspace: vspheretypes.WorkspaceOpts{
 			Datacenter:       c.Datacenter,
 			VCenterIP:        u.Hostname(),
-			DefaultDatastore: c.Datastore,
+			DefaultDatastore: datastore,
 			Folder:           workingDir,
 		},
 		VirtualCenter: map[string]*vspheretypes.VirtualCenterConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:
In case user has specified `DatastoreCluster` for a machine deployment on vSphere, we should use that as the `datastore` in cloud-config so that the disks attached to the VM are placed accordingly.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vSphere: Fix a bug where datastore cluster value was not being propagated to the cloud-config
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
