### PR TITLE
Refactor bare metal provider machine cleanup

### DIFF
--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/hardware.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/hardware.go
@@ -62,7 +62,6 @@ func (h *HardwareClient) SetHardwareID(ctx context.Context, hardware *tinkv1alph
 	}
 
 	hardware.Spec.Metadata.Instance.ID = newID
-	// Set the new ID
 	hardware.Spec.Metadata.State = tbtypes.Staged
 	if newID == "" {
 		// Machine has been deprovisioned

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"time"
 
 	tink "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/types"
 
 	tinkv1alpha1 "github.com/tinkerbell/tink/api/v1alpha1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,7 +44,7 @@ func NewWorkflowClient(k8sClient client.Client) *WorkflowClient {
 }
 
 // CreateWorkflow creates a new Tinkerbell Workflow resource in the cluster.
-func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, workflowName, templateRef string, hardware tink.Hardware) error {
+func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, templateRef string, hardware tink.Hardware) error {
 	// Construct the Workflow object
 	ifaceConfig := hardware.Spec.Interfaces[0].DHCP
 	dnsNameservers := "1.1.1.1"
@@ -51,11 +53,14 @@ func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, workflowN
 		dnsNameservers = ns
 	}
 
+	workflowName := fmt.Sprintf("%s-%s-%s", hardware.Name, templateRef, time.Now().Format("20060102150405"))
 	workflow := &tinkv1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
-			// TODO(MQ): generalize the naming of the workflow and implement a function that can be used across the provider.
-			Name:      workflowName + "-workflow",
+			Name:      workflowName,
 			Namespace: hardware.Namespace,
+			Labels: map[string]string{
+				tink.HardwareRefLabel: hardware.Name,
+			},
 		},
 		Spec: tinkv1alpha1.WorkflowSpec{
 			TemplateRef: templateRef,
@@ -80,23 +85,6 @@ func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, workflowN
 	return nil
 }
 
-// DeleteWorkflow deletes an existing Tinkerbell Workflow resource from the cluster.
-func (w *WorkflowClient) DeleteWorkflow(ctx context.Context, name string, namespace string) error {
-	workflow := &tinkv1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-	if err := w.tinkclient.Delete(ctx, workflow); err != nil {
-		if !kerrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete workflow: %w", err)
-		}
-	}
-
-	return nil
-}
-
 // GetWorkflow retrieves a Tinkerbell Workflow resource from the cluster.
 func (w *WorkflowClient) GetWorkflow(ctx context.Context, name string, namespace string) (*tinkv1alpha1.Workflow, error) {
 	workflow := &tinkv1alpha1.Workflow{}
@@ -104,4 +92,35 @@ func (w *WorkflowClient) GetWorkflow(ctx context.Context, name string, namespace
 		return nil, fmt.Errorf("failed to get workflow: %w", err)
 	}
 	return workflow, nil
+}
+
+// CleanupWorkflows would delete all workflows that are assigned to a de-provisioned hardware, and they are in a pending
+// state, to avoid the situation of re-running a workflow for a de-provisioned machine.
+func (w *WorkflowClient) CleanupWorkflows(ctx context.Context, hardwareName, namespace string) error {
+	workflows := &tinkv1alpha1.WorkflowList{}
+	if err := w.tinkclient.List(ctx, workflows, &client.ListOptions{
+		Namespace: namespace,
+		LabelSelector: labels.SelectorFromSet(map[string]string{
+			tink.HardwareRefLabel: hardwareName,
+		}),
+	}); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to fetch workflows: %w", err)
+	}
+
+	for _, workflow := range workflows.Items {
+		if workflow.Status.State == tinkv1alpha1.WorkflowStatePending ||
+			workflow.Status.State == tinkv1alpha1.WorkflowStateTimeout {
+			if err := w.tinkclient.Delete(ctx, &workflow); err != nil {
+				if !kerrors.IsNotFound(err) {
+					return fmt.Errorf("failed to delete workflow: %w", err)
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
@@ -129,7 +129,7 @@ func (d *driver) ProvisionServer(ctx context.Context, _ *zap.SugaredLogger, meta
 
 	// Create Workflow to match the template and server
 	server := tinktypes.Hardware{Hardware: hardware}
-	if err = d.WorkflowClient.CreateWorkflow(ctx, userdata, server.Name, client.ProvisionWorkerNodeTemplate, server); err != nil {
+	if err = d.WorkflowClient.CreateWorkflow(ctx, userdata, client.ProvisionWorkerNodeTemplate, server); err != nil {
 		return nil, err
 	}
 
@@ -152,10 +152,8 @@ func (d *driver) DeprovisionServer(ctx context.Context) error {
 		return err
 	}
 
-	// Delete the associated Workflow.
-	workflowName := targetHardware.Name + "-workflow" // Assuming workflow names are derived from hardware names
-	if err := d.WorkflowClient.DeleteWorkflow(ctx, workflowName, targetHardware.Namespace); err != nil {
-		return fmt.Errorf("failed to delete workflow %s: %w", workflowName, err)
+	if err := d.WorkflowClient.CleanupWorkflows(ctx, targetHardware.Name, targetHardware.Namespace); err != nil {
+		return fmt.Errorf("failed to cleanup workflows for hardware %s: %w", targetHardware.Name, err)
 	}
 
 	// Reset the hardware ID and state in the tinkerbell cluster.

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/types/types.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/types/types.go
@@ -27,6 +27,8 @@ const (
 	Staged         string = "Staged"
 	Provisioned    string = "Provisioned"
 	Decommissioned string = "Decommissioned"
+
+	HardwareRefLabel = "app.kubernetes.io/hardware-reference"
 )
 
 // TinkerbellPluginSpec defines the required information for the Tinkerbell plugin.


### PR DESCRIPTION
**What this PR does / why we need it**:
In Tinkerbell a workflow brings together [Hardware](https://tinkerbell.org/docs/concepts/hardware) and a [Template](https://tinkerbell.org/docs/concepts/templates) for execution.. The status field of the workflow can be used to determine the current state of the workflow and to identify any issues that may have occurred during the execution of it. Thus, it is important to keep track of those workflows even if they were executed to keep track of the provisioning processes. This PR makes the workflows of a hardware unique and it opens up the possibility to run a workflow multiple times and treat them as an idempotent process which can't be resumed in terms of failures. Those workflows must be deleted in two situations: 

1- The workflow has a pending state however the machine deployment has been deleted. Thus we should get rid of those workflows to prevent triggering them in the future. 
2- The workflow is stuck in a timeout state and it cannot be resumed thus they don't have any real value.

This PR cleans up those workflows based on the criteria above.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Tinerkebll: cleanup workflows that are either in a pending state or timeout state.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
