### PR TITLE
Add static up support for KubeVirt in KubeOVN

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -637,16 +637,16 @@ func (p *provider) newVirtualMachine(_ context.Context, c *Config, pc *providerc
 
 	var (
 		dataVolumeName = machine.Name
-		annotations    map[string]string
+		annotations    = map[string]string{}
 	)
 	// Add machineName as prefix to secondaryDisks.
 	addPrefixToSecondaryDisk(c.SecondaryDisks, dataVolumeName)
 
 	if pc.OperatingSystem == providerconfigtypes.OperatingSystemFlatcar {
-		annotations = map[string]string{
-			"kubevirt.io/ignitiondata": userdata,
-		}
+		annotations["kubevirt.io/ignitiondata"] = userdata
 	}
+
+	annotations["ovn.kubernetes.io/allow_live_migration"] = "true"
 
 	defaultBridgeNetwork, err := defaultBridgeNetwork(macAddressGetter)
 	if err != nil {

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
@@ -28,6 +28,8 @@ spec:
   runStrategy: Once
   template:
     metadata:
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
@@ -28,6 +28,8 @@ spec:
   runStrategy: Once
   template:
     metadata:
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker

--- a/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
@@ -29,6 +29,8 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker

--- a/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
@@ -28,6 +28,8 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         kubevirt.io/vm: http-image-source
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
@@ -34,6 +34,8 @@ spec:
     name: custom-pref
   template:
     metadata:
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
@@ -34,6 +34,8 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker

--- a/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
@@ -28,6 +28,8 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker

--- a/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
@@ -29,6 +29,8 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         kubevirt.io/vm: pvc-image-source
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
@@ -29,6 +29,8 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         kubevirt.io/vm: registry-image-source-pod
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
@@ -29,6 +29,8 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         kubevirt.io/vm: registry-image-source
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
@@ -54,6 +54,8 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker

--- a/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
@@ -28,6 +28,8 @@ spec:
   template:
     metadata:
       creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker


### PR DESCRIPTION
**What this PR does / why we need it**:
Enabling the live migration of KubeVirt VMs by default. This would enable us to get a static ip address when using KubeOVN as a CNI. Another PR would actually fine tune this feature based on machine deployment configs.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
allow live migration by default
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
