### PR TITLE
Support topology aware zones and regions in KubeVirt

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -977,21 +977,3 @@ func getTopologySpreadConstraints(config *Config, matchLabels map[string]string)
 		},
 	}
 }
-
-//func getStorageTopologies(ctx context.Context, storageClasName string, client client.Client) (map[string]string, error) {
-//	sc := &storagev1.StorageClass{}
-//	if err := client.Get(ctx, types.NamespacedName{Name: storageClasName}, sc); err != nil {
-//		return err, nil
-//	}
-//
-//	topologies := make(map[string]string)
-//	for _, topology := range sc.AllowedTopologies {
-//		for _, exp := range topology.MatchLabelExpressions {
-//			if len(exp.Values) > 1 {
-//				return nil, errors.New("found multiple regions or zones. One zone/region is allowed  ")
-//			}
-//
-//			topologies[exp.Key] =
-//		}
-//	}
-//}

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -76,6 +76,10 @@ const (
 	registrySource imageSource = "registry"
 	// pvcSource defines the pvc source type for VM Disk Image.
 	pvcSource imageSource = "pvc"
+	// topologyRegionKey and topologyZoneKey  on PVC is a topology-aware volume provisioners will automatically set
+	// node affinity constraints on a PersistentVolume.
+	topologyRegionKey = "topology.kubernetes.io/region"
+	topologyZoneKey   = "topology.kubernetes.io/zone"
 )
 
 type provider struct {
@@ -106,6 +110,8 @@ type Config struct {
 	SecondaryDisks            []SecondaryDisks
 	NodeAffinityPreset        NodeAffinityPreset
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint
+	Region                    string
+	Zone                      string
 }
 
 // StorageTarget represents targeted storage definition that will be used to provision VirtualMachine volumes. Currently,
@@ -329,6 +335,11 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	config.TopologySpreadConstraints, err = p.parseTopologySpreadConstraint(rawConfig.TopologySpreadConstraints)
 	if err != nil {
 		return nil, nil, fmt.Errorf(`failed to parse "topologySpreadConstraints" field: %w`, err)
+	}
+
+	if rawConfig.VirtualMachine.Location != nil {
+		config.Zone = rawConfig.VirtualMachine.Location.Zone
+		config.Region = rawConfig.VirtualMachine.Location.Region
 	}
 
 	return &config, pconfig, nil
@@ -649,6 +660,14 @@ func (p *provider) newVirtualMachine(_ context.Context, c *Config, pc *providerc
 	labels["cluster.x-k8s.io/cluster-name"] = c.ClusterName
 	labels["cluster.x-k8s.io/role"] = "worker"
 
+	if c.Region != "" {
+		labels[topologyRegionKey] = c.Region
+	}
+
+	if c.Zone != "" {
+		labels[topologyZoneKey] = c.Zone
+	}
+
 	var (
 		dataVolumeName = machine.Name
 		annotations    = map[string]string{}
@@ -958,3 +977,21 @@ func getTopologySpreadConstraints(config *Config, matchLabels map[string]string)
 		},
 	}
 }
+
+//func getStorageTopologies(ctx context.Context, storageClasName string, client client.Client) (map[string]string, error) {
+//	sc := &storagev1.StorageClass{}
+//	if err := client.Get(ctx, types.NamespacedName{Name: storageClasName}, sc); err != nil {
+//		return err, nil
+//	}
+//
+//	topologies := make(map[string]string)
+//	for _, topology := range sc.AllowedTopologies {
+//		for _, exp := range topology.MatchLabelExpressions {
+//			if len(exp.Values) > 1 {
+//				return nil, errors.New("found multiple regions or zones. One zone/region is allowed  ")
+//			}
+//
+//			topologies[exp.Key] =
+//		}
+//	}
+//}

--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"embed"
 	"html/template"
+	"k8c.io/machine-controller/pkg/cloudprovider/provider/kubevirt/types"
 	"path"
 	"reflect"
 	"testing"
@@ -68,6 +69,7 @@ type kubevirtProviderSpecConf struct {
 	OsImageSource            imageSource
 	OsImageSourceURL         string
 	PullMethod               cdiv1beta1.RegistryPullMethod
+	Location                 *types.Location
 }
 
 func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
