### PR TITLE
bump to Go 1.23.0

### DIFF
--- a/.prow/e2e-features.yaml
+++ b/.prow/e2e-features.yaml
@@ -34,7 +34,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -63,7 +63,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -92,7 +92,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -119,7 +119,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - /bin/bash
             - -c
@@ -54,7 +54,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/provider-alibaba.yaml
+++ b/.prow/provider-alibaba.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -31,7 +31,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -61,7 +61,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -93,7 +93,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -126,7 +126,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -157,7 +157,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -188,7 +188,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -219,7 +219,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -93,7 +93,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-equinix-metal.yaml
+++ b/.prow/provider-equinix-metal.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -26,7 +26,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-linode.yaml
+++ b/.prow/provider-linode.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -62,7 +62,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-scaleway.yaml
+++ b/.prow/provider-scaleway.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -31,7 +31,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -60,7 +60,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -92,7 +92,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -124,7 +124,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -156,7 +156,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -42,7 +42,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -63,7 +63,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -83,7 +83,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:
@@ -102,7 +102,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - "/usr/local/bin/shfmt"
           args:
@@ -130,7 +130,7 @@ presubmits:
     clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - "./hack/verify-boilerplate.sh"
           resources:
@@ -149,7 +149,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -165,7 +165,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-11
+        - image: quay.io/kubermatic/build:go-1.23-node-20-0
           command:
             - make
           args:

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-11 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-0 containerize ./hack/update-fixtures.sh
 
 go test ./... -v -update || go test ./...
 

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-20-11 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-0 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/pkg/cloudprovider/provider/alibaba/provider.go
+++ b/pkg/cloudprovider/provider/alibaba/provider.go
@@ -423,9 +423,7 @@ func getInstance(client *ecs.Client, instanceName string, uid string) (*ecs.Inst
 		return nil, fmt.Errorf("failed to describe instance with instanceName: %s: %w", instanceName, err)
 	}
 
-	if response.Instances.Instance == nil ||
-		len(response.Instances.Instance) == 0 ||
-		response.GetHttpStatus() == http.StatusNotFound {
+	if len(response.Instances.Instance) == 0 || response.GetHttpStatus() == http.StatusNotFound {
 		return nil, cloudprovidererrors.ErrInstanceNotFound
 	}
 

--- a/pkg/controller/util/machine_deployment.go
+++ b/pkg/controller/util/machine_deployment.go
@@ -132,7 +132,7 @@ func SetDeploymentRevision(deployment *v1alpha1.MachineDeployment, revision stri
 
 // MaxRevision finds the highest revision in the machine sets.
 func MaxRevision(log *zap.SugaredLogger, allMSs []*v1alpha1.MachineSet) int64 {
-	max := int64(0)
+	maxRev := int64(0)
 	for _, ms := range allMSs {
 		if v, err := Revision(ms); err != nil {
 			log.Debugw(
@@ -140,11 +140,11 @@ func MaxRevision(log *zap.SugaredLogger, allMSs []*v1alpha1.MachineSet) int64 {
 				"machinset", client.ObjectKeyFromObject(ms),
 				zap.Error(err),
 			)
-		} else if v > max {
-			max = v
+		} else if v > maxRev {
+			maxRev = v
 		}
 	}
-	return max
+	return maxRev
 }
 
 // Revision returns the revision number of the input object.


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps all Prowjobs to Go 1.23.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update to Go 1.23.0
```

**Documentation**:
```documentation
NONE
```
