### PR TITLE
Remove Kubernetes 1.27 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Currently supported K8S versions are:
 - 1.30
 - 1.29
 - 1.28
-- 1.27
 
 ### Community Providers
 

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -457,11 +457,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, mach
 	}
 
 	// case 3.2: if the node exists and both external and internal CCM are not available. Then set the provider-id for the node.
-	inTree, err := providerconfigtypes.IntreeCloudProviderImplementationSupported(providerConfig.CloudProvider, machine.Spec.Versions.Kubelet)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if cloud provider %q has in-tree implementation: %w", providerConfig.CloudProvider, err)
-	}
-
+	inTree := providerconfigtypes.IntreeCloudProviderImplementationSupported(providerConfig.CloudProvider)
 	if !inTree && !r.nodeSettings.ExternalCloudProvider && node.Spec.ProviderID == "" {
 		providerID := fmt.Sprintf(ProviderIDPattern, providerConfig.CloudProvider, machine.UID)
 		if err := r.updateNode(ctx, node, func(n *corev1.Node) {
@@ -897,11 +893,7 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 
 	var providerID string
 	if machine.Spec.ProviderID == nil {
-		inTree, err := providerconfigtypes.IntreeCloudProviderImplementationSupported(providerConfig.CloudProvider, machine.Spec.Versions.Kubelet)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check if cloud provider %q has in-tree implementation: %w", providerConfig.CloudProvider, err)
-		}
-
+		inTree := providerconfigtypes.IntreeCloudProviderImplementationSupported(providerConfig.CloudProvider)
 		// If both external and internal CCM are not available. We set provider-id for the machine explicitly.
 		if !inTree && !r.nodeSettings.ExternalCloudProvider {
 			providerID = fmt.Sprintf(ProviderIDPattern, providerConfig.CloudProvider, machine.UID)

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/Masterminds/semver/v3"
-
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
 	"github.com/kubermatic/machine-controller/pkg/jsonutil"
@@ -120,25 +118,11 @@ var (
 	}
 )
 
-func IntreeCloudProviderImplementationSupported(cloudProvider CloudProvider, version string) (inTree bool, err error) {
-	kubeletVer, err := semver.NewVersion(version)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse kubelet version: %w", err)
+func IntreeCloudProviderImplementationSupported(cloudProvider CloudProvider) (inTree bool) {
+	if cloudProvider == CloudProviderAzure || cloudProvider == CloudProviderVsphere || cloudProvider == CloudProviderGoogle {
+		return true
 	}
-
-	switch cloudProvider {
-	case CloudProviderAzure, CloudProviderVsphere, CloudProviderGoogle:
-		return true, nil
-	case CloudProviderAWS:
-		// In-tree AWS support was removed in Kubernetes 1.27.
-		ltKube127Condition, _ := semver.NewConstraint("< 1.27")
-		if ltKube127Condition.Check(kubeletVer) {
-			return true, nil
-		}
-		return false, nil
-	default:
-		return false, nil
-	}
+	return false
 }
 
 // DNSConfig contains a machine's DNS configuration.

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -348,7 +348,7 @@ func TestOpenstackProvisioningE2E(t *testing.T) {
 	}
 
 	// In-tree cloud provider is not supported from Kubernetes v1.26.
-	selector := And(Not(OsSelector("amzn2")), Not(VersionSelector("1.27.13", "1.28.11", "1.29.6", "1.30.2")))
+	selector := And(Not(OsSelector("amzn2")), Not(VersionSelector("1.28.11", "1.29.6", "1.30.2")))
 	runScenarios(context.Background(), t, selector, params, OSManifest, fmt.Sprintf("os-%s", *testRunIdentifier))
 }
 
@@ -424,7 +424,7 @@ func TestAWSProvisioningE2E(t *testing.T) {
 	}
 
 	// In-tree cloud provider is not supported from Kubernetes v1.27.
-	selector := Not(VersionSelector("1.27.13", "1.28.11", "1.29.6", "1.30.2"))
+	selector := Not(VersionSelector("1.28.11", "1.29.6", "1.30.2"))
 
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
@@ -478,7 +478,7 @@ func TestAWSSpotInstanceProvisioningE2E(t *testing.T) {
 	}
 	// Since we are only testing the spot instance functionality, testing it against a single OS is sufficient.
 	// In-tree cloud provider is not supported from Kubernetes v1.27.
-	selector := And(OsSelector("ubuntu"), Not(VersionSelector("1.27.13", "1.28.11", "1.29.6", "1.30.2")))
+	selector := And(OsSelector("ubuntu"), Not(VersionSelector("1.28.11", "1.29.6", "1.30.2")))
 
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
@@ -500,7 +500,7 @@ func TestAWSARMProvisioningE2E(t *testing.T) {
 		t.Fatal("Unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
 	}
 	// In-tree cloud provider is not supported from Kubernetes v1.27.
-	selector := And(OsSelector("ubuntu"), Not(VersionSelector("1.27.13", "1.28.11", "1.29.6", "1.30.2")))
+	selector := And(OsSelector("ubuntu"), Not(VersionSelector("1.28.11", "1.29.6", "1.30.2")))
 
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -34,7 +34,6 @@ var (
 	scenarios = buildScenarios()
 
 	versions = []*semver.Version{
-		semver.MustParse("v1.27.13"),
 		semver.MustParse("v1.28.11"),
 		semver.MustParse("v1.29.6"),
 		semver.MustParse("v1.30.2"),


### PR DESCRIPTION
**What this PR does / why we need it**:
1.27 has reached EOL https://kubernetes.io/releases/#release-v1-27

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove support for Kubernetes v1.27
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
