### PR TITLE
Add partition number annotation

### DIFF
--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
@@ -60,6 +60,7 @@ const (
 	hardwareDisk1               = "{{ index .Hardware.Disks 0 }}"
 	hardwareName                = "{{.hardware_name}}"
 	ProvisionWorkerNodeTemplate = "provision-worker-node"
+	PartitionNumber             = "{{.partition_number}}"
 )
 
 // TemplateClient handles interactions with the Tinkerbell Templates in the Tinkerbell cluster.
@@ -195,11 +196,11 @@ func createGrowPartitionAction(destDisk string) Action {
 		Image:   "quay.io/tinkerbell/actions/cexec:c5bde803d9f6c90f1a9d5e06930d856d1481854c",
 		Timeout: 90,
 		Environment: map[string]string{
-			"BLOCK_DEVICE":        "{{ index .Hardware.Disks 0 }}3",
+			"BLOCK_DEVICE":        fmt.Sprintf("{{ index .Hardware.Disks 0 }}%s", PartitionNumber),
 			"FS_TYPE":             fsType,
 			"CHROOT":              "y",
 			"DEFAULT_INTERPRETER": defaultInterpreter,
-			"CMD_LINE":            fmt.Sprintf("growpart %s 3 && resize2fs %s3", destDisk, destDisk),
+			"CMD_LINE":            fmt.Sprintf("growpart %s %s && resize2fs %s%s", destDisk, PartitionNumber, destDisk, PartitionNumber),
 		},
 	}
 }
@@ -225,7 +226,7 @@ network:
 		Image:   "quay.io/tinkerbell-actions/writefile:v1.0.0",
 		Timeout: 90,
 		Environment: map[string]string{
-			"DEST_DISK": "{{ index .Hardware.Disks 0 }}3",
+			"DEST_DISK": fmt.Sprintf("{{ index .Hardware.Disks 0 }}%s", PartitionNumber),
 			"FS_TYPE":   fsType,
 			"DEST_PATH": "/etc/netplan/config.yaml",
 			"CONTENTS":  netplaneConfig,
@@ -250,7 +251,7 @@ echo 'local-hostname: {{.hardware_name}}' >> /var/lib/cloud/seed/nocloud/meta-da
 		Image:   "quay.io/tinkerbell-actions/cexec:v1.0.0",
 		Timeout: 90,
 		Environment: map[string]string{
-			"BLOCK_DEVICE":        "{{ index .Hardware.Disks 0 }}3",
+			"BLOCK_DEVICE":        fmt.Sprintf("{{ index .Hardware.Disks 0 }}%s", PartitionNumber),
 			"FS_TYPE":             fsType,
 			"CHROOT":              "y",
 			"DEFAULT_INTERPRETER": defaultInterpreter,
@@ -265,7 +266,7 @@ func decodeCloudInitFile(hardwareName string) Action {
 		Image:   "quay.io/tinkerbell/actions/cexec:latest",
 		Timeout: 90,
 		Environment: map[string]string{
-			"BLOCK_DEVICE":        "{{ index .Hardware.Disks 0 }}3",
+			"BLOCK_DEVICE":        fmt.Sprintf("{{ index .Hardware.Disks 0 }}%s", PartitionNumber),
 			"FS_TYPE":             fsType,
 			"CHROOT":              "y",
 			"DEFAULT_INTERPRETER": "/bin/sh -c",

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
@@ -34,7 +34,7 @@ import (
 // DefaultPartitionNumber defines the default value for the "partition_number" field.
 const DefaultPartitionNumber = "3"
 
-// PartitionNumberAnnotation is used to specify the main partition number of the disk device
+// PartitionNumberAnnotation is used to specify the main partition number of the disk device.
 const PartitionNumberAnnotation = "hardware.kubermatic.io/partition-number"
 
 // WorkflowClient handles interactions with the Tinkerbell Workflows.

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
@@ -31,6 +31,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// DefaultPartitionNumber defines the default value for the "partition_number" field.
+const DefaultPartitionNumber = "3"
+
+// PartitionNumberAnnotation is used to specify the main partition number of the disk device
+const PartitionNumberAnnotation = "hardware.kubermatic.io/partition-number"
+
 // WorkflowClient handles interactions with the Tinkerbell Workflows.
 type WorkflowClient struct {
 	tinkclient client.Client
@@ -73,6 +79,7 @@ func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, templateR
 				"cidr":              convertNetmaskToCIDR(ifaceConfig.IP),
 				"ns":                dnsNameservers,
 				"default_route":     ifaceConfig.IP.Gateway,
+				"partition_number":  w.getPartitionNumber(hardware),
 			},
 		},
 	}
@@ -123,4 +130,12 @@ func (w *WorkflowClient) CleanupWorkflows(ctx context.Context, hardwareName, nam
 	}
 
 	return nil
+}
+
+func (w *WorkflowClient) getPartitionNumber(hardware tink.Hardware) string {
+	partitionNumber, exists := hardware.Annotations[PartitionNumberAnnotation]
+	if !exists {
+		partitionNumber = DefaultPartitionNumber // Use the default value
+	}
+	return partitionNumber
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for specifying the main partition number for OS installation in bare-metal servers via the 
`hardware.kubermatic.io/partition-number` annotation in Tinkerbell Hardware Objects.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support added for specifying the main OS partition number in baremetal provider machines using the `hardware.kubermatic.io/partition-number` annotation.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
