### PR TITLE
fix kubevirt cpu check + update sdk version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0
 	google.golang.org/api v0.197.0
 	gopkg.in/yaml.v3 v3.0.1
-	k8c.io/machine-controller/sdk v0.0.0-00010101000000-000000000000
+	k8c.io/machine-controller/sdk v0.0.0-20250314150330-99a4aa5532ca
 	k8s.io/api v0.31.1
 	k8s.io/apiextensions-apiserver v0.31.1
 	k8s.io/apimachinery v0.31.1

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0
 	google.golang.org/api v0.197.0
 	gopkg.in/yaml.v3 v3.0.1
-	k8c.io/machine-controller/sdk v0.0.0-20250314150330-99a4aa5532ca
+	k8c.io/machine-controller/sdk v0.0.0-00010101000000-000000000000
 	k8s.io/api v0.31.1
 	k8s.io/apiextensions-apiserver v0.31.1
 	k8s.io/apimachinery v0.31.1

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -285,9 +285,11 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 		return nil, nil, fmt.Errorf(`failed to get value of "memory" field: %w`, err)
 	}
 
-	config.Resources, config.VCPUs, err = parseResources(cpus, memory, rawConfig.VirtualMachine.Template.VCPUs)
-	if err != nil {
-		return nil, nil, fmt.Errorf(`failed to configure resource requests and limits and vcpus: %w`, err)
+	if rawConfig.VirtualMachine.Instancetype == nil {
+		config.Resources, config.VCPUs, err = parseResources(cpus, memory, rawConfig.VirtualMachine.Template.VCPUs)
+		if err != nil {
+			return nil, nil, fmt.Errorf(`failed to configure resource requests and limits and vcpus: %w`, err)
+		}
 	}
 
 	config.Namespace = getNamespace()

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -629,11 +629,11 @@ func (p *provider) Validate(ctx context.Context, _ *zap.SugaredLogger, spec clus
 			return fmt.Errorf("no resource requests set for the virtual machine")
 		}
 
-		if c.VCPUs == nil && c.Resources.Cpu() == nil {
+		if c.VCPUs == nil && c.Resources.Cpu().IsZero() {
 			return fmt.Errorf("no CPUs configured. Either vCPUs or CPUs have to be set.")
 		}
 
-		if c.VCPUs != nil && c.Resources.Cpu() != nil {
+		if c.VCPUs != nil && !c.Resources.Cpu().IsZero() {
 			return fmt.Errorf("vCPUs and CPUs cannot be configured at the same time.")
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr fixes the validation of kubevirt virtual machines for dedicated cpus. With the current check the validation will fail when vcpus are configured because `c.Resources.Cpu()`  will never be nil because at least the format is set in the struct. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
