### PR TITLE
Remove CentOS tests

### DIFF
--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -174,37 +174,6 @@ presubmits:
             limits:
               memory: 7Gi
 
-  - name: pull-machine-controller-e2e-aws-centos8
-    always_run: false
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
-    labels:
-      preset-aws: "true"
-      preset-hetzner: "true"
-      preset-e2e-ssh: "true"
-      preset-goproxy: "true"
-      preset-kind-volume-mounts: "true"
-      preset-docker-mirror: "true"
-      preset-kubeconfig-ci: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.23-0
-          command:
-            - "./hack/ci/run-e2e-tests.sh"
-          args:
-            - "TestAWSCentOS8ProvisioningE2E"
-          env:
-            - name: CLOUD_PROVIDER
-              value: aws
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 7Gi
-              cpu: 2
-            limits:
-              memory: 7Gi
-
   - name: pull-machine-controller-e2e-aws-assume-role
     always_run: false
     decorate: true

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -302,7 +302,7 @@ func TestKubevirtProvisioningE2E(t *testing.T) {
 		t.Fatal("Unable to run kubevirt tests, KUBEVIRT_E2E_TESTS_KUBECONFIG must be set")
 	}
 
-	selector := OsSelector("ubuntu", "centos", "flatcar", "rockylinux")
+	selector := OsSelector("ubuntu", "flatcar", "rockylinux")
 
 	params := []string{
 		fmt.Sprintf("<< KUBECONFIG_BASE64 >>=%s", safeBase64Encoding(kubevirtKubeconfig)),
@@ -402,7 +402,7 @@ func TestDigitalOceanProvisioningE2E(t *testing.T) {
 		t.Fatal("Unable to run the test suite, DO_E2E_TESTS_TOKEN environment variable cannot be empty")
 	}
 
-	selector := OsSelector("ubuntu", "centos", "rockylinux")
+	selector := OsSelector("ubuntu", "rockylinux")
 
 	// act
 	params := []string{fmt.Sprintf("<< DIGITALOCEAN_TOKEN >>=%s", doToken)}
@@ -528,29 +528,6 @@ func TestAWSFlatcarCoreOSCloudInit8ProvisioningE2E(t *testing.T) {
 
 	// We would like to test flatcar with CoreOS-cloud-init
 	selector := OsSelector("flatcar")
-	runScenarios(context.Background(), t, selector, params, AWSManifest, fmt.Sprintf("aws-%s", *testRunIdentifier))
-}
-
-func TestAWSCentOS8ProvisioningE2E(t *testing.T) {
-	t.Parallel()
-
-	// test data
-	awsKeyID := os.Getenv("AWS_E2E_TESTS_KEY_ID")
-	awsSecret := os.Getenv("AWS_E2E_TESTS_SECRET")
-	if len(awsKeyID) == 0 || len(awsSecret) == 0 {
-		t.Fatal("Unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
-	}
-
-	amiID := "ami-032025b3afcbb6b34" // official "CentOS 8.2.2004 x86_64"
-
-	params := []string{
-		fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
-		fmt.Sprintf("<< AWS_SECRET_ACCESS_KEY >>=%s", awsSecret),
-		fmt.Sprintf("<< AMI >>=%s", amiID),
-	}
-
-	// We would like to test CentOS8 image only in this test as the other images are tested in TestAWSProvisioningE2E
-	selector := OsSelector("centos")
 	runScenarios(context.Background(), t, selector, params, AWSManifest, fmt.Sprintf("aws-%s", *testRunIdentifier))
 }
 
@@ -686,7 +663,6 @@ func TestGCEProvisioningE2E(t *testing.T) {
 		t.Fatal("Unable to run the test suite, GOOGLE_SERVICE_ACCOUNT environment variable cannot be empty")
 	}
 
-	// Act. GCE does not support CentOS.
 	selector := OsSelector("ubuntu", "flatcar")
 	params := []string{
 		fmt.Sprintf("<< GOOGLE_SERVICE_ACCOUNT_BASE64 >>=%s", safeBase64Encoding(googleServiceAccount)),
@@ -729,7 +705,7 @@ func TestEquinixMetalProvisioningE2E(t *testing.T) {
 		t.Fatal("Unable to run the test suite, METAL_PROJECT_ID environment variable cannot be empty")
 	}
 
-	selector := And(OsSelector("ubuntu", "centos", "rockylinux", "flatcar"), Not(NameSelector("migrateUID")))
+	selector := And(OsSelector("ubuntu", "rockylinux", "flatcar"), Not(NameSelector("migrateUID")))
 
 	// act
 	params := []string{
@@ -776,7 +752,6 @@ func TestLinodeProvisioningE2E(t *testing.T) {
 		t.Fatal("Unable to run the test suite, LINODE_E2E_TESTS_TOKEN environment variable cannot be empty")
 	}
 
-	// we're shimming userdata through Linode stackscripts and the stackscript hasn't been verified for use with centos
 	selector := OsSelector("ubuntu")
 
 	// act
@@ -841,7 +816,7 @@ func TestVsphereProvisioningE2E(t *testing.T) {
 	t.Parallel()
 
 	// In-tree cloud provider is not supported from Kubernetes v1.30.
-	selector := And(Not(OsSelector("amzn2", "centos")), Not(VersionSelector("1.30.4", "1.31.0")))
+	selector := And(Not(OsSelector("amzn2")), Not(VersionSelector("1.30.4", "1.31.0")))
 	params := getVSphereTestParams(t)
 
 	runScenarios(context.Background(), t, selector, params, VSPhereManifest, fmt.Sprintf("vs-%s", *testRunIdentifier))
@@ -882,7 +857,7 @@ func TestVsphereDatastoreClusterProvisioningE2E(t *testing.T) {
 	t.Parallel()
 
 	// In-tree cloud provider is not supported from Kubernetes v1.30.
-	selector := And(OsSelector("ubuntu", "centos", "rhel", "flatcar"), Not(VersionSelector("1.30.4", "1.31.0")))
+	selector := And(OsSelector("ubuntu", "rhel", "flatcar"), Not(VersionSelector("1.30.4", "1.31.0")))
 
 	params := getVSphereTestParams(t)
 	runScenarios(context.Background(), t, selector, params, VSPhereDSCManifest, fmt.Sprintf("vs-dsc-%s", *testRunIdentifier))
@@ -975,7 +950,7 @@ func TestNutanixProvisioningE2E(t *testing.T) {
 
 	// exclude migrateUID test case because it's a no-op for Nutanix and runs from a different
 	// location, thus possibly blocking access a HTTP proxy if it is configured.
-	selector := And(OsSelector("ubuntu", "centos"), Not(NameSelector("migrateUID")))
+	selector := And(OsSelector("ubuntu"), Not(NameSelector("migrateUID")))
 	params := getNutanixTestParams(t)
 	runScenarios(context.Background(), t, selector, params, nutanixManifest, fmt.Sprintf("nx-%s", *testRunIdentifier))
 }
@@ -1113,7 +1088,7 @@ func TestVultrProvisioningE2E(t *testing.T) {
 		t.Fatal("Unable to run the test suite, VULTR_API_KEY environment variable cannot be empty")
 	}
 
-	selector := OsSelector("ubuntu", "centos", "rockylinux")
+	selector := OsSelector("ubuntu", "rockylinux")
 
 	// act
 	params := []string{fmt.Sprintf("<< VULTR_API_KEY >>=%s", apiKey)}

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -42,7 +42,6 @@ var (
 
 	operatingSystems = []providerconfigtypes.OperatingSystem{
 		providerconfigtypes.OperatingSystemUbuntu,
-		providerconfigtypes.OperatingSystemCentOS,
 		providerconfigtypes.OperatingSystemAmazonLinux2,
 		providerconfigtypes.OperatingSystemRHEL,
 		providerconfigtypes.OperatingSystemFlatcar,
@@ -51,7 +50,6 @@ var (
 
 	openStackImages = map[string]string{
 		string(providerconfigtypes.OperatingSystemUbuntu):     "kubermatic-ubuntu",
-		string(providerconfigtypes.OperatingSystemCentOS):     "machine-controller-e2e-centos",
 		string(providerconfigtypes.OperatingSystemRHEL):       "machine-controller-e2e-rhel-8-5",
 		string(providerconfigtypes.OperatingSystemFlatcar):    "kubermatic-e2e-flatcar",
 		string(providerconfigtypes.OperatingSystemRockyLinux): "machine-controller-e2e-rockylinux",
@@ -63,7 +61,6 @@ var (
 	}
 
 	vSphereOSImageTemplates = map[string]string{
-		string(providerconfigtypes.OperatingSystemCentOS):     "kkp-centos-7",
 		string(providerconfigtypes.OperatingSystemFlatcar):    "kkp-flatcar-3139.2.0",
 		string(providerconfigtypes.OperatingSystemRHEL):       "kkp-rhel-8.6",
 		string(providerconfigtypes.OperatingSystemRockyLinux): "kkp-rockylinux-8",
@@ -71,7 +68,6 @@ var (
 	}
 
 	kubevirtImages = map[string]string{
-		string(providerconfigtypes.OperatingSystemCentOS):     "centos",
 		string(providerconfigtypes.OperatingSystemFlatcar):    "flatcar",
 		string(providerconfigtypes.OperatingSystemRHEL):       "rhel",
 		string(providerconfigtypes.OperatingSystemRockyLinux): "rockylinux",
@@ -245,9 +241,6 @@ func testScenario(ctx context.Context, t *testing.T, testCase scenario, cloudPro
 
 	if strings.Contains(cloudProvider, string(providerconfigtypes.CloudProviderEquinixMetal)) {
 		switch testCase.osName {
-		case string(providerconfigtypes.OperatingSystemCentOS):
-			scenarioParams = append(scenarioParams, fmt.Sprintf("<< INSTANCE_TYPE >>=%s", "m3.small.x86"))
-			scenarioParams = append(scenarioParams, fmt.Sprintf("<< METRO_CODE >>=%s", "AM"))
 		case string(providerconfigtypes.OperatingSystemFlatcar):
 			scenarioParams = append(scenarioParams, fmt.Sprintf("<< INSTANCE_TYPE >>=%s", "c3.small.x86"))
 			scenarioParams = append(scenarioParams, fmt.Sprintf("<< METRO_CODE >>=%s", "NY"))

--- a/test/e2e/provisioning/testdata/machinedeployment-digitalocean.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-digitalocean.yaml
@@ -35,7 +35,6 @@ spec:
             monitoring: false
             tags:
               - "machine-controller"
-          # Can be 'ubuntu' or 'centos'
           operatingSystem: "<< OS_NAME >>"
           operatingSystemSpec:
             distUpgradeOnBoot: false


### PR DESCRIPTION
**What this PR does / why we need it**:

CentOS 7 has reached end-of-life and the E2E tests are not functional any longer. Perhaps the CentOS 7 repositories are not functional any longer.

We need to completely clean up CentOS support from machine-controller, but this is the first step to unblock other PRs because of the failing E2E tests.

**What type of PR is this?**

/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```

/assign @xrstf 