### PR TITLE
aws: fix rocky linux description filter

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -115,12 +115,12 @@ var (
 		},
 		providerconfigtypes.OperatingSystemRockyLinux: {
 			awstypes.CPUArchitectureX86_64: {
-				description: "Rocky-8-ec2-8*.x86_64",
+				description: "*Rocky-8-ec2-8*.x86_64",
 				// The AWS marketplace ID from Rocky Linux Community Platform Engineering (CPE)
 				owner: "792107900819",
 			},
 			awstypes.CPUArchitectureARM64: {
-				description: "Rocky-8-ec2-8*.aarch64",
+				description: "*Rocky-8-ec2-8*.aarch64",
 				// The AWS marketplace ID from Rocky Linux Community Platform Engineering (CPE)
 				owner: "792107900819",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
The e2e dualstack tests started to fail consistently
https://public-prow.loodse.com/job-history/gs/prow-dev-public-data/pr-logs/directory/pre-kubermatic-dualstack-e2e-aws-canal
```
2023-11-22T13:18:27.476Z	info	wait/wait.go:85	Waiting: 3 of 4 nodes are ready (unready: [])	{"provider": "aws", "cni": "canal", "ipfamily": "IPv4+IPv6", "cluster": "dualstack-e2e-7tr4m"}
2023-11-22T13:18:57.469Z	info	wait/wait.go:85	Waiting: failed to list nodes: client rate limiter Wait returned an error: context deadline exceeded	{"provider": "aws", "cni": "canal", "ipfamily": "IPv4+IPv6", "cluster": "dualstack-e2e-7tr4m"}
    cloud_providers_dualstack_test.go:455: Not all nodes did get ready: context deadline exceeded; last error was: failed to list nodes: client rate limiter Wait returned an error: context deadline exceeded
2023-11-22T13:18:57.518Z	info	jig/cluster.go:428	Deleting cluster...	{"provider": "aws", "cni": "canal", "ipfamily": "IPv4+IPv6", "cluster": "dualstack-e2e-7tr4m", "cluster": "dualstack-e2e-7tr4m"}
```
```
$ k describe machine -n kube-system md-rockylinux-c4d6455c5-rdhcv
...
  Type     Reason            Age                   From                Message
  ----     ------            ----                  ----                -------
  Warning  ReconcilingError  45s (x18 over 4m57s)  machine-controller  An error of type = InvalidConfiguration, with message = Failed to get AMI-ID for operating system rockylinux in region eu-west-1: could not find Image for 'rockylinux' with arch 'x86_64' occurred
```
The reason is the `description` for rocky linux images changed and includes prefix where are these images copied from: `[Copied ami-077c5602b64cb2c66 from us-east-2] Rocky-8-ec2-8.6-20220515.0.x86_64`
```
$ aws ec2 describe-images --region eu-central-1 --owners 792107900819 --filters "Name=description,Values=*Rocky-8-ec2-8*.x86_64"  --query 'Images[*].[ImageId,Name,Description,OwnerId,VirtualizationType,RootDeviceType,Architecture]' --output table
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
|                                                                                     DescribeImages                                                                                      |
+-----------------------+------------------------------------+-----------------------------------------------------------------------------------+---------------+------+------+----------+
|  ami-053c6780c32bd5d5e|  Rocky-8-ec2-8.6-20220515.0.x86_64 |  [Copied ami-077c5602b64cb2c66 from us-east-2] Rocky-8-ec2-8.6-20220515.0.x86_64  |  792107900819 |  hvm |  ebs |  x86_64  |
+-----------------------+------------------------------------+-----------------------------------------------------------------------------------+---------------+------+------+----------+
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
maybe for the next KKP release, we could set these filters on the `Seed` CRD like we do for the `KubeVirt` images?

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
aws: fix rocky linux description filter
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
