### PR TITLE
Support KubeVirt CDI Datavolume Secret Ref

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -78,6 +78,8 @@ type Template struct {
 // PrimaryDisk.
 type PrimaryDisk struct {
 	Disk
+	// DataVolumeSecretRef is the name of the secret that will be sent to the CDI data importer pod to read basic auth parameters.
+	DataVolumeSecretRef providerconfigtypes.ConfigVarString `json:"dataVolumeSecretRef,omitempty"`
 	// ExtraHeaders is a list of strings containing extra headers to include with HTTP transfer requests
 	// +optional
 	ExtraHeaders []string `json:"extraHeaders,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Support sending the Basic Auth information to the data volume importing process using CDI secret ref.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt CDI Datavolume Secret Ref Support
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
