### PR TITLE
[release/v1.54] Revert "Pin flatcar to 3510.2.8 (#1714)"

### DIFF
--- a/examples/operating-system-manager.yaml
+++ b/examples/operating-system-manager.yaml
@@ -1076,7 +1076,7 @@ spec:
     spec:
       serviceAccountName: operating-system-manager-webhook
       containers:
-        - image: quay.io/kubermatic/operating-system-manager:v1.1.2
+        - image: quay.io/kubermatic/operating-system-manager:v1.1.4
           imagePullPolicy: IfNotPresent
           name: webhook
           command:
@@ -1377,7 +1377,7 @@ spec:
     spec:
       serviceAccountName: operating-system-manager
       containers:
-        - image: quay.io/kubermatic/operating-system-manager:v1.1.2
+        - image: quay.io/kubermatic/operating-system-manager:v1.1.4
           imagePullPolicy: IfNotPresent
           name: operating-system-manager
           command:

--- a/hack/ci/setup-machine-controller-in-kind.sh
+++ b/hack/ci/setup-machine-controller-in-kind.sh
@@ -23,7 +23,6 @@ fi
 
 export MC_VERSION="${MC_VERSION:-$(git rev-parse HEAD)}"
 export OPERATING_SYSTEM_MANAGER="${OPERATING_SYSTEM_MANAGER:-true}"
-OSM_TAG="v1.1.3"
 
 # Build the Docker image for machine-controller
 beforeDockerBuild=$(nowms)
@@ -70,9 +69,6 @@ if [[ "$OPERATING_SYSTEM_MANAGER" == "true" ]]; then
 
   echodate "Installing operating-system-manager"
   (
-    # In release branches we'll have this pinned to a specific semver instead of latest.
-    sed -i "s;:latest;:$OSM_TAG;g" examples/operating-system-manager.yaml
-
     # This is required for running e2e tests in KIND
     url="-override-bootstrap-kubelet-apiserver=$MASTER_URL"
     sed -i "s;-container-runtime=containerd;$url;g" examples/operating-system-manager.yaml

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -181,9 +181,7 @@ var (
 		providerconfigtypes.OperatingSystemFlatcar: {
 			awstypes.CPUArchitectureX86_64: {
 				// Be as precise as possible - otherwise we might get a nightly dev build
-				// Pin flatcar to 3510.2.8 since the latest version 3602.2.0 is broken. Reference: https://github.com/kubermatic/kubermatic/issues/12690
-				// TODO: Remove this pinning once the issue is fixed.
-				description: "Flatcar Container Linux stable 3510.2.8 *",
+				description: "Flatcar Container Linux stable *",
 				// The AWS marketplace ID from AWS
 				owner: "075585003325",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit b3607e1011b9fe14e60bcf0d20098a1254826589 since this issue is [resolved in OSM](https://github.com/kubermatic/operating-system-manager/pull/314) now and we don't need to pin the image for AWS anymore.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
