### PR TITLE
Fix decode kubeconfig from envar

### DIFF
--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
@@ -185,7 +185,14 @@ func GetConfig(driverConfig tinktypes.TinkerbellPluginSpec, valueFromStringOrEnv
 		if err != nil {
 			return nil, fmt.Errorf(`failed to get value of "kubeconfig" field: %w`, err)
 		}
+		val, err := base64.StdEncoding.DecodeString(config.Kubeconfig)
+		// We intentionally ignore errors here with an assumption that an unencoded YAML or JSON must have been passed on
+		// in this case.
+		if err == nil {
+			config.Kubeconfig = string(val)
+		}
 	}
+
 	config.ClusterName, err = valueFromStringOrEnvVar(driverConfig.ClusterName, "CLUSTER_NAME")
 	if err != nil {
 		return nil, fmt.Errorf(`failed to get value of "clusterName" field: %w`, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will fix the decode fail when we use kubeconfig from envar. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix decoding kubeconfig from the variable environment in the Tinkerbell provider.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
