### PR TITLE
Support KubeVirt Provider Network

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -113,6 +113,11 @@ type Config struct {
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint
 	Region                    string
 	Zone                      string
+
+	ProviderNetworkName string
+	SubnetName          string
+	SubnetCIDRBlock     string
+	SubnetGatewayIP     string
 }
 
 // StorageTarget represents targeted storage definition that will be used to provision VirtualMachine volumes. Currently,
@@ -341,6 +346,15 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	if rawConfig.VirtualMachine.Location != nil {
 		config.Zone = rawConfig.VirtualMachine.Location.Zone
 		config.Region = rawConfig.VirtualMachine.Location.Region
+	}
+
+	if rawConfig.VirtualMachine.ProviderNetwork != nil {
+		config.ProviderNetworkName = rawConfig.VirtualMachine.ProviderNetwork.Name
+		if rawConfig.VirtualMachine.ProviderNetwork.Subnet != nil {
+			config.SubnetName = rawConfig.VirtualMachine.ProviderNetwork.Subnet.Name
+			config.SubnetCIDRBlock = rawConfig.VirtualMachine.ProviderNetwork.Subnet.CIDRBlock
+			config.SubnetGatewayIP = rawConfig.VirtualMachine.ProviderNetwork.Subnet.GatewayIP
+		}
 	}
 
 	return &config, pconfig, nil
@@ -686,8 +700,11 @@ func (p *provider) newVirtualMachine(c *Config, pc *providerconfigtypes.Config, 
 		annotations["kubevirt.io/ignitiondata"] = userdata
 	}
 
-	annotations["ovn.kubernetes.io/allow_live_migration"] = "true"
 	annotations["kubevirt.io/allow-pod-bridge-network-live-migration"] = "true"
