### PR TITLE
OpenStack: Support enabling config drive

### DIFF
--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -135,6 +135,8 @@ network: ""
 computeAPIVersion: ""
 # set trust-device-path flag for kubelet
 trustDevicePath: false
+# set to true to store metadata on a configuration drive instead of the metadata service
+configDrive: false
 # set root disk size
 rootDiskSizeGB: 50
 # set root disk volume type

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -103,6 +103,7 @@ type Config struct {
 	FloatingIPPool        string
 	AvailabilityZone      string
 	TrustDevicePath       bool
+	ConfigDrive           bool
 	RootDiskSizeGB        *int
 	RootDiskVolumeType    string
 	NodeVolumeAttachLimit *uint
@@ -263,6 +264,11 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	}
 
 	cfg.TrustDevicePath, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.TrustDevicePath)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	cfg.ConfigDrive, _, err = p.configVarResolver.GetConfigVarBoolValue(rawConfig.ConfigDrive)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -611,6 +617,7 @@ func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *
 		Name:             machine.Spec.Name,
 		FlavorRef:        flavor.ID,
 		UserData:         []byte(userdata),
+		ConfigDrive:      &cfg.ConfigDrive,
 		SecurityGroups:   securityGroups,
 		AvailabilityZone: cfg.AvailabilityZone,
 		Networks:         []osservers.Network{{UUID: network.ID}},

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -45,6 +45,7 @@ import (
 const expectedServerRequest = `{
   "server": {
 	  "availability_zone": "eu-de-01",
+	  "config_drive": false,
 	  "flavorRef": "1",
 	  "imageRef": "1bea47ed-f6a9-463b-b423-14b9cca9ad27",
 	  "metadata": {
@@ -72,6 +73,7 @@ const expectedServerRequest = `{
 const expectedBlockDeviceBootRequest = `{
   "server": {
 	"availability_zone": "eu-de-01",
+	"config_drive": false,
 	"block_device_mapping_v2": [
 	  {
 		"boot_index": 0,
@@ -108,6 +110,7 @@ const expectedBlockDeviceBootRequest = `{
 const expectedBlockDeviceBootVolumeTypeRequest = `{
 	"server": {
 	  "availability_zone": "eu-de-01",
+	  "config_drive": false,
 	  "block_device_mapping_v2": [
 		{
 		  "boot_index": 0,
@@ -152,6 +155,7 @@ type openstackProviderSpecConf struct {
 	ProjectID                   string
 	TenantID                    string
 	TenantName                  string
+	ConfigDrive                 bool
 	ComputeAPIVersion           string
 }
 

--- a/pkg/cloudprovider/provider/openstack/types/types.go
+++ b/pkg/cloudprovider/provider/openstack/types/types.go
@@ -52,6 +52,7 @@ type RawConfig struct {
 	RootDiskVolumeType    providerconfigtypes.ConfigVarString   `json:"rootDiskVolumeType,omitempty"`
 	NodeVolumeAttachLimit *uint                                 `json:"nodeVolumeAttachLimit"`
 	ServerGroup           providerconfigtypes.ConfigVarString   `json:"serverGroup"`
+	ConfigDrive           providerconfigtypes.ConfigVarBool     `json:"configDrive,omitempty"`
 	// This tag is related to server metadata, not compute server's tag
 	Tags map[string]string `json:"tags,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds support for enabling config drive for OpenStack VMs. When enabled, metadata for machines is stored on a configuration drive instead of the metadata service.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Towards #1773 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
OpenStack: Support enabling config drive
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
