### PR TITLE
Support Different Storage Targets for KubeVirt Provider 

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -50,7 +50,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -870,7 +869,7 @@ func getDataVolumeTemplates(config *Config, dataVolumeName string, annotations m
 	switch config.StorageTarget {
 	case Storage:
 		dataVolumeTemplates[0].Spec.Storage = &cdiv1beta1.StorageSpec{
-			StorageClassName: pointer.String(config.StorageClassName),
+			StorageClassName: ptr.To(config.StorageClassName),
 			AccessModes: []corev1.PersistentVolumeAccessMode{
 				config.StorageAccessType,
 			},
@@ -880,7 +879,7 @@ func getDataVolumeTemplates(config *Config, dataVolumeName string, annotations m
 		}
 	default:
 		dataVolumeTemplates[0].Spec.PVC = &corev1.PersistentVolumeClaimSpec{
-			StorageClassName: pointer.String(config.StorageClassName),
+			StorageClassName: ptr.To(config.StorageClassName),
 			AccessModes: []corev1.PersistentVolumeAccessMode{
 				config.StorageAccessType,
 			},

--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -59,6 +59,7 @@ type kubevirtProviderSpecConf struct {
 	OsImageDV                string // if OsImage from DV and not from http source
 	Instancetype             *kubevirtv1.InstancetypeMatcher
 	Preference               *kubevirtv1.PreferenceMatcher
+	StorageTarget            StorageTarget
 	OperatingSystem          string
 	TopologySpreadConstraint bool
 	Affinity                 bool
@@ -123,6 +124,9 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 					"storageClassName": "longhorn3"}],
 				{{- end }}
 				"primaryDisk": {
+					{{- if .StorageTarget }}
+					"storageTarget": "{{ .StorageTarget }}",
+					{{- end }}                    
 					{{- if .OsImageDV }}
 					"osImage": "{{ .OsImageDV }}",
 					{{- else }}
@@ -217,6 +221,9 @@ func TestNewVirtualMachine(t *testing.T) {
 		{
 			name:     "custom-local-disk",
 			specConf: kubevirtProviderSpecConf{OsImageDV: "ns/dvname"},
+		}, {
+			name:     "use-storage-as-storage-target",
+			specConf: kubevirtProviderSpecConf{StorageTarget: Storage},
 		},
 		{
 			name:     "http-image-source",

--- a/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
@@ -1,0 +1,80 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  labels:
+    cluster.x-k8s.io/cluster-name: cluster-name
+    cluster.x-k8s.io/role: worker
+    kubevirt.io/vm: use-storage-as-storage-target
+    md: md-name
+  name: use-storage-as-storage-target
+  namespace: test-namespace
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: use-storage-as-storage-target
+        annotations: {}
+      spec:
+        source:
+          http:
+            url: "http://x.y.z.t/ubuntu.img"
+        storage:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+          storageClassName: longhorn
+  runStrategy: Once
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
+      labels:
+        cluster.x-k8s.io/cluster-name: cluster-name
+        cluster.x-k8s.io/role: worker
+        kubevirt.io/vm: use-storage-as-storage-target
+        md: md-name
+    spec:
+      affinity: {}
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: datavolumedisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - macAddress: b6:f5:b4:fe:45:1d
+              name: default
+              bridge: {}
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 30
+      topologyspreadconstraints:
+        - maxskew: 1
+          topologykey: kubernetes.io/hostname
+          whenunsatisfiable: ScheduleAnyway
+          labelselector:
+            matchlabels:
+              md: md-name
+      volumes:
+        - dataVolume:
+            name: use-storage-as-storage-target
+          name: datavolumedisk
+        - cloudInitNoCloud:
+            secretRef:
+              name: udsn
+          name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -76,6 +76,9 @@ type Template struct {
 // PrimaryDisk.
 type PrimaryDisk struct {
 	Disk
+	// StorageTarget describes which VirtualMachine storage target will be used in the DataVolumeTemplate.
+	StorageTarget providerconfigtypes.ConfigVarString `json:"storageTarget,omitempty"`
+	// OsImage describes the OS that will be installed on the VirtualMachine.
 	OsImage providerconfigtypes.ConfigVarString `json:"osImage,omitempty"`
 	// Source describes the VM Disk Image source.
 	Source providerconfigtypes.ConfigVarString `json:"source,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, machine controller only supports the creation of KubeVirt Data Volumes using PVCs without specifying what storage profile will be used which is quite important for some CSI drivers. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
This PR was tested manually with KubeVirt and two machine have been created and they were reflected correctly on the VMs: 
```shell
spec:
  dataVolumeTemplates:
  - metadata:
      creationTimestamp: null
      name: dv-test-557f6b6c88-2z7g2
    spec:
      source:
        http:
          url: http://remote/host/os
      storage:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 25Gi
        storageClassName: nfs
```
**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
support `storage ` as a another KubeVirt DataVolume storage definition 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
