### PR TITLE
[release/v1.58] Update Prow jobs to build image with Go 1.21.5

### DIFF
--- a/.prow/e2e-features.yaml
+++ b/.prow/e2e-features.yaml
@@ -34,7 +34,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -63,7 +63,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -92,7 +92,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -119,7 +119,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/e2e-features.yaml
+++ b/.prow/e2e-features.yaml
@@ -34,7 +34,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -63,7 +63,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -92,7 +92,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -119,7 +119,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - /bin/bash
             - -c
@@ -54,7 +54,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - /bin/bash
             - -c
@@ -54,7 +54,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/provider-alibaba.yaml
+++ b/.prow/provider-alibaba.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-alibaba.yaml
+++ b/.prow/provider-alibaba.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -31,7 +31,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -31,7 +31,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           env:
             - name: OPERATING_SYSTEM_MANAGER
               value: "false"
@@ -93,7 +93,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -124,7 +124,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -156,7 +156,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -187,7 +187,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -218,7 +218,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -249,7 +249,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           env:
             - name: OPERATING_SYSTEM_MANAGER
               value: "false"
@@ -93,7 +93,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -124,7 +124,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -156,7 +156,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -187,7 +187,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -218,7 +218,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -249,7 +249,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -93,7 +93,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -93,7 +93,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-equinix-metal.yaml
+++ b/.prow/provider-equinix-metal.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-equinix-metal.yaml
+++ b/.prow/provider-equinix-metal.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-linode.yaml
+++ b/.prow/provider-linode.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-linode.yaml
+++ b/.prow/provider-linode.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -62,7 +62,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -62,7 +62,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-scaleway.yaml
+++ b/.prow/provider-scaleway.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-scaleway.yaml
+++ b/.prow/provider-scaleway.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -92,7 +92,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -124,7 +124,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -92,7 +92,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -124,7 +124,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.21.3
+        - image: golang:1.21.5
           command:
             - make
           args:
@@ -42,7 +42,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.21.3
+        - image: golang:1.21.5
           command:
             - make
           args:
@@ -149,7 +149,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: golang:1.21.3
+        - image: golang:1.21.5
           command:
             - make
           args:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -149,7 +149,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9
           command:
             - ./hack/verify-licenses.sh
           resources:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.21.0
+ARG GO_VERSION=1.21.5
 FROM docker.io/golang:${GO_VERSION} AS builder
 WORKDIR /go/src/github.com/kubermatic/machine-controller
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 SHELL = /bin/bash -eu -o pipefail
 
-GO_VERSION ?= 1.21.0
+GO_VERSION ?= 1.21.5
 
 GOOS ?= $(shell go env GOOS)
 

--- a/examples/operating-system-manager.yaml
+++ b/examples/operating-system-manager.yaml
@@ -990,7 +990,7 @@ spec:
     spec:
       serviceAccountName: operating-system-manager-webhook
       containers:
-        - image: quay.io/kubermatic/operating-system-manager:latest
+        - image: quay.io/kubermatic/operating-system-manager:v1.4.0
           imagePullPolicy: Always
           name: webhook
           command:

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.21.3 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=golang:1.21.5 containerize ./hack/update-fixtures.sh
 
 go test ./... -v -update || go test ./...
 

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-9 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-6 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-8 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps Prow jobs for the `release/v1.58` branch to use a build image that includes Go 1.21.5.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Towards https://github.com/kubermatic/release/issues/22

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Machine Controller is now built using Go 1.21.5
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
