### PR TITLE
Support kubevirt evection strategy in kv provider

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -640,6 +640,13 @@ func (p *provider) Validate(ctx context.Context, _ *zap.SugaredLogger, spec clus
 		return fmt.Errorf("failed to request VirtualMachineInstances: %w", err)
 	}
 
+	if c.EvictionStrategy != "" {
+		if c.EvictionStrategy != kubevirtv1.EvictionStrategyExternal &&
+			c.EvictionStrategy != kubevirtv1.EvictionStrategyLiveMigrate {
+			return fmt.Errorf("unsupported vm eviction strategy: %s", c.EvictionStrategy)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -117,6 +117,7 @@ type Config struct {
 	ExtraHeaders              []string
 	ExtraHeadersSecretRef     string
 	DataVolumeSecretRef       string
+	EvictionStrategy          kubevirtv1.EvictionStrategy
 
 	ProviderNetworkName string
 	SubnetName          string
@@ -364,6 +365,10 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 		if rawConfig.VirtualMachine.ProviderNetwork.VPC.Subnet != nil {
 			config.SubnetName = rawConfig.VirtualMachine.ProviderNetwork.VPC.Subnet.Name
 		}
+	}
+
+	if rawConfig.VirtualMachine.EvictionStrategy != "" {
+		config.EvictionStrategy = kubevirtv1.EvictionStrategy(rawConfig.VirtualMachine.EvictionStrategy)
 	}
 
 	return &config, pconfig, nil
@@ -729,6 +734,9 @@ func (p *provider) newVirtualMachine(c *Config, pc *providerconfigtypes.Config, 
 	terminationGracePeriodSeconds := int64(30)
 
 	evictionStrategy := kubevirtv1.EvictionStrategyExternal
+	if c.EvictionStrategy != "" {
+		evictionStrategy = c.EvictionStrategy
+	}
 
 	resourceRequirements := kubevirtv1.ResourceRequirements{}
 	labels["kubevirt.io/vm"] = machine.Name

--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -71,6 +71,7 @@ type kubevirtProviderSpecConf struct {
 	PullMethod               cdiv1beta1.RegistryPullMethod
 	ProviderNetwork          *types.ProviderNetwork
 	ExtraHeadersSet          bool
+	EvictStrategy            string
 }
 
 func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
@@ -104,6 +105,9 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 		},
 		{{- end }}
 		"virtualMachine": {
+            {{- if .EvictStrategy }}
+            "evictionStrategy": "LiveMigrate",        
+            {{- end }}
             {{- if .ProviderNetwork }}
             "providerNetwork": {
                "name": "kubeovn",
@@ -274,6 +278,10 @@ func TestNewVirtualMachine(t *testing.T) {
 		{
 			name:     "pvc-image-source",
 			specConf: kubevirtProviderSpecConf{OsImageSource: pvcSource, OsImageDV: "ns/dvname"},
+		},
+		{
+			name:     "eviction-strategy-live-migrate",
+			specConf: kubevirtProviderSpecConf{EvictStrategy: "LiveMigrate"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cloudprovider/provider/kubevirt/testdata/eviction-strategy-live-migrate.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/eviction-strategy-live-migrate.yaml
@@ -1,0 +1,80 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  labels:
+    cluster.x-k8s.io/cluster-name: cluster-name
+    cluster.x-k8s.io/role: worker
+    kubevirt.io/vm: eviction-strategy-live-migrate
+    md: md-name
+  name: eviction-strategy-live-migrate
+  namespace: test-namespace
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: eviction-strategy-live-migrate
+      spec:
+        storage:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 10Gi
+          storageClassName: longhorn
+        source:
+          http:
+            url: http://x.y.z.t/ubuntu.img
+  runStrategy: Once
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
+        "ovn.kubernetes.io/allow_live_migration": "true"
+      labels:
+        cluster.x-k8s.io/cluster-name: cluster-name
+        cluster.x-k8s.io/role: worker
+        kubevirt.io/vm: eviction-strategy-live-migrate
+        md: md-name
+    spec:
+      affinity: {}
+      domain:
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: datavolumedisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              bridge: {}
+          networkInterfaceMultiqueue: true
+        resources:
+          limits:
+            cpu: "2"
+            memory: 2Gi
+          requests:
+            cpu: "2"
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 30
+      topologyspreadconstraints:
+        - maxskew: 1
+          topologykey: kubernetes.io/hostname
+          whenunsatisfiable: ScheduleAnyway
+          labelselector:
+            matchlabels:
+              md: md-name
+      volumes:
+        - dataVolume:
+            name: eviction-strategy-live-migrate
+          name: datavolumedisk
+        - cloudInitNoCloud:
+            secretRef:
+              name: udsn
+          name: cloudinitdisk
+      evictionStrategy: LiveMigrate

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -59,6 +59,7 @@ type VirtualMachine struct {
 	Location                *Location                           `json:"location,omitempty"`
 	ProviderNetwork         *ProviderNetwork                    `json:"providerNetwork,omitempty"`
 	EnableNetworkMultiQueue providerconfigtypes.ConfigVarBool   `json:"enableNetworkMultiQueue,omitempty"`
+	EvictionStrategy        string                              `json:"evictionStrategy,omitempty"`
 }
 
 // Flavor.


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the KubeVirt VMs which are created using machine controller have an eviction strategy of `External` . With `EvictionStrategy: External`, kubevirt will create a PDB for the VMI which blocks eviction, and it will also set the `vmi.Status.EvacuationNodeName` on the vmi's status. When a VMI is being evicted, we need a way to have that eviction blocked so the cluster api related controllers can properly drain the k8s node running within the VMI before the VMI is torn down.

However, in some scenarios, users would like to be able to migrate VMs without blocking the migration by machine controller thus we would like to enable the users to decide which eviction strategy they would like to use.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support multiple eviction strategy for KubeVirt VMs
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
