### PR TITLE
Added the multuqueue spec to network interfaces

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -744,8 +744,9 @@ func (p *provider) newVirtualMachine(c *Config, pc *providerconfigtypes.Config, 
 					},
 					Domain: kubevirtv1.DomainSpec{
 						Devices: kubevirtv1.Devices{
-							Interfaces: []kubevirtv1.Interface{*defaultBridgeNetwork},
-							Disks:      getVMDisks(c),
+							Interfaces:      []kubevirtv1.Interface{*defaultBridgeNetwork},
+							Disks:           getVMDisks(c),
+							BlockMultiQueue: pointerToBool(true),
 						},
 						Resources: resourceRequirements,
 					},
@@ -761,6 +762,10 @@ func (p *provider) newVirtualMachine(c *Config, pc *providerconfigtypes.Config, 
 		},
 	}
 	return virtualMachine, nil
+}
+
+func pointerToBool(b bool) *bool {
+	return &b
 }
 
 func (p *provider) Cleanup(ctx context.Context, _ *zap.SugaredLogger, machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables multiqueing for kubevirt VM network interfaces . 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```
