### PR TITLE
Bump Go version to 1.23.7

### DIFF
--- a/.prow/e2e-features.yaml
+++ b/.prow/e2e-features.yaml
@@ -35,7 +35,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -65,7 +65,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -95,7 +95,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -123,7 +123,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -27,7 +27,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - /bin/bash
             - -c
@@ -56,7 +56,7 @@ postsubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/upload-gocache.sh"
           resources:

--- a/.prow/provider-alibaba.yaml
+++ b/.prow/provider-alibaba.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -63,7 +63,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -96,7 +96,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -130,7 +130,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -162,7 +162,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -194,7 +194,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -62,7 +62,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -96,7 +96,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-equinix-metal.yaml
+++ b/.prow/provider-equinix-metal.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -31,7 +31,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-linode.yaml
+++ b/.prow/provider-linode.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -64,7 +64,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-scaleway.yaml
+++ b/.prow/provider-scaleway.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -62,7 +62,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -95,7 +95,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -128,7 +128,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:
@@ -161,7 +161,7 @@ presubmits:
       preset-kubeconfig-ci: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.24-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-kind-0.26-10
           command:
             - "./hack/ci/run-e2e-tests.sh"
           args:

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -22,7 +22,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - make
           args:
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - make
           args:
@@ -66,7 +66,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - make
           args:
@@ -87,7 +87,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - make
           args:
@@ -107,7 +107,7 @@ presubmits:
     path_alias: k8c.io/machine-controller
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - "/usr/local/bin/shfmt"
           args:
@@ -136,7 +136,7 @@ presubmits:
     path_alias: k8c.io/machine-controller
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - "./hack/verify-boilerplate.sh"
           resources:
@@ -156,7 +156,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - ./hack/verify-licenses.sh
           resources:
@@ -173,7 +173,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.23-node-20-4
+        - image: quay.io/kubermatic/build:go-1.23-node-20-10
           command:
             - make
           args:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.23.2
+ARG GO_VERSION=1.23.7
 FROM docker.io/golang:${GO_VERSION} AS builder
 WORKDIR /go/src/k8c.io/machine-controller
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 SHELL = /bin/bash -eu -o pipefail
 
-GO_VERSION ?= 1.23.2
+GO_VERSION ?= 1.23.7
 
 GOOS ?= $(shell go env GOOS)
 

--- a/hack/update-fixtures.sh
+++ b/hack/update-fixtures.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-4 containerize ./hack/update-fixtures.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/update-fixtures.sh
 
 go test ./... -v -update || go test ./...
 

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-4 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.23-node-20-10 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to bump Go version to 1.23.7.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
machine-controller is now built using Go 1.23.7
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
