### PR TITLE
Support VM Network Multi-Queue in KubeVirt Provider

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity-no-values.yaml
@@ -56,6 +56,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/affinity.yaml
@@ -59,6 +59,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/custom-local-disk.yaml
@@ -51,6 +51,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/http-image-source.yaml
@@ -50,6 +50,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-custom.yaml
@@ -56,6 +56,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
       networks:
         - name: default
           pod: {}

--- a/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/instancetype-preference-standard.yaml
@@ -56,6 +56,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
       networks:
         - name: default
           pod: {}

--- a/pkg/cloudprovider/provider/kubevirt/testdata/kubeovn-provider-network.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/kubeovn-provider-network.yaml
@@ -51,6 +51,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/nominal-case.yaml
@@ -50,6 +50,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/pvc-image-source.yaml
@@ -51,6 +51,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source-pod.yaml
@@ -51,6 +51,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/registry-image-source.yaml
@@ -51,6 +51,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/secondary-disks.yaml
@@ -82,6 +82,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/topologyspreadconstraints.yaml
@@ -50,6 +50,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/use-storage-as-storage-target.yaml
@@ -51,6 +51,7 @@ spec:
           interfaces:
             - name: default
               bridge: {}
+          networkInterfaceMultiqueue: true
         resources:
           limits:
             cpu: "2"

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -53,12 +53,13 @@ type VirtualMachine struct {
 	// Instancetype is optional.
 	Instancetype *kubevirtv1.InstancetypeMatcher `json:"instancetype,omitempty"`
 	// Preference is optional.
-	Preference      *kubevirtv1.PreferenceMatcher       `json:"preference,omitempty"`
-	Template        Template                            `json:"template,omitempty"`
-	DNSPolicy       providerconfigtypes.ConfigVarString `json:"dnsPolicy,omitempty"`
-	DNSConfig       *corev1.PodDNSConfig                `json:"dnsConfig,omitempty"`
-	Location        *Location                           `json:"location,omitempty"`
-	ProviderNetwork *ProviderNetwork                    `json:"providerNetwork,omitempty"`
+	Preference              *kubevirtv1.PreferenceMatcher       `json:"preference,omitempty"`
+	Template                Template                            `json:"template,omitempty"`
+	DNSPolicy               providerconfigtypes.ConfigVarString `json:"dnsPolicy,omitempty"`
+	DNSConfig               *corev1.PodDNSConfig                `json:"dnsConfig,omitempty"`
+	Location                *Location                           `json:"location,omitempty"`
+	ProviderNetwork         *ProviderNetwork                    `json:"providerNetwork,omitempty"`
+	EnableNetworkMultiQueue providerconfigtypes.ConfigVarBool   `json:"enableNetworkMultiQueue,omitempty"`
 }
 
 // Flavor.


### PR DESCRIPTION
**What this PR does / why we need it**:
As the title reads, support and default to true for the KubeVirt VM Network Multi-Queue.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
support network multi queue in KubeVirt VM
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
none
```