+
+	if c.ProviderNetworkName == "KubeOVN" {
+		setOVNAnnotations(c, annotations)
+	}
 
 	for k, v := range machine.Annotations {
 		if strings.HasPrefix(k, "cdi.kubevirt.io") {
@@ -1041,4 +1058,20 @@ func getStorageTopologies(ctx context.Context, storageClasName string, c *Config
 	}
 
 	return nil
+}
+
+func setOVNAnnotations(c *Config, annotations map[string]string) {
+	annotations["ovn.kubernetes.io/allow_live_migration"] = "true"
+
+	if c.SubnetName != "" {
+		annotations["ovn.kubernetes.io/logical_switch"] = c.SubnetName
+	}
+
+	if c.SubnetGatewayIP != "" {
+		annotations["ovn.kubernetes.io/routes"] = fmt.Sprintf(`|
+  [{
+    "gw": "%s"
+  }]
+`, c.SubnetGatewayIP)
+	}
 }

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -350,10 +350,10 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 
 	if rawConfig.VirtualMachine.ProviderNetwork != nil {
 		config.ProviderNetworkName = rawConfig.VirtualMachine.ProviderNetwork.Name
-		if rawConfig.VirtualMachine.ProviderNetwork.Subnet != nil {
-			config.SubnetName = rawConfig.VirtualMachine.ProviderNetwork.Subnet.Name
-			config.SubnetCIDRBlock = rawConfig.VirtualMachine.ProviderNetwork.Subnet.CIDRBlock
-			config.SubnetGatewayIP = rawConfig.VirtualMachine.ProviderNetwork.Subnet.GatewayIP
+		if rawConfig.VirtualMachine.ProviderNetwork.VPC.Subnet != nil {
+			config.SubnetName = rawConfig.VirtualMachine.ProviderNetwork.VPC.Subnet.Name
+			config.SubnetCIDRBlock = rawConfig.VirtualMachine.ProviderNetwork.VPC.Subnet.CIDRBlock
+			config.SubnetGatewayIP = rawConfig.VirtualMachine.ProviderNetwork.VPC.Subnet.GatewayIP
 		}
 	}
 

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
@@ -29,7 +29,6 @@ spec:
   template:
     metadata:
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
@@ -29,7 +29,6 @@ spec:
   template:
     metadata:
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
@@ -30,7 +30,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
@@ -29,7 +29,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         kubevirt.io/vm: http-image-source

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
@@ -35,7 +35,6 @@ spec:
   template:
     metadata:
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
@@ -35,7 +35,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/kubeovn-provider-network.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/kubeovn-provider-network.yaml
@@ -1,0 +1,81 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  labels:
+    cluster.x-k8s.io/cluster-name: cluster-name
+    cluster.x-k8s.io/role: worker
+    kubevirt.io/vm: kubeovn-provider-network
+    md: md-name
+  name: kubeovn-provider-network
+  namespace: test-namespace
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: kubeovn-provider-network
+      spec:
+        pvc:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+          storageClassName: longhorn
+        source:
+          http:
+            url: http://x.y.z.t/ubuntu.img
+  runStrategy: Once
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        ovn.kubernetes.io/allow_live_migration: "true"
+        ovn.kubernetes.io/logical_switch: test-subnet
+        ovn.kubernetes.io/routes: '[{"gw":"10.10.0.1"}]'
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
+      labels:
+        cluster.x-k8s.io/cluster-name: cluster-name
+        cluster.x-k8s.io/role: worker
+        kubevirt.io/vm: kubeovn-provider-network
+        md: md-name
+    spec:
+      affinity: {}
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: datavolumedisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              bridge: {}
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 30
+      topologyspreadconstraints:
+        - maxskew: 1
+          topologykey: kubernetes.io/hostname
+          whenunsatisfiable: ScheduleAnyway
+          labelselector:
+            matchlabels:
+              md: md-name
+      volumes:
+        - dataVolume:
+            name: kubeovn-provider-network
+          name: datavolumedisk
+        - cloudInitNoCloud:
+            secretRef:
+              name: udsn
+          name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
@@ -29,7 +29,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
@@ -30,7 +30,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         kubevirt.io/vm: pvc-image-source

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
@@ -30,7 +30,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         kubevirt.io/vm: registry-image-source-pod

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
@@ -30,7 +30,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         kubevirt.io/vm: registry-image-source

--- a/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
@@ -55,7 +55,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
@@ -29,7 +29,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
@@ -30,7 +30,6 @@ spec:
     metadata:
       creationTimestamp: null
       annotations:
-        "ovn.kubernetes.io/allow_live_migration": "true"
         "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
       labels:
         cluster.x-k8s.io/cluster-name: cluster-name

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -135,7 +135,14 @@ type Location struct {
 
 // ProviderNetwork describes the infra cluster network fabric that is being used.
 type ProviderNetwork struct {
-	Name   string  `json:"name,omitempty"`
+	Name string `json:"name"`
+	VPC  VPC    `json:"vpc"`
+}
+
+// VPC  is a virtual network dedicated to a single tenant within a KubeVirt, where the resources in the VPC
+// is isolated from any other resources within the KubeVirt infra cluster.
+type VPC struct {
+	Name   string  `json:"name"`
 	Subnet *Subnet `json:"subnet,omitempty"`
 }
 

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -53,11 +53,12 @@ type VirtualMachine struct {
 	// Instancetype is optional.
 	Instancetype *kubevirtv1.InstancetypeMatcher `json:"instancetype,omitempty"`
 	// Preference is optional.
-	Preference *kubevirtv1.PreferenceMatcher       `json:"preference,omitempty"`
-	Template   Template                            `json:"template,omitempty"`
-	DNSPolicy  providerconfigtypes.ConfigVarString `json:"dnsPolicy,omitempty"`
-	DNSConfig  *corev1.PodDNSConfig                `json:"dnsConfig,omitempty"`
-	Location   *Location                           `json:"location,omitempty"`
+	Preference      *kubevirtv1.PreferenceMatcher       `json:"preference,omitempty"`
+	Template        Template                            `json:"template,omitempty"`
+	DNSPolicy       providerconfigtypes.ConfigVarString `json:"dnsPolicy,omitempty"`
+	DNSConfig       *corev1.PodDNSConfig                `json:"dnsConfig,omitempty"`
+	Location        *Location                           `json:"location,omitempty"`
+	ProviderNetwork *ProviderNetwork                    `json:"providerNetwork,omitempty"`
 }
 
 // Flavor.
@@ -130,6 +131,19 @@ type TopologySpreadConstraint struct {
 type Location struct {
 	Region string `json:"region,omitempty"`
 	Zone   string `json:"zone,omitempty"`
+}
+
+// ProviderNetwork describes the infra cluster network fabric that is being used.
+type ProviderNetwork struct {
+	Name   string  `json:"name,omitempty"`
+	Subnet *Subnet `json:"subnet,omitempty"`
+}
+
+// Subnet a smaller, segmented portion of a larger network, like a Virtual Private Cloud (VPC).
+type Subnet struct {
+	Name      string `json:"name"`
+	CIDRBlock string `json:"cidrBlock"`
+	GatewayIP string `json:"gatewayIP,omitempty"`
 }
 
 func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
KubeOvn has some features that can be used along side with KubeVirt. One of those features is subnet and vpc support. This PR supports the KubeOVN VPC and Subnet as a provider network in KubeVirt.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support KubeOVN as a provider network in KubeVirt
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
