### PR TITLE
Fix vSphere E2E tests

### DIFF
--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -816,7 +816,7 @@ func TestVsphereProvisioningE2E(t *testing.T) {
 	t.Parallel()
 
 	// In-tree cloud provider is not supported from Kubernetes v1.30.
-	selector := And(Not(OsSelector("amzn2")), Not(VersionSelector("1.30.4", "1.31.0")))
+	selector := And(OsSelector("ubuntu"), Not(VersionSelector("1.30.4", "1.31.0")))
 	params := getVSphereTestParams(t)
 
 	runScenarios(context.Background(), t, selector, params, VSPhereManifest, fmt.Sprintf("vs-%s", *testRunIdentifier))

--- a/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vsphere.yaml
@@ -30,12 +30,12 @@ spec:
             username: '<< VSPHERE_USERNAME >>'
             vsphereURL: '<< VSPHERE_ADDRESS >>'
             datacenter: 'Hamburg'
-            folder: '/Hamburg/vm/Kubermatic-ci'
+            folder: '/Hamburg/vm/Kubermatic-dev'
             password: << VSPHERE_PASSWORD >>
             # example: 'https://your-vcenter:8443'. '/sdk' gets appended automatically
-            cluster: Kubermatic
+            cluster: 'vSAN Cluster'
             vmAntiAffinity: true
-            datastore: vsan
+            datastore: Datastore0-truenas
             cpus: 2
             MemoryMB: 4096
             diskSizeGB: << DISK_SIZE >>


### PR DESCRIPTION
**What this PR does / why we need it**:

Some parameters on the vSphere side are temporarily changed. This PR ensures that the vSphere E2E tests can pass.

**What type of PR is this?**

/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```