### PR TITLE
Fix isssue of creation of multiple vultr instance due to eventual consistency

### DIFF
--- a/examples/vultr-machinedeployment.yaml
+++ b/examples/vultr-machinedeployment.yaml
@@ -43,9 +43,22 @@ spec:
                 namespace: kube-system
                 name: machine-controller-vultr
                 key: apiKey
+            # Default is false meaning a virtual machine instance is created
+            # If true, a bare metal instance is created
+            physicalMachine: false
             region: blr
             plan: "vhf-8c-32gb"
+            # This takes precedence over enableVPC
+            vpcId:
+            - <VPC_IDS>
+            # For more reference, see
+            # https://www.vultr.com/api/#tag/instances/operation/create-instance
+            enableVPC: false
+            enableVPC2: true
+            vpc2Id:
+            - <VPC_IDS>
             # Required: app_id, image_id, os_id, snapshot_id, or iso_id must be provided. Currently only os_id is supported.
+            # This takes precedence over operatingSystem
             osId: 215
             # Optional
             tags:

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/tinkerbell/tink v0.8.0
 	github.com/vmware/go-vcloud-director/v2 v2.21.0
 	github.com/vmware/govmomi v0.30.7
-	github.com/vultr/govultr/v2 v2.17.2
+	github.com/vultr/govultr/v3 v3.3.1
 	go.anx.io/go-anxcloud v0.5.3
 	go.uber.org/zap v1.25.0
 	golang.org/x/crypto v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -720,8 +720,8 @@ github.com/vmware/govmomi v0.30.7 h1:YO8CcDpLJzmq6PK5/CBQbXyV21iCMh8SbdXt+xNkXp8
 github.com/vmware/govmomi v0.30.7/go.mod h1:epgoslm97rLECMV4D+08ORzUBEU7boFSepKjt7AYVGg=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/vmware/vmw-ovflib v0.0.0-20170608004843-1f217b9dc714/go.mod h1:jiPk45kn7klhByRvUq5i2vo1RtHKBHj+iWGFpxbXuuI=
-github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
-github.com/vultr/govultr/v2 v2.17.2/go.mod h1:ZFOKGWmgjytfyjeyAdhQlSWwTjh2ig+X49cAp50dzXI=
+github.com/vultr/govultr/v3 v3.3.1 h1:gn46pSL0A3pxBKZklzwtYgSW2Iq7dW1euDRBlOsIzTo=
+github.com/vultr/govultr/v3 v3.3.1/go.mod h1:7NjuHeQv5vgUWR2H1sPc9D+xffrT5ql+kNi6R3yuwzo=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=

--- a/pkg/cloudprovider/provider/vultr/provider.go
+++ b/pkg/cloudprovider/provider/vultr/provider.go
@@ -18,11 +18,14 @@ package vultr
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"strconv"
+	"time"
 
-	"github.com/vultr/govultr/v2"
+	"github.com/vultr/govultr/v3"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
@@ -38,7 +41,19 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
+
+const (
+	createCheckPeriod           = 10 * time.Second
+	createCheckTimeout          = 5 * time.Minute
+	createCheckFailedWaitPeriod = 10 * time.Second
+)
+
+type ValidVPC struct {
+	IsAllValid  bool
+	InvalidVpcs []string
+}
 
 type provider struct {
 	configVarResolver *providerconfig.ConfigVarResolver
@@ -50,11 +65,17 @@ func New(configVarResolver *providerconfig.ConfigVarResolver) cloudprovidertypes
 }
 
 type Config struct {
-	APIKey string
-	Region string
-	Plan   string
-	OsID   string
-	Tags   []string
+	PhysicalMachine bool
+	APIKey          string
+	Region          string
+	Plan            string
+	OsID            string
+	Tags            []string
+	VpcID           []string
+	EnableVPC       bool
+	EnableIPv6      bool
+	EnableVPC2      bool
+	Vpc2ID          []string
 }
 
 func getIDForOS(os providerconfigtypes.OperatingSystem) (int, error) {
@@ -97,6 +118,7 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	}
 
 	c := Config{}
+
 	c.APIKey, err = p.configVarResolver.GetConfigVarStringValueOrEnv(rawConfig.APIKey, "VULTR_API_KEY")
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get the value of \"apiKey\" field, error = %w", err)
@@ -118,12 +140,80 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	}
 
 	c.Tags = rawConfig.Tags
