### PR TITLE
Support External Cloud Provider

### DIFF
--- a/pkg/cloudprovider/provider.go
+++ b/pkg/cloudprovider/provider.go
@@ -28,6 +28,7 @@ import (
 	"k8c.io/machine-controller/pkg/cloudprovider/provider/digitalocean"
 	"k8c.io/machine-controller/pkg/cloudprovider/provider/edge"
 	"k8c.io/machine-controller/pkg/cloudprovider/provider/equinixmetal"
+	"k8c.io/machine-controller/pkg/cloudprovider/provider/external"
 	"k8c.io/machine-controller/pkg/cloudprovider/provider/fake"
 	"k8c.io/machine-controller/pkg/cloudprovider/provider/gce"
 	"k8c.io/machine-controller/pkg/cloudprovider/provider/hetzner"
@@ -110,6 +111,9 @@ var (
 		},
 		providerconfigtypes.CloudProviderVMwareCloudDirector: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
 			return vcd.New(cvr)
+		},
+		providerconfigtypes.CloudProviderExternal: func(cvr *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
+			return external.New(cvr)
 		},
 	}
 

--- a/pkg/cloudprovider/provider/external/provider.go
+++ b/pkg/cloudprovider/provider/external/provider.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2025 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package external
+
+import (
+	"context"
+	"go.uber.org/zap"
+
+	clusterv1alpha1 "k8c.io/machine-controller/pkg/apis/cluster/v1alpha1"
+	"k8c.io/machine-controller/pkg/cloudprovider/instance"
+	cloudprovidertypes "k8c.io/machine-controller/pkg/cloudprovider/types"
+	"k8c.io/machine-controller/pkg/providerconfig"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type provider struct{}
+
+type CloudProviderSpec struct {
+}
+
+type CloudProviderInstance struct{}
+
+func (f CloudProviderInstance) Name() string {
+	return ""
+}
+
+func (f CloudProviderInstance) ID() string {
+	return ""
+}
+
+func (f CloudProviderInstance) ProviderID() string {
+	return ""
+}
+
+func (f CloudProviderInstance) Addresses() map[string]corev1.NodeAddressType {
+	return nil
+}
+
+func (f CloudProviderInstance) Status() instance.Status {
+	return instance.StatusUnknown
+}
+
+// New returns an external cloud provider.
+func New(_ *providerconfig.ConfigVarResolver) cloudprovidertypes.Provider {
+	return &provider{}
+}
+
+func (p *provider) AddDefaults(_ *zap.SugaredLogger, spec clusterv1alpha1.MachineSpec) (clusterv1alpha1.MachineSpec, error) {
+	return spec, nil
+}
+
+// Validate returns success or failure based according to its ExternalCloudProviderSpec.
+func (p *provider) Validate(_ context.Context, _ *zap.SugaredLogger, _ clusterv1alpha1.MachineSpec) error {
+	return nil
+}
+
+func (p *provider) Get(_ context.Context, _ *zap.SugaredLogger, _ *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
+	return CloudProviderInstance{}, nil
+}
+
+// Create creates a cloud instance according to the given machine.
+func (p *provider) Create(_ context.Context, _ *zap.SugaredLogger, _ *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, _ string) (instance.Instance, error) {
+	return CloudProviderInstance{}, nil
+}
+
+func (p *provider) Cleanup(_ context.Context, _ *zap.SugaredLogger, _ *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (bool, error) {
+	return true, nil
+}
+
+func (p *provider) MigrateUID(_ context.Context, _ *zap.SugaredLogger, _ *clusterv1alpha1.Machine, _ types.UID) error {
+	return nil
+}
+
+func (p *provider) MachineMetricsLabels(_ *clusterv1alpha1.Machine) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+func (p *provider) SetMetricsForMachines(_ clusterv1alpha1.MachineList) error {
+	return nil
+}

--- a/pkg/providerconfig/types/types.go
+++ b/pkg/providerconfig/types/types.go
@@ -113,6 +113,7 @@ var (
 		CloudProviderBaremetal,
 		CloudProviderVultr,
 		CloudProviderOpenNebula,
+		CloudProviderExternal,
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new provider called external, which takes care of the machine deployment lifecycle from a machine controller point of view. Another external service should be responsible for creating and orchestrating that cloud instance and sync these changes back to the machine object(e.g: adding labels, remove finalizers upon deleting etc...)
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for external cloud providers 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
