### PR TITLE
fix: change default configuration for KubeVirt networking

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -126,7 +126,7 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 				"primaryDisk": {
 					{{- if .StorageTarget }}
 					"storageTarget": "{{ .StorageTarget }}",
-					{{- end }}                    
+					{{- end }}
 					{{- if .OsImageDV }}
 					"osImage": "{{ .OsImageDV }}",
 					{{- else }}
@@ -221,7 +221,8 @@ func TestNewVirtualMachine(t *testing.T) {
 		{
 			name:     "custom-local-disk",
 			specConf: kubevirtProviderSpecConf{OsImageDV: "ns/dvname"},
-		}, {
+		},
+		{
 			name:     "use-storage-as-storage-target",
 			specConf: kubevirtProviderSpecConf{StorageTarget: Storage},
 		},
@@ -263,7 +264,7 @@ func TestNewVirtualMachine(t *testing.T) {
 			c.Namespace = testNamespace
 
 			// Check the created VirtualMachine
-			vm, _ := p.newVirtualMachine(context.TODO(), c, pc, machine, "udsn", userdata, fakeMachineDeploymentNameAndRevisionForMachineGetter(), fixedMacAddressGetter)
+			vm, _ := p.newVirtualMachine(context.TODO(), c, pc, machine, "udsn", userdata, fakeMachineDeploymentNameAndRevisionForMachineGetter())
 			vm.TypeMeta.APIVersion, vm.TypeMeta.Kind = kubevirtv1.VirtualMachineGroupVersionKind.ToAPIVersionAndKind()
 
 			if !equality.Semantic.DeepEqual(vm, expectedVms[tt.name]) {
@@ -287,10 +288,6 @@ func toVirtualMachines(objects []runtime.Object) map[string]*kubevirtv1.VirtualM
 		}
 	}
 	return vms
-}
-
-func fixedMacAddressGetter() (string, error) {
-	return "b6:f5:b4:fe:45:1d", nil
 }
 
 // runtimeFromYaml returns a list of Kubernetes runtime objects from their yaml templates.

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
@@ -30,6 +30,7 @@ spec:
     metadata:
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
@@ -53,8 +54,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
@@ -30,6 +30,7 @@ spec:
     metadata:
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
@@ -56,8 +57,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
@@ -31,6 +31,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
@@ -48,8 +49,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
@@ -30,6 +30,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         kubevirt.io/vm: http-image-source
         cluster.x-k8s.io/cluster-name: cluster-name
@@ -47,8 +48,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
@@ -36,6 +36,7 @@ spec:
     metadata:
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
@@ -53,8 +54,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
       networks:
         - name: default

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
@@ -36,6 +36,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
@@ -53,8 +54,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
       networks:
         - name: default

--- a/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
@@ -30,6 +30,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
@@ -47,8 +48,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
@@ -31,6 +31,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         kubevirt.io/vm: pvc-image-source
         cluster.x-k8s.io/cluster-name: cluster-name
@@ -48,8 +49,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
@@ -31,6 +31,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         kubevirt.io/vm: registry-image-source-pod
         cluster.x-k8s.io/cluster-name: cluster-name
@@ -48,8 +49,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
@@ -31,6 +31,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         kubevirt.io/vm: registry-image-source
         cluster.x-k8s.io/cluster-name: cluster-name
@@ -48,8 +49,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
@@ -56,6 +56,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
@@ -79,8 +80,7 @@ spec:
                 bus: virtio
               name: secondary-disks-secondarydisk1
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
@@ -30,6 +30,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
@@ -47,8 +48,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:

--- a/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
@@ -31,6 +31,7 @@ spec:
       creationTimestamp: null
       annotations:
         "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name
         cluster.x-k8s.io/role: worker
@@ -48,8 +49,7 @@ spec:
                 bus: virtio
               name: cloudinitdisk
           interfaces:
-            - macAddress: b6:f5:b4:fe:45:1d
-              name: default
+            - name: default
               bridge: {}
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will remove random mac address actually to allow other solutions e.g KubeOVN CNI to properly attach one to the VM.
Also, it introduces an annotation for KubeVIrt live-migration in bridge mode

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #https://github.com/kubermatic/machine-controller/issues/1752

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove random mac address generation as default in KubeVirt
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