+	c.PhysicalMachine = rawConfig.PhysicalMachine
+	c.EnableIPv6 = rawConfig.EnableIPv6
+	c.VpcID = rawConfig.VpcID
+	c.EnableVPC = rawConfig.EnableVPC
+	c.EnableVPC2 = rawConfig.EnableVPC2
+	c.Vpc2ID = rawConfig.Vpc2ID
 
 	return &c, pconfig, err
 }
 
 func (p *provider) AddDefaults(_ *zap.SugaredLogger, spec clusterv1alpha1.MachineSpec) (clusterv1alpha1.MachineSpec, error) {
 	return spec, nil
+}
+
+func (p *provider) validateVpc(ctx context.Context, client *govultr.Client, c *Config, legacyVPC bool) (ValidVPC, error) {
+	validVpc := ValidVPC{IsAllValid: true}
+	accountvpcs := []string{}
+	var requestedvpcs []string
+
+	if legacyVPC {
+		for {
+			vpcs, meta, err := func(ctx context.Context, client *govultr.Client) ([]govultr.VPC, *govultr.Meta, error) {
+				vpcs, meta, resp, err := client.VPC.List(ctx, &govultr.ListOptions{})
+				if err != nil {
+					return nil, nil, vltErrorToTerminalError(resp.StatusCode, err)
+				}
+				defer resp.Body.Close()
+
+				return vpcs, meta, nil
+			}(ctx, client)
+			if err != nil {
+				return validVpc, err
+			}
+			for _, v := range vpcs {
+				accountvpcs = append(accountvpcs, v.ID)
+			}
+			if meta.Links.Next == "" {
+				break
+			}
+		}
+		requestedvpcs = c.VpcID
+	} else {
+		for {
+			vpcs, meta, err := func(ctx context.Context, client *govultr.Client) ([]govultr.VPC2, *govultr.Meta, error) {
+				vpcs, meta, resp, err := client.VPC2.List(ctx, &govultr.ListOptions{})
+				if err != nil {
+					return nil, nil, vltErrorToTerminalError(resp.StatusCode, err)
+				}
+				defer resp.Body.Close()
+
+				return vpcs, meta, nil
+			}(ctx, client)
+			if err != nil {
+				return validVpc, err
+			}
+			for _, v := range vpcs {
+				accountvpcs = append(accountvpcs, v.ID)
+			}
+			if meta.Links.Next == "" {
+				break
+			}
+		}
+		requestedvpcs = c.Vpc2ID
+	}
+	accountvpcsset := sets.New[string](accountvpcs...)
+	// Iterator to provide user the exact mismatches
+	for _, v := range requestedvpcs {
+		if !accountvpcsset.Has(v) {
+			validVpc.IsAllValid = false
+			validVpc.InvalidVpcs = append(validVpc.InvalidVpcs, v)
+		}
+	}
+
+	return validVpc, nil
 }
 
 func (p *provider) Validate(ctx context.Context, _ *zap.SugaredLogger, spec clusterv1alpha1.MachineSpec) error {
@@ -155,12 +245,13 @@ func (p *provider) Validate(ctx context.Context, _ *zap.SugaredLogger, spec clus
 
 	client := getClient(ctx, c.APIKey)
 
-	plans, err := client.Region.Availability(ctx, c.Region, "")
+	plans, resp, err := client.Region.Availability(ctx, c.Region, "")
 
 	// TODO: Validate region separately
 	if err != nil {
-		return fmt.Errorf("invalid/not supported region specified %q: %w", c.Region, err)
+		return err
 	}
+	resp.Body.Close()
 
 	planFound := false
 
@@ -168,37 +259,73 @@ func (p *provider) Validate(ctx context.Context, _ *zap.SugaredLogger, spec clus
 	for _, plan := range plans.AvailablePlans {
 		if plan == c.Plan {
 			planFound = true
+			break
 		}
 	}
 	if !planFound {
-		return fmt.Errorf("invalid/not supported plan specified %q: %w", c.Plan, err)
+		return fmt.Errorf("invalid/not supported plan specified %q, available plans are: %q, %w", c.Plan, plans.AvailablePlans, err)
 	}
+
+	validvpc, err := p.validateVpc(ctx, client, c, false)
+	if err != nil {
+		return err
+	}
+	if !validvpc.IsAllValid {
+		return fmt.Errorf("invalid/not supported vpc id specified %v", validvpc.InvalidVpcs)
+	}
+
+	if c.PhysicalMachine {
+		// Don't check for validity of legacy VPC as BareMetal doesn't support VPC v1
+		return nil
+	}
+
+	// Verify legacy VPCs
+	validvpc, err = p.validateVpc(ctx, client, c, true)
+	if err != nil {
+		return err
+	}
+
+	if !validvpc.IsAllValid {
+		return fmt.Errorf("invalid/not supported vpc id specified %v", validvpc.InvalidVpcs)
+	}
+
 	return nil
 }
 
-func (p *provider) get(ctx context.Context, machine *clusterv1alpha1.Machine) (*vultrInstance, error) {
-	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
-	if err != nil {
-		return nil, cloudprovidererrors.TerminalError{
-			Reason:  common.InvalidConfigurationMachineError,
-			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
-		}
-	}
-
+func (p *provider) getPhysicalMachine(ctx context.Context, c *Config, machine *clusterv1alpha1.Machine) (*vultrPhysicalMachine, error) {
 	client := getClient(ctx, c.APIKey)
-
-	instances, _, err := client.Instance.List(ctx, &govultr.ListOptions{
+	// Not looping on metadata assuming that tagged machines won;t cross
+	// pagination boundary
+	instances, _, resp, err := client.BareMetalServer.List(ctx, &govultr.ListOptions{
 		Tag: string(machine.UID),
 	})
 	if err != nil {
-		return nil, vltErrorToTerminalError(err, "failed to list servers")
+		return nil, vltErrorToTerminalError(resp.StatusCode, err)
 	}
+	resp.Body.Close()
+	for _, instance := range instances {
+		if sets.NewString(instance.Tags...).Has(string(machine.UID)) {
+			return &vultrPhysicalMachine{instance: &instance}, nil
+		}
+	}
+	return nil, cloudprovidererrors.ErrInstanceNotFound
+}
+
+func (p *provider) getVirtualMachine(ctx context.Context, c *Config, machine *clusterv1alpha1.Machine) (*vultrVirtualMachine, error) {
+	client := getClient(ctx, c.APIKey)
+
+	instances, _, resp, err := client.Instance.List(ctx, &govultr.ListOptions{
+		Tag: string(machine.UID),
+	})
+	if err != nil {
+		return nil, vltErrorToTerminalError(resp.StatusCode, err)
+	}
+	resp.Body.Close()
 
 	for _, instance := range instances {
-		for _, tag := range instance.Tags {
-			if tag == string(machine.UID) {
-				return &vultrInstance{instance: &instance}, nil
-			}
+		if sets.NewString(instance.Tags...).Has(string(machine.UID)) &&
+			instance.Label == machine.Name {
+			return &vultrVirtualMachine{instance: &instance}, nil
 		}
 	}
 
@@ -206,14 +333,101 @@ func (p *provider) get(ctx context.Context, machine *clusterv1alpha1.Machine) (*
 }
 
 func (p *provider) Get(ctx context.Context, _ *zap.SugaredLogger, machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
-	return p.get(ctx, machine)
+	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	if err != nil {
+		return nil, cloudprovidererrors.TerminalError{
+			Reason:  common.InvalidConfigurationMachineError,
+			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
+		}
+	}
+	if !c.PhysicalMachine {
+		return p.getVirtualMachine(ctx, c, machine)
+	}
+
+	return p.getPhysicalMachine(ctx, c, machine)
 }
 
 func (p *provider) GetCloudConfig(_ clusterv1alpha1.MachineSpec) (config string, name string, err error) {
 	return "", "", nil
 }
 
-func (p *provider) Create(ctx context.Context, _ *zap.SugaredLogger, machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
+func (p *provider) waitForInstanceCreation(ctx context.Context, c *Config, instance instance.Instance, machine *clusterv1alpha1.Machine) error {
+	return wait.PollUntilContextTimeout(ctx, createCheckPeriod, createCheckTimeout, false, func(ctx context.Context) (bool, error) {
+		var err error
+		if !c.PhysicalMachine {
+			_, err = p.getVirtualMachine(ctx, c, machine)
+		} else {
+			_, err = p.getPhysicalMachine(ctx, c, machine)
+		}
+
+		if err != nil {
+			if cloudprovidererrors.IsNotFound(err) {
+				// Continue the loop as the instances was successfully fetched
+				// just that our instance was not found
+				return false, nil
+			}
+			if isTerminalErr, _, _ := cloudprovidererrors.IsTerminalError(err); isTerminalErr {
+				return true, err
+			}
+			// Wait for some time as instance creation is successful
+			// just that we are not able to fetch it
+			time.Sleep(createCheckFailedWaitPeriod)
+			return false, fmt.Errorf("instance %q created but controller failed to fetch instance details", instance.Name())
+		}
+		return true, nil
+	})
+}
+
+func (p *provider) createVirtualMachine(ctx context.Context, client *govultr.Client, c *Config, machine *clusterv1alpha1.Machine, osid int, userdata string) (*vultrVirtualMachine, error) {
+	tags := sets.List[string](sets.New(c.Tags...).Insert(string(machine.UID)))
+
+	instanceCreateRequest := govultr.InstanceCreateReq{
+		Region: c.Region,
+		Plan:   c.Plan,
+		OsID:   osid,
+
+		Label:    machine.Spec.Name,
+		UserData: base64.StdEncoding.EncodeToString([]byte(userdata)),
+		Tags:     tags,
+
+		EnableIPv6: &c.EnableIPv6,
+		EnableVPC:  &c.EnableVPC,
+		AttachVPC:  c.VpcID,
+		EnableVPC2: &c.EnableVPC2,
+		AttachVPC2: c.Vpc2ID,
+	}
+	instance, resp, err := client.Instance.Create(ctx, &instanceCreateRequest)
+	if err != nil {
+		return nil, vltErrorToTerminalError(resp.StatusCode, err)
+	}
+	resp.Body.Close()
+
+	return &vultrVirtualMachine{instance: instance}, nil
+}
+
+func (p *provider) createPhysicalMachine(ctx context.Context, client *govultr.Client, c *Config, machine *clusterv1alpha1.Machine, osid int, userdata string) (*vultrPhysicalMachine, error) {
+	tags := sets.NewString(c.Tags...).Insert(string(machine.UID)).List()
+
+	bareMetalCreateRequest := govultr.BareMetalCreate{
+		Region:     c.Region,
+		Plan:       c.Plan,
+		Label:      machine.Spec.Name,
+		UserData:   base64.StdEncoding.EncodeToString([]byte(userdata)),
+		EnableIPv6: &c.EnableIPv6,
+		Tags:       tags,
+		OsID:       osid,
+		AttachVPC2: c.Vpc2ID,
+		EnableVPC2: &c.EnableVPC2,
+	}
+	instance, resp, err := client.BareMetalServer.Create(ctx, &bareMetalCreateRequest)
+	if err != nil {
+		return nil, vltErrorToTerminalError(resp.StatusCode, err)
+	}
+	resp.Body.Close()
+	return &vultrPhysicalMachine{instance: instance}, nil
+}
+
+func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
 	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
@@ -221,8 +435,6 @@ func (p *provider) Create(ctx context.Context, _ *zap.SugaredLogger, machine *cl
 			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
 		}
 	}
-
-	client := getClient(ctx, c.APIKey)
 
 	if c.OsID == "" {
 		osID, err := getIDForOS(pc.OperatingSystem)
@@ -234,33 +446,42 @@ func (p *provider) Create(ctx context.Context, _ *zap.SugaredLogger, machine *cl
 		}
 		c.OsID = strconv.Itoa(osID)
 	}
-
-	if c.Tags == nil {
-		c.Tags = []string{}
-	}
-
-	c.Tags = append(c.Tags, string(machine.UID))
-
 	strOsID, err := strconv.Atoi(c.OsID)
 	if err != nil {
+		return nil, cloudprovidererrors.TerminalError{
+			Reason:  common.InvalidConfigurationMachineError,
+			Message: fmt.Sprintf("Cannot parse operating system id %q, details = %v", pc.OperatingSystem, err),
+		}
+	}
+	client := getClient(ctx, c.APIKey)
+
+	var instance instance.Instance
+	if !c.PhysicalMachine {
+		instance, err = p.createVirtualMachine(ctx, client, c, machine, strOsID, userdata)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		instance, err = p.createPhysicalMachine(ctx, client, c, machine, strOsID, userdata)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = p.waitForInstanceCreation(ctx, c, instance, machine)
+	if err != nil {
+		if !c.PhysicalMachine {
+			if err := client.Instance.Delete(ctx, instance.ID()); err != nil {
+				log.Error("Failed to cleanup instance after failed creation: %v", err)
+			}
+		} else {
+			if err := client.BareMetalServer.Delete(ctx, instance.ID()); err != nil {
+				log.Error("Failed to cleanup bare metal instance after failed creation: %v", err)
+			}
+		}
 		return nil, err
 	}
-
-	instanceCreateRequest := govultr.InstanceCreateReq{
-		Region:   c.Region,
-		Plan:     c.Plan,
-		Label:    machine.Spec.Name,
-		UserData: userdata,
-		Tags:     c.Tags,
-		OsID:     strOsID,
-	}
-
-	res, err := client.Instance.Create(ctx, &instanceCreateRequest)
-	if err != nil {
-		return nil, vltErrorToTerminalError(err, "failed to create server")
-	}
-
-	return &vultrInstance{instance: res}, nil
+	return instance, nil
 }
 
 func (p *provider) Cleanup(ctx context.Context, log *zap.SugaredLogger, machine *clusterv1alpha1.Machine, data *cloudprovidertypes.ProviderData) (bool, error) {
@@ -281,8 +502,14 @@ func (p *provider) Cleanup(ctx context.Context, log *zap.SugaredLogger, machine 
 	}
 	client := getClient(ctx, c.APIKey)
 
-	if err = client.Instance.Delete(ctx, instance.ID()); err != nil {
-		return false, vltErrorToTerminalError(err, "failed to delete server")
+	if !c.PhysicalMachine {
+		if err := client.Instance.Delete(ctx, instance.ID()); err != nil {
+			return false, fmt.Errorf("failed to delete instance: %w", err)
+		}
+	} else {
+		if err := client.BareMetalServer.Delete(ctx, instance.ID()); err != nil {
+			return false, fmt.Errorf("failed to delete bare metal instance: %w", err)
+		}
 	}
 
 	return false, nil
@@ -306,49 +533,87 @@ func (p *provider) MigrateUID(ctx context.Context, _ *zap.SugaredLogger, machine
 		return fmt.Errorf("failed to decode providerconfig: %w", err)
 	}
 	client := getClient(ctx, c.APIKey)
-	instances, _, err := client.Instance.List(ctx, &govultr.ListOptions{PerPage: 1000})
-	if err != nil {
-		return fmt.Errorf("failed to list instances: %w", err)
-	}
 
-	for _, instance := range instances {
-		if instance.Label == machine.Spec.Name && sets.NewString(instance.Tags...).Has(string(machine.UID)) {
-			_, err = client.Instance.Update(ctx, instance.ID, &govultr.InstanceUpdateReq{
-				Tags: sets.NewString(instance.Tags...).Delete(string(machine.UID)).Insert(string(newUID)).List(),
-			})
-			if err != nil {
-				return fmt.Errorf("failed to tag instance with new UID tag: %w", err)
-			}
+	if !c.PhysicalMachine {
+		instance, err := p.getVirtualMachine(ctx, c, machine)
+		if err != nil {
+			return err
 		}
+		_, resp, err := client.Instance.Update(ctx, instance.instance.ID, &govultr.InstanceUpdateReq{
+			Tags: sets.NewString(instance.instance.Tags...).Delete(string(machine.UID)).Insert(string(newUID)).List(),
+		})
+		if err != nil {
+			return vltErrorToTerminalError(resp.StatusCode, err)
+		}
+		resp.Body.Close()
+		return nil
 	}
-
+	instance, err := p.getPhysicalMachine(ctx, c, machine)
+	if err != nil {
+		return fmt.Errorf("failed to get instance with UID tag: %w", err)
+	}
+	_, resp, err := client.BareMetalServer.Update(ctx, instance.instance.ID, &govultr.BareMetalUpdate{
+		Tags: sets.NewString(instance.instance.Tags...).Delete(string(machine.UID)).Insert(string(newUID)).List(),
+	})
+	if err != nil {
+		return vltErrorToTerminalError(resp.StatusCode, err)
+	}
+	resp.Body.Close()
 	return nil
 }
 
-type vultrInstance struct {
+type vultrVirtualMachine struct {
 	instance *govultr.Instance
 }
+type vultrPhysicalMachine struct {
+	instance *govultr.BareMetalServer
+}
 
-func (v *vultrInstance) Name() string {
+func (v *vultrVirtualMachine) Name() string {
+	return v.instance.Label
+}
+func (v *vultrPhysicalMachine) Name() string {
 	return v.instance.Label
 }
 
-func (v *vultrInstance) ID() string {
+func (v *vultrVirtualMachine) ID() string {
+	return v.instance.ID
+}
+func (v *vultrPhysicalMachine) ID() string {
 	return v.instance.ID
 }
 
-func (v *vultrInstance) ProviderID() string {
+func (v *vultrVirtualMachine) ProviderID() string {
+	return "vultr://" + v.instance.ID
+}
+func (v *vultrPhysicalMachine) ProviderID() string {
 	return "vultr://" + v.instance.ID
 }
 
-func (v *vultrInstance) Addresses() map[string]v1.NodeAddressType {
+func (v *vultrVirtualMachine) Addresses() map[string]v1.NodeAddressType {
 	addresses := map[string]v1.NodeAddressType{}
 	addresses[v.instance.MainIP] = v1.NodeExternalIP
 	addresses[v.instance.InternalIP] = v1.NodeInternalIP
 	return addresses
 }
+func (v *vultrPhysicalMachine) Addresses() map[string]v1.NodeAddressType {
+	addresses := map[string]v1.NodeAddressType{}
+	addresses[v.instance.MainIP] = v1.NodeExternalIP
+	return addresses
+}
 
-func (v *vultrInstance) Status() instance.Status {
+func (v *vultrVirtualMachine) Status() instance.Status {
+	switch v.instance.Status {
+	case "active":
+		return instance.StatusRunning
+	case "pending":
+		return instance.StatusCreating
+		// "suspending" or "resizing"
+	default:
+		return instance.StatusUnknown
+	}
+}
+func (v *vultrPhysicalMachine) Status() instance.Status {
 	switch v.instance.Status {
 	case "active":
 		return instance.StatusRunning
@@ -360,14 +625,16 @@ func (v *vultrInstance) Status() instance.Status {
 	}
 }
 
-func vltErrorToTerminalError(err error, msg string) error {
-	prepareAndReturnError := func() error {
-		return fmt.Errorf("%s, due to %w", msg, err)
+func vltErrorToTerminalError(status int, err error) error {
+	switch status {
+	case http.StatusUnauthorized:
+		return cloudprovidererrors.TerminalError{
+			Reason:  common.InvalidConfigurationMachineError,
+			Message: "A request has been rejected due to invalid credentials which were taken from the MachineSpec",
+		}
+	default:
+		return err
 	}
-	if err != nil {
-		return prepareAndReturnError()
-	}
-	return err
 }
 
 func (p *provider) SetMetricsForMachines(_ clusterv1alpha1.MachineList) error {

--- a/pkg/cloudprovider/provider/vultr/types/types.go
+++ b/pkg/cloudprovider/provider/vultr/types/types.go
@@ -22,11 +22,17 @@ import (
 )
 
 type RawConfig struct {
-	APIKey providerconfigtypes.ConfigVarString `json:"apiKey,omitempty"`
-	Region providerconfigtypes.ConfigVarString `json:"region"`
-	Plan   providerconfigtypes.ConfigVarString `json:"plan"`
-	OsID   providerconfigtypes.ConfigVarString `json:"osId"`
-	Tags   []string                            `json:"tags,omitempty"`
+	PhysicalMachine bool                                `json:"physicalMachine,omitempty"`
+	APIKey          providerconfigtypes.ConfigVarString `json:"apiKey,omitempty"`
+	Region          providerconfigtypes.ConfigVarString `json:"region"`
+	Plan            providerconfigtypes.ConfigVarString `json:"plan"`
+	OsID            providerconfigtypes.ConfigVarString `json:"osId"`
+	Tags            []string                            `json:"tags,omitempty"`
+	VpcID           []string                            `json:"vpcId,omitempty"`
+	Vpc2ID          []string                            `json:"vpc2Id,omitempty"`
+	EnableVPC       bool                                `json:"enableVPC,omitempty"`
+	EnableVPC2      bool                                `json:"enableVPC2,omitempty"`
+	EnableIPv6      bool                                `json:"enableIPv6,omitempty"`
 }
 
 func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
There has been a bug introduced because of vultr wherein the tags on instances are eventually consistent due to which machine controller is led to believe that the instance was not created as we poll instance based on label and tags. This PR wait for complete creation of the instance so that eventual fetches to get machine are more deterministic
Additionally, there is the support for Vultr bare metal instances
And suppport for specifying VPC v1/v2 for instances has been added in accordance to https://www.vultr.com/api/#tag/instances/operation/create-instance and https://www.vultr.com/api/#tag/baremetal/operation/create-baremetal

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1704

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Fixed multiple instance creation issue for vultr by waiting for instance to get started.
- Add support for vultr bare metal instances
- Upgrade govulr to v3
- Add support for vultr VPC v1/v2
- Handle go vultr API response codes 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
