### PR TITLE
[release/v1.59] Update AMI filter for rocky linux (#1803)

### DIFF
--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -157,8 +157,11 @@ if [ -z "${DISABLE_CLUSTER_EXPOSER:-}" ]; then
     cd /tmp/kubermatic
     echodate "Cloning cluster exposer"
     KKP_REPO_URL="${KKP_REPO_URL:-https://github.com/kubermatic/kubermatic.git}"
-    KKP_REPO_TAG="${KKP_REPO_BRANCH:-main}"
-    git clone --depth 1 --branch "${KKP_REPO_TAG}" "${KKP_REPO_URL}" .
+    KKP_REPO_TAG="${KKP_REPO_BRANCH:-release/v2.25}"
+    (
+      set -x
+      git clone --depth 1 --branch "${KKP_REPO_TAG}" "${KKP_REPO_URL}" .
+    )
 
     echodate "Building cluster exposer"
     CGO_ENABLED=0 go build --tags ce -v -o /tmp/clusterexposer ./pkg/test/clusterexposer/cmd

--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -115,12 +115,12 @@ var (
 		},
 		providerconfigtypes.OperatingSystemRockyLinux: {
 			awstypes.CPUArchitectureX86_64: {
-				description: "*Rocky-8-ec2-8*.x86_64",
+				description: "*Rocky-8-EC2-*.x86_64",
 				// The AWS marketplace ID from Rocky Linux Community Platform Engineering (CPE)
 				owner: "792107900819",
 			},
 			awstypes.CPUArchitectureARM64: {
-				description: "*Rocky-8-ec2-8*.aarch64",
+				description: "*Rocky-8-EC2-*.aarch64",
 				// The AWS marketplace ID from Rocky Linux Community Platform Engineering (CPE)
 				owner: "792107900819",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #1803.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update AWS AMI filter for rocky linux 8
```

**Documentation**:
```documentation
NONE
```
