### PR TITLE
add kubermatic to packngo User-Agent

### DIFF
--- a/pkg/cloudprovider/provider/equinixmetal/provider.go
+++ b/pkg/cloudprovider/provider/equinixmetal/provider.go
@@ -478,7 +478,9 @@ func getNameForOS(os providerconfigtypes.OperatingSystem) (string, error) {
 }
 
 func getClient(apiKey string) *packngo.Client {
-	return packngo.NewClientWithAuth("kubermatic", apiKey, nil)
+	client := packngo.NewClientWithAuth("kubermatic", apiKey, nil)
+	client.UserAgent = fmt.Sprintf("kubermatic/machine-controller %s", client.UserAgent)
+	return client
 }
 
 func generateTag(ID string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds "kubermatic" to the packngo User-Agent. This will help in usage and debug detail gathering.
This is also done in the Linode and Scaleway providers.

Related: https://github.com/kubermatic/kubermatic/pull/13629

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
