### PR TITLE
[release/v1.61] Cherry pick 1906 to release/v1.61

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -72,6 +72,7 @@ type kubevirtProviderSpecConf struct {
 	ProviderNetwork          *types.ProviderNetwork
 	ExtraHeadersSet          bool
 	EvictStrategy            string
+	VCPUs                    uint32
 }
 
 func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
@@ -132,7 +133,13 @@ func (k kubevirtProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 			},
 			{{- end }}
 			"template": {
+				{{- if .VCPUs }}
+				"vcpus": {
+					"cores": {{ .VCPUs }}
+				},
+				{{- else }}
 				"cpus": "2",
+				{{- end }}
 				"memory": "2Gi",
 				{{- if .SecondaryDisks }}
 				"secondaryDisks": [{
@@ -282,6 +289,10 @@ func TestNewVirtualMachine(t *testing.T) {
 		{
 			name:     "eviction-strategy-live-migrate",
 			specConf: kubevirtProviderSpecConf{EvictStrategy: "LiveMigrate"},
+		},
+		{
+			name:     "dedicated-vcpus",
+			specConf: kubevirtProviderSpecConf{VCPUs: 2},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/cloudprovider/provider/kubevirt/testdata/dedicated-vcpus.yaml
+++ b/pkg/cloudprovider/provider/kubevirt/testdata/dedicated-vcpus.yaml
@@ -1,0 +1,80 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  annotations:
+  labels:
+    cluster.x-k8s.io/cluster-name: cluster-name
+    cluster.x-k8s.io/role: worker
+    kubevirt.io/vm: dedicated-vcpus
+    md: md-name
+  name: dedicated-vcpus
+  namespace: test-namespace
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        name: dedicated-vcpus
+      spec:
+        storage:
+          accessModes:
+            - ReadWriteMany
+          resources:
+            requests:
+              storage: 10Gi
+          storageClassName: longhorn
+        source:
+          http:
+            url: http://x.y.z.t/ubuntu.img
+  runStrategy: Once
+  template:
+    metadata:
+      creationTimestamp: null
+      annotations:
+        "kubevirt.io/allow-pod-bridge-network-live-migration": "true"
+        "ovn.kubernetes.io/allow_live_migration": "true"
+      labels:
+        cluster.x-k8s.io/cluster-name: cluster-name
+        cluster.x-k8s.io/role: worker
+        kubevirt.io/vm: dedicated-vcpus
+        md: md-name
+    spec:
+      affinity: {}
+      domain:
+        cpu:
+          cores: 2
+        devices:
+          disks:
+            - disk:
+                bus: virtio
+              name: datavolumedisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          interfaces:
+            - name: default
+              bridge: {}
+          networkInterfaceMultiqueue: true
+        resources:
+          limits:
+            memory: 2Gi
+          requests:
+            memory: 2Gi
+      networks:
+        - name: default
+          pod: {}
+      terminationGracePeriodSeconds: 30
+      topologyspreadconstraints:
+        - maxskew: 1
+          topologykey: kubernetes.io/hostname
+          whenunsatisfiable: ScheduleAnyway
+          labelselector:
+            matchlabels:
+              md: md-name
+      volumes:
+        - dataVolume:
+            name: dedicated-vcpus
+          name: datavolumedisk
+        - cloudInitNoCloud:
+            secretRef:
+              name: udsn
+          name: cloudinitdisk
+      evictionStrategy: External

--- a/pkg/cloudprovider/provider/kubevirt/types/types.go
+++ b/pkg/cloudprovider/provider/kubevirt/types/types.go
@@ -70,10 +70,21 @@ type Flavor struct {
 
 // Template.
 type Template struct {
+	// VCPUs is to configure vcpus used by a the virtual machine
+	// when using kubevirts cpuAllocationRatio feature this leads to auto assignment of the
+	// calculated ratio as resource cpu requests for the pod which launches the virtual machine
+	VCPUs VCPUs `json:"vcpus,omitempty"`
+	// CPUs is to configure cpu requests and limits directly for the pod which launches the virtual machine
+	// and is related to the underlying hardware
 	CPUs           providerconfigtypes.ConfigVarString `json:"cpus,omitempty"`
 	Memory         providerconfigtypes.ConfigVarString `json:"memory,omitempty"`
 	PrimaryDisk    PrimaryDisk                         `json:"primaryDisk,omitempty"`
 	SecondaryDisks []SecondaryDisks                    `json:"secondaryDisks,omitempty"`
+}
+
+// VCPUs.
+type VCPUs struct {
+	Cores int `json:"cores,omitempty"`
 }
 
 // PrimaryDisk.


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubermatic/machine-controller/pull/1906 and https://github.com/kubermatic/machine-controller/pull/1912

```release-note
A new field `cloudProviderSpec.virtualMachine.template.vcpus` was added to kubevirt provider. When `vcpus.cores` is set, the cpus for the virtual machine will be configured in `spec.template.spec.domain.cpu` instead of setting resource requests and limits explicit. The webhook validation will fail if both `vcpus` and `cpus` are configured for a machine.
```

/assign soer3n