### PR TITLE
Anexia: various patches (request/response logging, CPU performance type, 404 fix on delete)

### DIFF
--- a/examples/anexia-machinedeployment.yaml
+++ b/examples/anexia-machinedeployment.yaml
@@ -39,6 +39,11 @@ spec:
             cpus: 2
             memory: 2048
 
+            # this defaults to "performance", but you can set anything
+            # supported by the Anexia Engine here - or not set this attribute
+            # at all
+            cpuPerformanceType: standard
+
             disks:
               - size: 60
                 performanceType: ENT6

--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -48,6 +48,7 @@ import (
 	"github.com/kubermatic/machine-controller/pkg/providerconfig"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 
+	cloudproviderutil "github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -107,7 +108,7 @@ func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *
 		Machine:        machine,
 	})
 
-	_, client, err := getClient(config.Token)
+	_, client, err := getClient(config.Token, &machine.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +335,7 @@ func (p *provider) resolveConfig(ctx context.Context, log *zap.SugaredLogger, co
 
 	// when "templateID" is not set, we expect "template" to be
 	if ret.TemplateID == "" {
-		a, _, err := getClient(ret.Token)
+		a, _, err := getClient(ret.Token, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed initializing API clients: %w", err)
 		}
@@ -467,7 +468,7 @@ func (p *provider) Get(ctx context.Context, log *zap.SugaredLogger, machine *clu
 		return nil, newError(common.InvalidConfigurationMachineError, "failed to retrieve config: %v", err)
 	}
 
-	_, cli, err := getClient(config.Token)
+	_, cli, err := getClient(config.Token, &machine.Name)
 	if err != nil {
 		return nil, newError(common.InvalidConfigurationMachineError, "failed to create Anexia client: %v", err)
 	}
@@ -550,7 +551,7 @@ func (p *provider) Cleanup(ctx context.Context, log *zap.SugaredLogger, machine 
 		return false, newError(common.InvalidConfigurationMachineError, "failed to parse MachineSpec: %v", err)
 	}
 
-	_, cli, err := getClient(config.Token)
+	_, cli, err := getClient(config.Token, &machine.Name)
 	if err != nil {
 		return false, newError(common.InvalidConfigurationMachineError, "failed to create Anexia client: %v", err)
 	}
@@ -616,16 +617,29 @@ func (p *provider) SetMetricsForMachines(_ clusterv1alpha1.MachineList) error {
 	return nil
 }
 
-func getClient(token string) (api.API, anxclient.Client, error) {
-	tokenOpt := anxclient.TokenFromString(token)
-	client := anxclient.HTTPClient(&http.Client{Timeout: 120 * time.Second})
+func getClient(token string, machineName *string) (api.API, anxclient.Client, error) {
+	logPrefix := "[Anexia API]"
 
-	a, err := api.NewAPI(api.WithClientOptions(client, tokenOpt))
+	if machineName != nil {
+		logPrefix = fmt.Sprintf("[Anexia API for Machine %q]", *machineName)
+	}
+
+	httpClient := cloudproviderutil.HTTPClientConfig{
+		Timeout:   120 * time.Second,
+		LogPrefix: logPrefix,
+	}.New()
+
+	legacyClientOptions := []anxclient.Option{
+		anxclient.TokenFromString(token),
+		anxclient.HTTPClient(&httpClient),
+	}
+
+	a, err := api.NewAPI(api.WithClientOptions(legacyClientOptions...))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating generic API client: %w", err)
 	}
 
-	legacyClient, err := anxclient.New(tokenOpt, client)
+	legacyClient, err := anxclient.New(legacyClientOptions...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating legacy client: %w", err)
 	}

--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -565,9 +565,19 @@ func (p *provider) Cleanup(ctx context.Context, log *zap.SugaredLogger, machine 
 		response, err := vsphereAPI.Provisioning().VM().Deprovision(deleteCtx, status.InstanceID, false)
 		if err != nil {
 			var respErr *anxclient.ResponseError
+
 			// Only error if the error was not "not found"
 			if !(errors.As(err, &respErr) && respErr.ErrorData.Code == http.StatusNotFound) {
 				return false, newError(common.DeleteMachineError, "failed to delete machine: %v", err)
+			}
+
+			// good thinking checking for a "not found" error, but go-anxcloud does only
+			// return >= 500 && < 600 errors (:
+			// since that's the legacy client in go-anxcloud and the new one is not yet available,
+			// this will not be fixed there but we have a nice workaround here:
+
+			if response.Identifier == "" {
+				return true, nil
 			}
 		}
 		status.DeprovisioningID = response.Identifier

--- a/pkg/cloudprovider/provider/anexia/provider.go
+++ b/pkg/cloudprovider/provider/anexia/provider.go
@@ -162,6 +162,10 @@ func provisionVM(ctx context.Context, log *zap.SugaredLogger, client anxclient.C
 
 		vm.DiskType = config.Disks[0].PerformanceType
 
+		if config.CPUPerformanceType != "" {
+			vm.CPUPerformanceType = config.CPUPerformanceType
+		}
+
 		for _, disk := range config.Disks[1:] {
 			vm.AdditionalDisks = append(vm.AdditionalDisks, anxvm.AdditionalDisk{
 				SizeGBs: disk.Size,

--- a/pkg/cloudprovider/provider/anexia/types/types.go
+++ b/pkg/cloudprovider/provider/anexia/types/types.go
@@ -63,8 +63,9 @@ type RawConfig struct {
 	Template      providerconfigtypes.ConfigVarString `json:"template"`
 	TemplateBuild providerconfigtypes.ConfigVarString `json:"templateBuild"`
 
-	CPUs   int `json:"cpus"`
-	Memory int `json:"memory"`
+	CPUs               int    `json:"cpus"`
+	CPUPerformanceType string `json:"cpuPerformanceType"`
+	Memory             int    `json:"memory"`
 
 	// Deprecated, use Disks instead.
 	DiskSize int `json:"diskSize"`


### PR DESCRIPTION
**What this PR does / why we need it**:

We found some old patches that are probably still worth adding and I combined them with a new feature here in this PR:

* use `pkg/cloudprovider/util.HttpClient` to enable request/response logging
* fix handling for 404 responses when deleting a VM
* add config attribute to specify the CPU performance type

**What type of PR is this?**
/kind bug
/kind feature

**Special notes for your reviewer**:

Since this is all localized in the Anexia provider and all just small changes, I figured there's no harm in combining that into a single PR.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anexia: you can now configure the CPU performance type
```

**Documentation**:

I extended the example `MachineDeployment` in this repository.

```documentation
NONE
```
