### PR TITLE
Drop centos support for Hetzner

### DIFF
--- a/docs/operating-system.md
+++ b/docs/operating-system.md
@@ -11,7 +11,7 @@
 | Digitalocean  | ✓ | ✓ | x | x | x | ✓ |
 | Equinix Metal | ✓ | ✓ | ✓ | x | x | ✓ |
 | Google Cloud Platform | ✓ | x | x | x | x | x |
-| Hetzner | ✓ | ✓ | x | x | x | ✓ |
+| Hetzner | ✓ | x | x | x | x | ✓ |
 | KubeVirt | ✓ | ✓ | ✓ | ✓ | x | ✓ |
 | Nutanix | ✓ | ✓ | x | x | x | x |
 | Openstack | ✓ | ✓ | ✓ | ✓ | x | ✓ |

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -704,7 +704,7 @@ func TestHetznerProvisioningE2E(t *testing.T) {
 		t.Fatal("Unable to run the test suite, HZ_E2E_TOKEN environment variable cannot be empty")
 	}
 
-	selector := OsSelector("ubuntu", "centos", "rockylinux")
+	selector := OsSelector("ubuntu", "rockylinux")
 
 	// act
 	params := []string{fmt.Sprintf("<< HETZNER_TOKEN >>=%s", hzToken)}


### PR DESCRIPTION
**What this PR does / why we need it**:
Hetzner has deprecated their CentOS 7 image. CentOS 7 was/is the only release we ever supported and so this now means that there is no CentOS support at all anymore on Hetzner.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Removed support for centos with Hetzner
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
