### PR TITLE
kubevirt: allow setting storage volume access types

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -90,8 +90,9 @@ type SecondaryDisks struct {
 
 // Disk.
 type Disk struct {
-	Size             providerconfigtypes.ConfigVarString `json:"size,omitempty"`
-	StorageClassName providerconfigtypes.ConfigVarString `json:"storageClassName,omitempty"`
+	Size              providerconfigtypes.ConfigVarString `json:"size,omitempty"`
+	StorageClassName  providerconfigtypes.ConfigVarString `json:"storageClassName,omitempty"`
+	StorageAccessType providerconfigtypes.ConfigVarString `json:"storageAccessType,omitempty"`
 }
 
 // Affinity.


### PR DESCRIPTION
**What this PR does / why we need it**:
This is important for live migration because only `RWX` volumes can be live migrated
https://kubevirt.io/user-guide/operations/live_migration/#limitations

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
see also: https://github.com/kubermatic/kubermatic/issues/12860

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubevirt: allow setting storage volume access types
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