@@ -101,6 +103,12 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 		},
 		{{- end }}
 		"virtualMachine": {
+            {{- if .Location }}
+            "location": {
+               "zone": "{{ .Location.Zone }}",
+               "region": "{{ .Location.Region }}"
+            },
+            {{- end }}
 			{{- if .Instancetype }}
 			"instancetype": {
 				"name": "{{ .Instancetype.Name }}",
@@ -199,6 +207,15 @@ func TestNewVirtualMachine(t *testing.T) {
 				Preference: &kubevirtv1.PreferenceMatcher{
 					Name: "custom-pref",
 					Kind: "VirtualMachineClusterPreference",
+				},
+			},
+		},
+		{
+			name: "location-zone-and-region-aware",
+			specConf: kubevirtProviderSpecConf{
+				Location: &types.Location{
+					Region: "europe-central",
+					Zone:   "hh",
 				},
 			},
 		},

--- a/pkg/cloudprovider/provider/kubevirt/testdata/location-zone-and-region-aware.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/location-zone-and-region-aware.yaml
@@ -1,0 +1,83 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  labels:
+    cluster.x-k8s.io/cluster-name: cluster-name
+    cluster.x-k8s.io/role: worker
+    kubevirt.io/vm: location-zone-and-region-aware
+    topology.kubernetes.io/region: europe-central
+    topology.kubernetes.io/zone: hh
+    md: md-name
+  name: location-zone-and-region-aware
+  namespace: test-namespace
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: location-zone-and-region-aware
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+          storageClassName: longhorn
+        source:
+          http:
+            url: http://x.y.z.t/ubuntu.img
+  runStrategy: Once
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        "ovn.kubernetes.io/allow_live_migration": "true"
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
+      labels:
+        cluster.x-k8s.io/cluster-name: cluster-name
+        cluster.x-k8s.io/role: worker
+        kubevirt.io/vm: location-zone-and-region-aware
+        md: md-name
+        topology.kubernetes.io/region: europe-central
+        topology.kubernetes.io/zone: hh
+    spec:
+      affinity: {}
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: datavolumedisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              bridge: {}
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 30
+      topologyspreadconstraints:
+        - maxskew: 1
+          topologykey: kubernetes.io/hostname
+          whenunsatisfiable: ScheduleAnyway
+          labelselector:
+            matchlabels:
+              md: md-name
+      volumes:
+        - dataVolume:
+            name: location-zone-and-region-aware
+          name: datavolumedisk
+        - cloudInitNoCloud:
+            secretRef:
+              name: udsn
+          name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -57,6 +57,7 @@ type VirtualMachine struct {
 	Template   Template                            `json:"template,omitempty"`
 	DNSPolicy  providerconfigtypes.ConfigVarString `json:"dnsPolicy,omitempty"`
 	DNSConfig  *corev1.PodDNSConfig                `json:"dnsConfig,omitempty"`
+	Location   *Location                           `json:"location,omitempty"`
 }
 
 // Flavor.
@@ -123,6 +124,12 @@ type TopologySpreadConstraint struct {
 	// WhenUnsatisfiable indicates how to deal with a VM if it doesn't satisfy
 	// the spread constraint.
 	WhenUnsatisfiable providerconfigtypes.ConfigVarString `json:"whenUnsatisfiable,omitempty"`
+}
+
+// Location describes the region and zone where the machines are created at and where the deployed resources will reside.
+type Location struct {
+	Region string `json:"region,omitempty"`
+	Zone   string `json:"zone,omitempty"`
 }
 
 func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Support for the two labels `topology.kubernetes.io/region` and `topology.kubernetes.io/zone` labels where they can deployed on both Node level(The kubelet or the external cloud-controller-manager populates this with the information from the cloud provider) and on PVC level(topology-aware volume provisioners will automatically set node affinity constraints on a PersistentVolume.). 

A zone represents a logical failure domain. It is common for Kubernetes clusters to span multiple zones for increased availability and a region represents a larger domain, made up of one or more zones. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
region and zone aware labels support
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
