### PR TITLE
Fix Hardware Metadata Condition for Tinkerbell Provider 

### DIFF
--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
@@ -89,7 +89,7 @@ func (d *driver) GetServer(ctx context.Context) (plugins.Server, error) {
 		return nil, err
 	}
 
-	if targetHardware.Spec.Metadata != nil && targetHardware.Spec.Metadata.State != tinktypes.Staged {
+	if targetHardware.Spec.Metadata == nil || targetHardware.Spec.Metadata.State == "" {
 		return nil, cloudprovidererrors.ErrInstanceNotFound
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The Tinkerbell provider should provision bare metal machine deployment if the hardware has no metadata nor the metadata state is empty. This indicates that, the machine isn't yet provisioned nor staged. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
