### PR TITLE
Bump Go version to 1.22.4

### DIFF
--- a/.prow/e2e-features.yaml
+++ b/.prow/e2e-features.yaml
@@ -34,7 +34,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -63,7 +63,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -92,7 +92,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -119,7 +119,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - /bin/bash
             - -c
@@ -54,7 +54,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/provider-alibaba.yaml
+++ b/.prow/provider-alibaba.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -31,7 +31,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -61,7 +61,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -93,7 +93,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -126,7 +126,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -157,7 +157,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -188,7 +188,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -219,7 +219,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -93,7 +93,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-equinix-metal.yaml
+++ b/.prow/provider-equinix-metal.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-linode.yaml
+++ b/.prow/provider-linode.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -62,7 +62,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-scaleway.yaml
+++ b/.prow/provider-scaleway.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -92,7 +92,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -124,7 +124,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -156,7 +156,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-9
           command:
             - make
           args:
@@ -42,7 +42,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-9
           command:
             - make
           args:
@@ -63,7 +63,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-9
           command:
             - make
           args:
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-9
           command:
             - make
           args:
@@ -102,7 +102,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-9
           command:
             - "/usr/local/bin/shfmt"
           args:
@@ -130,7 +130,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-9
           command:
             - "./hack/verify-boilerplate.sh"
           resources:
@@ -149,7 +149,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-9
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-3
+        - image: quay.io/kubermatic/build:go-1.22-node-20-9
           command:
             - make
           args:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.22.2
+ARG GO_VERSION=1.22.4
 FROM docker.io/golang:${GO_VERSION} AS builder
 WORKDIR /go/src/github.com/kubermatic/machine-controller
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 SHELL = /bin/bash -eu -o pipefail
 
-GO_VERSION ?= 1.22.2
+GO_VERSION ?= 1.22.4
 
 GOOS ?= $(shell go env GOOS)
 

--- a/hack/ci/calico.yaml
+++ b/hack/ci/calico.yaml
@@ -325,7 +325,7 @@ spec:
               numAllowedLocalASNumbers:
                 description: Maximum number of local AS numbers that are allowed in
                   the AS path for received routes. This removes BGP loop prevention
-                  and should only be used if absolutely necesssary.
+                  and should only be used if absolutely necessary.
                 format: int32
                 type: integer
               password:

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=golang:1.22.2 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=golang:1.22.4 containerize ./hack/update-fixtures.sh
 
 go test ./... -v -update || go test ./...
 

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to update Go version to 1.22.4.
Related to https://github.com/kubermatic/infra/pull/2707

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Go version to 1.22.4
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
