### PR TITLE
baremetal: Templating OSImage links through Tinkerbell workflow objects

### DIFF
--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
@@ -61,6 +61,7 @@ const (
 	hardwareName                = "{{.hardware_name}}"
 	ProvisionWorkerNodeTemplate = "provision-worker-node"
 	PartitionNumber             = "{{.partition_number}}"
+	OSImageURL                  = "{{.os_image}}"
 )
 
 // TemplateClient handles interactions with the Tinkerbell Templates in the Tinkerbell cluster.
@@ -91,14 +92,14 @@ func (t *TemplateClient) Delete(ctx context.Context, namespacedName types.Namesp
 }
 
 // CreateTemplate creates a Tinkerbell Template in the Kubernetes cluster.
-func (t *TemplateClient) CreateTemplate(ctx context.Context, namespace, osImageURL string) error {
+func (t *TemplateClient) CreateTemplate(ctx context.Context, namespace string) error {
 	template := &tinkv1alpha1.Template{}
 	if err := t.tinkclient.Get(ctx, types.NamespacedName{
 		Name:      ProvisionWorkerNodeTemplate,
 		Namespace: namespace,
 	}, template); err != nil {
 		if kerrors.IsNotFound(err) {
-			data, err := getTemplate(osImageURL)
+			data, err := getTemplate(OSImageURL)
 			if err != nil {
 				return err
 			}

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
@@ -50,7 +50,7 @@ func NewWorkflowClient(k8sClient client.Client) *WorkflowClient {
 }
 
 // CreateWorkflow creates a new Tinkerbell Workflow resource in the cluster.
-func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, templateRef string, hardware tink.Hardware) error {
+func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, templateRef, OSImageURL string, hardware tink.Hardware) error {
 	// Construct the Workflow object
 	ifaceConfig := hardware.Spec.Interfaces[0].DHCP
 	dnsNameservers := "1.1.1.1"
@@ -80,6 +80,7 @@ func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, templateR
 				"ns":                dnsNameservers,
 				"default_route":     ifaceConfig.IP.Gateway,
 				"partition_number":  w.getPartitionNumber(hardware),
+				"os_image":          OSImageURL,
 			},
 		},
 	}

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/workflow.go
@@ -50,7 +50,7 @@ func NewWorkflowClient(k8sClient client.Client) *WorkflowClient {
 }
 
 // CreateWorkflow creates a new Tinkerbell Workflow resource in the cluster.
-func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, templateRef, OSImageURL string, hardware tink.Hardware) error {
+func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, templateRef, osImageURL string, hardware tink.Hardware) error {
 	// Construct the Workflow object
 	ifaceConfig := hardware.Spec.Interfaces[0].DHCP
 	dnsNameservers := "1.1.1.1"
@@ -80,7 +80,7 @@ func (w *WorkflowClient) CreateWorkflow(ctx context.Context, userData, templateR
 				"ns":                dnsNameservers,
 				"default_route":     ifaceConfig.IP.Gateway,
 				"partition_number":  w.getPartitionNumber(hardware),
-				"os_image":          OSImageURL,
+				"os_image":          osImageURL,
 			},
 		},
 	}

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/driver.go
@@ -123,14 +123,14 @@ func (d *driver) ProvisionServer(ctx context.Context, _ *zap.SugaredLogger, meta
 	}
 
 	// Create template if it doesn't exist
-	err = d.TemplateClient.CreateTemplate(ctx, d.HardwareRef.Namespace, d.OSImageURL)
+	err = d.TemplateClient.CreateTemplate(ctx, d.HardwareRef.Namespace)
 	if err != nil {
 		return nil, err
 	}
 
 	// Create Workflow to match the template and server
 	server := tinktypes.Hardware{Hardware: hardware}
-	if err = d.WorkflowClient.CreateWorkflow(ctx, userdata, client.ProvisionWorkerNodeTemplate, server); err != nil {
+	if err = d.WorkflowClient.CreateWorkflow(ctx, userdata, client.ProvisionWorkerNodeTemplate, d.OSImageURL, server); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable OSImageURL templating in workflows to support different OS images for each hardware server, as machine-controller creates templates only once.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
