### PR TITLE
Drop support for Kubernetes v1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Currently supported K8S versions are:
 - 1.31
 - 1.30
 - 1.29
-- 1.28
 
 ### Community Providers
 

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -348,7 +348,7 @@ func TestOpenstackProvisioningE2E(t *testing.T) {
 	}
 
 	// In-tree cloud provider is not supported from Kubernetes v1.26.
-	selector := And(Not(OsSelector("amzn2")), Not(VersionSelector("1.28.14", "1.29.9", "1.30.5", "1.31.1")))
+	selector := And(Not(OsSelector("amzn2")), Not(VersionSelector("1.29.9", "1.30.5", "1.31.1")))
 	runScenarios(context.Background(), t, selector, params, OSManifest, fmt.Sprintf("os-%s", *testRunIdentifier))
 }
 
@@ -424,7 +424,7 @@ func TestAWSProvisioningE2E(t *testing.T) {
 	}
 
 	// In-tree cloud provider is not supported from Kubernetes v1.27.
-	selector := Not(VersionSelector("1.28.14", "1.29.9", "1.30.5", "1.31.1"))
+	selector := Not(VersionSelector("1.29.9", "1.30.5", "1.31.1"))
 
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
@@ -478,7 +478,7 @@ func TestAWSSpotInstanceProvisioningE2E(t *testing.T) {
 	}
 	// Since we are only testing the spot instance functionality, testing it against a single OS is sufficient.
 	// In-tree cloud provider is not supported from Kubernetes v1.27.
-	selector := And(OsSelector("ubuntu"), Not(VersionSelector("1.28.14", "1.29.9", "1.30.5", "1.31.1")))
+	selector := And(OsSelector("ubuntu"), Not(VersionSelector("1.29.9", "1.30.5", "1.31.1")))
 
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),
@@ -500,7 +500,7 @@ func TestAWSARMProvisioningE2E(t *testing.T) {
 		t.Fatal("Unable to run the test suite, AWS_E2E_TESTS_KEY_ID or AWS_E2E_TESTS_SECRET environment variables cannot be empty")
 	}
 	// In-tree cloud provider is not supported from Kubernetes v1.27.
-	selector := And(OsSelector("ubuntu"), Not(VersionSelector("1.28.14", "1.29.9", "1.30.5", "1.31.1")))
+	selector := And(OsSelector("ubuntu"), Not(VersionSelector("1.29.9", "1.30.5", "1.31.1")))
 
 	// act
 	params := []string{fmt.Sprintf("<< AWS_ACCESS_KEY_ID >>=%s", awsKeyID),

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -34,7 +34,6 @@ var (
 	scenarios = buildScenarios()
 
 	versions = []*semver.Version{
-		semver.MustParse("v1.28.14"),
 		semver.MustParse("v1.29.9"),
 		semver.MustParse("v1.30.5"),
 		semver.MustParse("v1.31.1"),


### PR DESCRIPTION
**What this PR does / why we need it**:
Active support for Kubernetes v1.28 is over and maintenance support ends on 28 Oct 2024. 

https://endoflife.date/kubernetes

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for Kubernetes v1.28 has been removed
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
