### PR TITLE
Pin flatcar on AWS to 3510.2.8

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -168,7 +168,9 @@ var (
 		providerconfigtypes.OperatingSystemFlatcar: {
 			awstypes.CPUArchitectureX86_64: {
 				// Be as precise as possible - otherwise we might get a nightly dev build
-				description: "Flatcar Container Linux stable *",
+				// Pin flatcar to 3510.2.8 since the latest version 3602.2.0 is broken. Reference: https://github.com/kubermatic/kubermatic/issues/12690
+				// TODO: Remove this pinning once the issue is fixed.
+				description: "Flatcar Container Linux stable 3510.2.8 *",
 				// The AWS marketplace ID from AWS
 				owner: "075585003325",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Pin flatcar on AWS to 3510.2.8 since the latest version 3602.2.0 is broken. 

Reference: https://github.com/kubermatic/kubermatic/issues/12690

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Pin flatcar on AWS to 3510.2.8
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
