### PR TITLE
[release/v1.57] Update AMI filter for rocky linux (#1803) / Bump OSM to 1.3.6

### DIFF
--- a/examples/operating-system-manager.yaml
+++ b/examples/operating-system-manager.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/kubermatic/operating-system-manager/tree/v0.5.0/deploy
+# Source: https://github.com/kubermatic/operating-system-manager/tree/v1.3.6/deploy
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -990,7 +990,7 @@ spec:
     spec:
       serviceAccountName: operating-system-manager-webhook
       containers:
-        - image: quay.io/kubermatic/operating-system-manager:v1.3.4
+        - image: quay.io/kubermatic/operating-system-manager:v1.3.6
           imagePullPolicy: Always
           name: webhook
           command:
@@ -1318,7 +1318,7 @@ spec:
     spec:
       serviceAccountName: operating-system-manager
       containers:
-        - image: quay.io/kubermatic/operating-system-manager:v1.3.4
+        - image: quay.io/kubermatic/operating-system-manager:v1.3.6
           imagePullPolicy: Always
           name: operating-system-manager
           command:

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -115,12 +115,12 @@ var (
 		},
 		providerconfigtypes.OperatingSystemRockyLinux: {
 			awstypes.CPUArchitectureX86_64: {
-				description: "*Rocky-8-ec2-8*.x86_64",
+				description: "*Rocky-8-EC2-*.x86_64",
 				// The AWS marketplace ID from Rocky Linux Community Platform Engineering (CPE)
 				owner: "792107900819",
 			},
 			awstypes.CPUArchitectureARM64: {
-				description: "*Rocky-8-ec2-8*.aarch64",
+				description: "*Rocky-8-EC2-*.aarch64",
 				// The AWS marketplace ID from Rocky Linux Community Platform Engineering (CPE)
 				owner: "792107900819",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #1803.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update AWS AMI filter for rocky linux 8
```

**Documentation**:
```documentation
NONE
```
