### PR TITLE
[release/v1.57] Configure provider-id for the machines/nodes 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,3 +59,4 @@ issues:
     - 'cyclomatic complexity 34 of func `\(\*provider\)\.getConfig` is high'
     - 'cyclomatic complexity 31 of func `\(\*provider\)\.Validate` is high'
     - 'cyclomatic complexity 33 of func `\(\*provider\)\.Create` is high'
+    - 'cyclomatic complexity 32 of func `\(\*Reconciler\)\.ensureInstanceExistsForMachine` is high'

--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -64,6 +64,16 @@ func (ad *admissionData) mutateMachines(ctx context.Context, ar admissionv1.Admi
 		if oldMachine.Spec.Name != machine.Spec.Name && machine.Spec.Name == machine.Name {
 			oldMachine.Spec.Name = machine.Spec.Name
 		}
+
+		if oldMachine.Spec.ProviderID != nil && machine.Spec.ProviderID != nil && *oldMachine.Spec.ProviderID != *machine.Spec.ProviderID {
+			return nil, fmt.Errorf("providerID is immutable")
+		}
+
+		// Allow mutation of the ProviderID field, as it can only be computed after the machine is created.
+		if oldMachine.Spec.ProviderID == nil && machine.Spec.ProviderID != nil {
+			oldMachine.Spec.ProviderID = machine.Spec.ProviderID
+		}
+
 		// Allow mutation when:
 		// * machine has the `MigrationBypassSpecNoModificationRequirementAnnotation` annotation (used for type migration)
 		bypassValidationForMigration := machine.Annotations[BypassSpecNoModificationRequirementAnnotation] == "true"

--- a/pkg/cloudprovider/provider/anexia/instance.go
+++ b/pkg/cloudprovider/provider/anexia/instance.go
@@ -51,6 +51,9 @@ func (ai *anexiaInstance) ID() string {
 }
 
 func (ai *anexiaInstance) ProviderID() string {
+	if ai == nil || ai.ID() == "" {
+		return ""
+	}
 	return ai.ID()
 }
 

--- a/pkg/cloudprovider/provider/digitalocean/provider.go
+++ b/pkg/cloudprovider/provider/digitalocean/provider.go
@@ -506,6 +506,9 @@ func (d *doInstance) ID() string {
 }
 
 func (d *doInstance) ProviderID() string {
+	if d.droplet == nil || d.droplet.Name == "" {
+		return ""
+	}
 	return fmt.Sprintf("digitalocean://%d", d.droplet.ID)
 }
 

--- a/pkg/cloudprovider/provider/equinixmetal/provider.go
+++ b/pkg/cloudprovider/provider/equinixmetal/provider.go
@@ -400,6 +400,9 @@ func (s *metalDevice) ID() string {
 }
 
 func (s *metalDevice) ProviderID() string {
+	if s.device == nil || s.device.ID == "" {
+		return ""
+	}
 	return "equinixmetal://" + s.device.ID
 }
 

--- a/pkg/cloudprovider/provider/gce/instance.go
+++ b/pkg/cloudprovider/provider/gce/instance.go
@@ -61,6 +61,9 @@ func (gi *googleInstance) ID() string {
 }
 
 func (gi *googleInstance) ProviderID() string {
+	if gi.ci == nil || gi.ci.Name == "" {
+		return ""
+	}
 	return fmt.Sprintf("gce://%s/%s/%s", gi.projectID, gi.zone, gi.ci.Name)
 }
 

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -553,6 +553,9 @@ func (s *hetznerServer) ID() string {
 }
 
 func (s *hetznerServer) ProviderID() string {
+	if s.server == nil || s.server.ID == 0 {
+		return ""
+	}
 	return fmt.Sprintf("hcloud://%d", s.server.ID)
 }
 

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -160,6 +160,9 @@ func (k *kubeVirtServer) ID() string {
 }
 
 func (k *kubeVirtServer) ProviderID() string {
+	if k.vmi.Name == "" {
+		return ""
+	}
 	return "kubevirt://" + k.vmi.Name
 }
 

--- a/pkg/cloudprovider/provider/linode/provider.go
+++ b/pkg/cloudprovider/provider/linode/provider.go
@@ -405,6 +405,9 @@ func (d *linodeInstance) ID() string {
 }
 
 func (d *linodeInstance) ProviderID() string {
+	if d == nil || d.ID() == "" {
+		return ""
+	}
 	return fmt.Sprintf("linode://%s", d.ID())
 }
 

--- a/pkg/cloudprovider/provider/nutanix/provider.go
+++ b/pkg/cloudprovider/provider/nutanix/provider.go
@@ -89,6 +89,9 @@ func (nutanixServer Server) ID() string {
 }
 
 func (nutanixServer Server) ProviderID() string {
+	if nutanixServer.ID() == "" {
+		return ""
+	}
 	return fmt.Sprintf("nutanix://%s", nutanixServer.ID())
 }
 

--- a/pkg/cloudprovider/provider/opennebula/provider.go
+++ b/pkg/cloudprovider/provider/opennebula/provider.go
@@ -427,6 +427,9 @@ func (i *openNebulaInstance) ID() string {
 }
 
 func (i *openNebulaInstance) ProviderID() string {
+	if i.vm == nil || i.vm.ID == 0 {
+		return ""
+	}
 	return "opennebula://" + strconv.Itoa(i.vm.ID)
 }
 

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -936,6 +936,9 @@ func (d *osInstance) ID() string {
 }
 
 func (d *osInstance) ProviderID() string {
+	if d.server == nil || d.server.ID == "" {
+		return ""
+	}
 	return "openstack:///" + d.server.ID
 }
 

--- a/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
@@ -123,6 +123,9 @@ func (s Server) ID() string {
 }
 
 func (s Server) ProviderID() string {
+	if s.ID() == "" {
+		return ""
+	}
 	return fmt.Sprintf("vmware-cloud-director://%s", s.ID())
 }
 

--- a/pkg/cloudprovider/provider/vsphere/provider.go
+++ b/pkg/cloudprovider/provider/vsphere/provider.go
@@ -101,6 +101,9 @@ func (vsphereServer Server) ID() string {
 }
 
 func (vsphereServer Server) ProviderID() string {
+	if vsphereServer.uuid == "" {
+		return ""
+	}
 	return "vsphere://" + vsphereServer.uuid
 }
 

--- a/pkg/cloudprovider/provider/vultr/provider.go
+++ b/pkg/cloudprovider/provider/vultr/provider.go
@@ -338,6 +338,9 @@ func (v *vultrInstance) ID() string {
 }
 
 func (v *vultrInstance) ProviderID() string {
+	if v.instance == nil || v.instance.ID == "" {
+		return ""
+	}
 	return "vultr://" + v.instance.ID
 }
 

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/Masterminds/semver/v3"
+
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
 	"github.com/kubermatic/machine-controller/pkg/jsonutil"
@@ -106,6 +108,27 @@ var (
 		CloudProviderOpenNebula,
 	}
 )
+
+func IntreeCloudProviderImplementationSupported(cloudProvider CloudProvider, version string) (inTree bool, err error) {
+	kubeletVer, err := semver.NewVersion(version)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse kubelet version: %w", err)
+	}
+
+	switch cloudProvider {
+	case CloudProviderAzure, CloudProviderVsphere, CloudProviderGoogle:
+		return true, nil
+	case CloudProviderAWS:
+		// In-tree AWS support was removed in Kubernetes 1.27.
+		ltKube127Condition, _ := semver.NewConstraint("< 1.27")
+		if ltKube127Condition.Check(kubeletVer) {
+			return true, nil
+		}
+		return false, nil
+	default:
+		return false, nil
+	}
+}
 
 // DNSConfig contains a machine's DNS configuration.
 type DNSConfig struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of #1723 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Machine-controller will inject provider-id for the machines that are created against cloud providers that don't have in-tree or external CCM support
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
