### PR TITLE
Support Importing Volume Over HTTP Using Basic Auth

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"embed"
 	"html/template"
-	"k8c.io/machine-controller/pkg/cloudprovider/provider/kubevirt/types"
 	"path"
 	"reflect"
 	"testing"
@@ -29,6 +28,7 @@ import (
 	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	"k8c.io/machine-controller/pkg/cloudprovider/provider/kubevirt/types"
 	cloudprovidertesting "k8c.io/machine-controller/pkg/cloudprovider/testing"
 	"k8c.io/machine-controller/pkg/providerconfig"
 
@@ -70,6 +70,7 @@ type kubevirtProviderSpecConf struct {
 	OsImageSourceURL         string
 	PullMethod               cdiv1beta1.RegistryPullMethod
 	ProviderNetwork          *types.ProviderNetwork
+	ExtraHeadersSet          bool
 }
 
 func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
@@ -139,6 +140,9 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 					"storageClassName": "longhorn3"}],
 				{{- end }}
 				"primaryDisk": {
+                    {{- if .ExtraHeadersSet }}
+                    "extraHeaders": ["authorization: Basic bXE6cGFzc3dvcmQ="],
+                    {{- end }}
                     "storageAccessType": "ReadWriteMany",
 					{{- if .StorageTarget }}
 					"storageTarget": "{{ .StorageTarget }}",
@@ -191,6 +195,12 @@ func TestNewVirtualMachine(t *testing.T) {
 		{
 			name:     "nominal-case",
 			specConf: kubevirtProviderSpecConf{},
+		},
+		{
+			name: "extra-headers-set",
+			specConf: kubevirtProviderSpecConf{
+				ExtraHeadersSet: true,
+			},
 		},
 		{
 			name: "instancetype-preference-standard",

--- a/pkg/cloudprovider/provider/kubevirt/testdata/extra-headers-set.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/extra-headers-set.yaml
@@ -1,0 +1,82 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  labels:
+    cluster.x-k8s.io/cluster-name: cluster-name
+    cluster.x-k8s.io/role: worker
+    kubevirt.io/vm: extra-headers-set
+    md: md-name
+  name: extra-headers-set
+  namespace: test-namespace
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: extra-headers-set
+      spec:
+        storage:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 10Gi
+          storageClassName: longhorn
+        source:
+          http:
+            url: http://x.y.z.t/ubuntu.img
+            extraHeaders:
+              - 'authorization: Basic bXE6cGFzc3dvcmQ='
+  runStrategy: Once
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
+        "ovn.kubernetes.io/allow_live_migration": "true"
+      labels:
+        cluster.x-k8s.io/cluster-name: cluster-name
+        cluster.x-k8s.io/role: worker
+        kubevirt.io/vm: extra-headers-set
+        md: md-name
+    spec:
+      affinity: {}
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: datavolumedisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              bridge: {}
+          networkInterfaceMultiqueue: true
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 30
+      topologyspreadconstraints:
+        - maxskew: 1
+          topologykey: kubernetes.io/hostname
+          whenunsatisfiable: ScheduleAnyway
+          labelselector:
+            matchlabels:
+              md: md-name
+      volumes:
+        - dataVolume:
+            name: extra-headers-set
+          name: datavolumedisk
+        - cloudInitNoCloud:
+            secretRef:
+              name: udsn
+          name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -79,6 +79,12 @@ type Template struct {
 // PrimaryDisk.
 type PrimaryDisk struct {
 	Disk
+	// ExtraHeaders is a list of strings containing extra headers to include with HTTP transfer requests
+	// +optional
+	ExtraHeaders []string `json:"extraHeaders,omitempty"`
+	// ExtraHeadersSecretRef is a secret that contains a list of strings containing extra headers to include with HTTP transfer requests
+	// +optional
+	ExtraHeadersSecretRef providerconfigtypes.ConfigVarString `json:"extraHeadersSecretRef,omitempty"`
 	// StorageTarget describes which VirtualMachine storage target will be used in the DataVolumeTemplate.
 	StorageTarget providerconfigtypes.ConfigVarString `json:"storageTarget,omitempty"`
 	// OsImage describes the OS that will be installed on the VirtualMachine.


### PR DESCRIPTION
**What this PR does / why we need it**:
One way to import a a virtual machine disk, is via an http endpoint that holds a raw image. So far this method didn't support basic auth to interact with the image repo server that holds these raw images. This PR supports sending the basic auth as a header in the CDI DataVolume object by reading the headers either explicitly from the Machine Deployment spec or referring to  a secret that contains those headers.

`ExtraHeaders` field in the MachineDeployment spec is used to read those headers explicitly and send them as part of the importing request.

`ExtraHeadersFromSecret` is used to read those headers from a secret that is being referenced in the MachineDeployment object.

**Which issue(s) this PR fixes**:
/kind feature
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
This PR has been tested manually and it succeeded.
**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support `ExtraHeaders  in the KubeVirt Provider 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
