### PR TITLE
Refactor kubervirt provider storage

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -353,8 +353,8 @@ func (p *provider) getStorageAccessType(ctx context.Context, accessType provider
 		// choose RWO as a default access mode and if RWX is supported then choose it instead.
 		accessMode := corev1.ReadWriteOnce
 		for _, claimProperty := range sp.Status.ClaimPropertySets {
-			for _, accessMode := range claimProperty.AccessModes {
-				if accessMode == corev1.ReadWriteMany {
+			for _, am := range claimProperty.AccessModes {
+				if am == corev1.ReadWriteMany {
 					accessMode = corev1.ReadWriteMany
 				}
 			}

--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -132,11 +132,14 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 				{{- if .SecondaryDisks }}
 				"secondaryDisks": [{
 					"size": "20Gi",
+                    "storageAccessType": "ReadWriteMany",
 					"storageClassName": "longhorn2"},{
 					"size": "30Gi",
+                    "storageAccessType": "ReadWriteMany",
 					"storageClassName": "longhorn3"}],
 				{{- end }}
 				"primaryDisk": {
+                    "storageAccessType": "ReadWriteMany",
 					{{- if .StorageTarget }}
 					"storageTarget": "{{ .StorageTarget }}",
 					{{- end }}

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
@@ -15,9 +15,9 @@ spec:
         creationTimestamp: null
         name: affinity-no-values
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
@@ -15,9 +15,9 @@ spec:
         creationTimestamp: null
         name: affinity
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: custom-local-disk
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: http-image-source
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
@@ -15,9 +15,9 @@ spec:
         creationTimestamp: null
         name: instancetype-preference-custom
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: instancetype-preference-standard
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/kubeovn-provider-network.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/kubeovn-provider-network.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: kubeovn-provider-network
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi
@@ -24,7 +24,7 @@ spec:
         source:
           http:
             url: http://x.y.z.t/ubuntu.img
-  runStrategy: Once
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null

--- a/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: nominal-case
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: pvc-image-source
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: registry-image-source-pod
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: registry-image-source
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: secondary-disks
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi
@@ -29,7 +29,7 @@ spec:
       spec:
         pvc:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 20Gi
@@ -42,7 +42,7 @@ spec:
       spec:
         pvc:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 30Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
@@ -14,9 +14,9 @@ spec:
     - metadata:
         name: topologyspreadconstraints
       spec:
-        pvc:
+        storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi

--- a/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
@@ -20,7 +20,7 @@ spec:
             url: "http://x.y.z.t/ubuntu.img"
         storage:
           accessModes:
-            - ReadWriteOnce
+            - ReadWriteMany
           resources:
             requests:
               storage: 10Gi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR set the default kuebvirt storage target from PVC to Storage in order to leverage multiple CSI drivers in the infra cluster instead if using k8s PVC setting which might lead to different issues, such as access mode, volume binding mode, etc... In addition to that, it can read and set the volume access mode to the data volume spec based on the CDI storage profile. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
Tested manually and worked as expected.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support `dataVolumeTemplateSpec.dataVolumeSpec.Storage` and configure DataVolume based onn CDI StorageProfile
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
