### PR TITLE
Anexia: Adds field to check if a IP reservation is still valid

### DIFF
--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -233,7 +233,7 @@ func getIPAddress(ctx context.Context, log *zap.SugaredLogger, client anxclient.
 	status := reconcileContext.Status
 
 	// only use IP if it is still unbound
-	if status.ReservedIP != "" && status.IPState == anxtypes.IPStateUnbound {
+	if status.ReservedIP != "" && status.IPState == anxtypes.IPStateUnbound && (!status.IPProvisioningExpires.IsZero() && status.IPProvisioningExpires.After(time.Now())) {
 		log.Infow("Re-using already provisioned IP", "ip", status.ReservedIP)
 		return status.ReservedIP, nil
 	}
@@ -259,6 +259,7 @@ func getIPAddress(ctx context.Context, log *zap.SugaredLogger, client anxclient.
 	ip := res.Data[0].Address
 	status.ReservedIP = ip
 	status.IPState = anxtypes.IPStateUnbound
+	status.IPProvisioningExpires = time.Now().Add(anxtypes.IPProvisioningExpires)
 
 	return ip, nil
 }

--- a/pkg/cloudprovider/provider/anexia/provider_test.go
+++ b/pkg/cloudprovider/provider/anexia/provider_test.go
@@ -301,6 +301,7 @@ func TestAnexiaProvider(t *testing.T) {
 			expectedIP := "8.8.8.8"
 			providerStatus.ReservedIP = expectedIP
 			providerStatus.IPState = anxtypes.IPStateUnbound
+			providerStatus.IPProvisioningExpires = time.Now().Add(anxtypes.IPProvisioningExpires)
 			reservedIP, err := getIPAddress(ctx, log, client)
 			testhelper.AssertNoErr(t, err)
 			testhelper.AssertEquals(t, expectedIP, reservedIP)

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -34,8 +34,9 @@ const (
 	GetRequestTimeout    = 1 * time.Minute
 	DeleteRequestTimeout = 1 * time.Minute
 
-	IPStateBound   = "Bound"
-	IPStateUnbound = "Unbound"
+	IPStateBound          = "Bound"
+	IPStateUnbound        = "Unbound"
+	IPProvisioningExpires = 1800 * time.Second
 
 	VmxNet3NIC       = "vmxnet3"
 	MachinePoweredOn = "poweredOn"
@@ -72,12 +73,13 @@ type RawConfig struct {
 }
 
 type ProviderStatus struct {
-	InstanceID       string         `json:"instanceID"`
-	ProvisioningID   string         `json:"provisioningID"`
-	DeprovisioningID string         `json:"deprovisioningID"`
-	ReservedIP       string         `json:"reservedIP"`
-	IPState          string         `json:"ipState"`
-	Conditions       []v1.Condition `json:"conditions,omitempty"`
+	InstanceID            string         `json:"instanceID"`
+	ProvisioningID        string         `json:"provisioningID"`
+	DeprovisioningID      string         `json:"deprovisioningID"`
+	ReservedIP            string         `json:"reservedIP"`
+	IPState               string         `json:"ipState"`
+	IPProvisioningExpires time.Time      `json:"ipProvisioningExpires"`
+	Conditions            []v1.Condition `json:"conditions,omitempty"`
 }
 
 func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a field to check if a IP reservation is still valid, if the IP is no longer valid a new one is requested.

This fixes a bug where we use a IP reservation that expired already for a VM, if the VM provisioning failed, which then leads to a race condition. In which we wait for the VM provisioning to finish, but it can't due the IP being no longer useable, but we also never request a new IP in that case.

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
Please backport to version v1.57

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anexia: Fix IP reservation related race condition.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
