### PR TITLE
Add tags usage when creating machine

### DIFF
--- a/pkg/cloudprovider/provider/equinixmetal/types/types.go
+++ b/pkg/cloudprovider/provider/equinixmetal/types/types.go
@@ -29,6 +29,7 @@ type RawConfig struct {
 	Metro        providerconfigtypes.ConfigVarString   `json:"metro,omitempty"`
 	Facilities   []providerconfigtypes.ConfigVarString `json:"facilities,omitempty"`
 	Tags         []providerconfigtypes.ConfigVarString `json:"tags,omitempty"`
+	Labels       map[string]string                     `json:"labels,omitempty"`
 }
 
 func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Equinix provider does not support any tags except the system. I also added labels to be as a tags, because no other way to pass cluster specific data to server metadata.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1756
 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add tags for Equinix metal provider when creating machines.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
No need

```
