### PR TITLE
Update e2e tests to Ubuntu 24.04

### DIFF
--- a/docs/operating-system.md
+++ b/docs/operating-system.md
@@ -43,4 +43,4 @@ Machine controller may work with other OS versions that are not listed in the ta
 | CentOS | 7.4.x, 7.6.x, 7.7.x |
 | RHEL | 8.x |
 | Rocky Linux | 8.5 |
-| Ubuntu | 20.04 LTS, 22.04 LTS |
+| Ubuntu | 20.04 LTS, 22.04 LTS, 24.04 LTS |

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -45,7 +45,7 @@ import (
 const (
 	machineUIDTag   = "machine_uid"
 	centosImageName = "CentOS  7.9 64 bit"
-	ubuntuImageName = "Ubuntu  22.04 64 bit"
+	ubuntuImageName = "Ubuntu  24.04 64 bit"
 
 	finalizerInstance = "kubermatic.io/cleanup-alibaba-instance"
 )

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -140,13 +140,13 @@ var (
 		providerconfigtypes.OperatingSystemUbuntu: {
 			awstypes.CPUArchitectureX86_64: {
 				// Be as precise as possible - otherwise we might get a nightly dev build
-				description: "Canonical, Ubuntu, 22.04 LTS, amd64 jammy image build on ????-??-??",
+				description: "Canonical, Ubuntu, 24.04 LTS, amd64 noble image build on ????-??-??",
 				// The AWS marketplace ID from Canonical
 				owner: "099720109477",
 			},
 			awstypes.CPUArchitectureARM64: {
 				// Be as precise as possible - otherwise we might get a nightly dev build
-				description: "Canonical, Ubuntu, 22.04 LTS, arm64 jammy image build on ????-??-??",
+				description: "Canonical, Ubuntu, 24.04 LTS, arm64 noble image build on ????-??-??",
 				// The AWS marketplace ID from Canonical
 				owner: "099720109477",
 			},

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -72,7 +72,7 @@ type Config struct {
 func getNameForOS(os providerconfigtypes.OperatingSystem) (string, error) {
 	switch os {
 	case providerconfigtypes.OperatingSystemUbuntu:
-		return "ubuntu-22.04", nil
+		return "ubuntu-24.04", nil
 	case providerconfigtypes.OperatingSystemCentOS:
 		return "centos-7", nil
 	case providerconfigtypes.OperatingSystemRockyLinux:

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -50,7 +50,7 @@ var (
 	}
 
 	openStackImages = map[string]string{
-		string(providerconfigtypes.OperatingSystemUbuntu):     "kubermatic-ubuntu",
+		string(providerconfigtypes.OperatingSystemUbuntu):     "ubuntu-24.04",
 		string(providerconfigtypes.OperatingSystemCentOS):     "machine-controller-e2e-centos",
 		string(providerconfigtypes.OperatingSystemRHEL):       "machine-controller-e2e-rhel-8-5",
 		string(providerconfigtypes.OperatingSystemFlatcar):    "kubermatic-e2e-flatcar",
@@ -75,7 +75,7 @@ var (
 		string(providerconfigtypes.OperatingSystemFlatcar):    "flatcar",
 		string(providerconfigtypes.OperatingSystemRHEL):       "rhel",
 		string(providerconfigtypes.OperatingSystemRockyLinux): "rockylinux",
-		string(providerconfigtypes.OperatingSystemUbuntu):     "ubuntu-22.04",
+		string(providerconfigtypes.OperatingSystemUbuntu):     "ubuntu-24.04",
 	}
 )
 

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -67,7 +67,7 @@ var (
 		string(providerconfigtypes.OperatingSystemFlatcar):    "kkp-flatcar-3139.2.0",
 		string(providerconfigtypes.OperatingSystemRHEL):       "kkp-rhel-8.6",
 		string(providerconfigtypes.OperatingSystemRockyLinux): "kkp-rockylinux-8",
-		string(providerconfigtypes.OperatingSystemUbuntu):     "kkp-ubuntu-22.04",
+		string(providerconfigtypes.OperatingSystemUbuntu):     "kkp-ubuntu-24.04",
 	}
 
 	kubevirtImages = map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:
To test whether 24.04 works, this PR bumps all e2e tests to Ubuntu 24.04.

Relates to https://github.com/kubermatic/kubermatic/issues/13340

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Support Ubuntu 24.04
```

**Documentation**:
```documentation
NONE
```
