### PR TITLE
Add sig-cluster-management as code owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-  - machine-controller-maintainers
   - sig-cluster-management
 
 reviewers:
-  - machine-controller-maintainers
   - sig-cluster-management
 
 labels:

--- a/OWNERS
+++ b/OWNERS
@@ -2,9 +2,11 @@
 
 approvers:
   - machine-controller-maintainers
+  - sig-cluster-management
 
 reviewers:
   - machine-controller-maintainers
+  - sig-cluster-management
 
 labels:
   - sig/cluster-management

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,11 +3,13 @@
 
 aliases:
   machine-controller-maintainers:
+    - yaa110
+  sig-cluster-management:
     - ahmedwaleedmalik
+    - cnvergence
     - embik
     - kron4eg
     - moadqassem
     - moelsayed
     - xmudrii
     - xrstf
-    - yaa110

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,8 +2,6 @@
 # To change team associations, update the GitHub teams via https://github.com/kubermatic/access.
 
 aliases:
-  machine-controller-maintainers:
-    - yaa110
   sig-cluster-management:
     - ahmedwaleedmalik
     - cnvergence
@@ -13,3 +11,4 @@ aliases:
     - moelsayed
     - xmudrii
     - xrstf
+    - yaa110


### PR DESCRIPTION
**What this PR does / why we need it**:
_Officially_ adding @kubermatic/sig-cluster-management as the code owner for machine-controller. We are retaining the `machine-controller-maintainers` section since there is a possibility that someone who doesn't belong to sig-cluster-management might still be a maintainer of MC as this project is a bit more open and can overlap with multiple SIGs. For example, sig-networking through https://github.com/kubermatic/machine-controller/pull/1849, which makes total sense to me.

**UPDATE:** After review, this PR simply removes the `machine-controller-maintainers` and adds Navid to `sig-cluster-management`

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:
I'm not adding or removing anyone who was already added as OWNER. I'm just adding sig-cluster-management there as the owners will be synced automatically then.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
