### PR TITLE
Revert "Pin flatcar to 3510.2.8 (#1711)"

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -168,9 +168,7 @@ var (
 		providerconfigtypes.OperatingSystemFlatcar: {
 			awstypes.CPUArchitectureX86_64: {
 				// Be as precise as possible - otherwise we might get a nightly dev build
-				// Pin flatcar to 3510.2.8 since the latest version 3602.2.0 is broken. Reference: https://github.com/kubermatic/kubermatic/issues/12690
-				// TODO: Remove this pinning once the issue is fixed.
-				description: "Flatcar Container Linux stable 3510.2.8 *",
+				description: "Flatcar Container Linux stable *",
 				// The AWS marketplace ID from AWS
 				owner: "075585003325",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit e6de2fe75fb141c6d8a937e0756f1376e0e792f9 since this issue is [resolved in OSM](https://github.com/kubermatic/operating-system-manager/pull/314) now and we don't need to pin the image for AWS anymore.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
