### PR TITLE
Fix namespace for Machinesets

### DIFF
--- a/pkg/controller/util/machine.go
+++ b/pkg/controller/util/machine.go
@@ -39,7 +39,7 @@ func GetMachineDeploymentNameAndRevisionForMachine(ctx context.Context, machine 
 
 	if machineSetName != "" {
 		machineSet := &clusterv1alpha1.MachineSet{}
-		if err := c.Get(ctx, types.NamespacedName{Name: machineSetName, Namespace: "kube-system"}, machineSet); err != nil {
+		if err := c.Get(ctx, types.NamespacedName{Name: machineSetName, Namespace: machine.Namespace}, machineSet); err != nil {
 			return "", "", err
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When fetching the MachineDeployment against Machine, to propagate user data, we were incorrectly assuming that the namespace would be `kube-system`. This is wrong since users can create MD/MS/Machine in any namespace.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a bug where namespace kube-system was hardcoded for finding the MachineDeployment against a Machine
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
/cherry-pick release/v1.59