### PR TITLE
Change Ubuntu template for Vsphere e2e tests

### DIFF
--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -63,7 +63,7 @@ var (
 		string(providerconfigtypes.OperatingSystemFlatcar):    "kkp-flatcar-3139.2.0",
 		string(providerconfigtypes.OperatingSystemRHEL):       "kkp-rhel-8.6",
 		string(providerconfigtypes.OperatingSystemRockyLinux): "kkp-rockylinux-8",
-		string(providerconfigtypes.OperatingSystemUbuntu):     "kubeone-ubuntu-22.04",
+		string(providerconfigtypes.OperatingSystemUbuntu):     "kkp-ubuntu-24.04",
 	}
 
 	kubevirtImages = map[string]string{

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -63,7 +63,7 @@ var (
 		string(providerconfigtypes.OperatingSystemFlatcar):    "kkp-flatcar-3139.2.0",
 		string(providerconfigtypes.OperatingSystemRHEL):       "kkp-rhel-8.6",
 		string(providerconfigtypes.OperatingSystemRockyLinux): "kkp-rockylinux-8",
-		string(providerconfigtypes.OperatingSystemUbuntu):     "kkp-ubuntu-22.04",
+		string(providerconfigtypes.OperatingSystemUbuntu):     "kubeone-ubuntu-22.04",
 	}
 
 	kubevirtImages = map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR aims to fix the e2e tests for vsphere, specifically the provisioning for Ubuntu.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
