### PR TITLE
Fix: Configure Cloud-Init Script to execute automatically

### DIFF
--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
@@ -238,7 +238,6 @@ network:
 }
 
 func configureCloudInitAction() Action {
-
 	commands := `mkdir -p /var/lib/cloud/seed/nocloud && chmod 755 /var/lib/cloud/seed/nocloud
 echo 'datasource_list: [ NoCloud ]' > /etc/cloud/cloud.cfg.d/01_ds-identify.cfg
 echo '{{.cloud_init_script}}' > /tmp/{{.hardware_name}}-bootstrap-config


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will fix a tiny bug. After provisioning the baremetal server successfully, the generated cloud-init script require manual interaction to execute correctly 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
