### PR TITLE
Fix: Add reboot action and fix decode cloud-init bug 

### DIFF
--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
@@ -67,7 +67,7 @@ func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, templateR
 			HardwareRef: hardware.GetName(),
 			HardwareMap: map[string]string{
 				"device_1":          hardware.GetMACAddress(),
-				"dst_path":          fmt.Sprintf("/tmp/%s-bootstrap-config", hardware.Name),
+				"hardware_name":     hardware.GetName(),
 				"cloud_init_script": base64.StdEncoding.EncodeToString([]byte(userData)),
 				"interface_name":    ifaceConfig.IfaceName,
 				"cidr":              convertNetmaskToCIDR(ifaceConfig.IP),

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
@@ -123,7 +123,7 @@ func (d *driver) ProvisionServer(ctx context.Context, _ *zap.SugaredLogger, meta
 	}
 
 	// Create template if it doesn't exist
-	err = d.TemplateClient.CreateTemplate(ctx, hardware, d.HardwareRef.Namespace, d.OSImageURL)
+	err = d.TemplateClient.CreateTemplate(ctx, d.HardwareRef.Namespace, d.OSImageURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will fix the following issues: 
- Restarting the host automatically in order to boot with new operating system and execute cloud-init scripts 
- The `decode-cloud-init-file` action was hardcoded based on the first reconciled hardware object, we fix it by using placeholder `{{.hardware_name}}` 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
