### PR TITLE
add support for nvme devices for tinkerbell provider

### DIFF
--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
@@ -197,17 +197,17 @@ func createGrowPartitionAction(destDisk string) Action {
 		Image:   "quay.io/tinkerbell/actions/cexec:c5bde803d9f6c90f1a9d5e06930d856d1481854c",
 		Timeout: 90,
 		Environment: map[string]string{
-			"BLOCK_DEVICE":        fmt.Sprintf("{{ index .Hardware.Disks 0 }}%s", PartitionNumber),
+			"BLOCK_DEVICE":        "{{ formatPartition ( index .Hardware.Disks 0 ) (.partition_number | int) }}",
 			"FS_TYPE":             fsType,
 			"CHROOT":              "y",
 			"DEFAULT_INTERPRETER": defaultInterpreter,
-			"CMD_LINE":            fmt.Sprintf("growpart %s %s && resize2fs %s%s", destDisk, PartitionNumber, destDisk, PartitionNumber),
+			"CMD_LINE":            fmt.Sprintf("growpart %s %s && resize2fs '{{ formatPartition ( index .Hardware.Disks 0 ) (.partition_number | int) }}'", destDisk, PartitionNumber),
 		},
 	}
 }
 
 func createNetworkConfigAction() Action {
-	netplaneConfig := `
+	netplanConfig := `
 network:
   version: 2
   renderer: networkd
@@ -227,10 +227,10 @@ network:
 		Image:   "quay.io/tinkerbell-actions/writefile:v1.0.0",
 		Timeout: 90,
 		Environment: map[string]string{
-			"DEST_DISK": fmt.Sprintf("{{ index .Hardware.Disks 0 }}%s", PartitionNumber),
+			"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) (.partition_number | int) }}",
 			"FS_TYPE":   fsType,
 			"DEST_PATH": "/etc/netplan/config.yaml",
-			"CONTENTS":  netplaneConfig,
+			"CONTENTS":  netplanConfig,
 			"UID":       "0",
 			"GID":       "0",
 			"MODE":      "0644",
@@ -252,7 +252,7 @@ echo 'local-hostname: {{.hardware_name}}' >> /var/lib/cloud/seed/nocloud/meta-da
 		Image:   "quay.io/tinkerbell-actions/cexec:v1.0.0",
 		Timeout: 90,
 		Environment: map[string]string{
-			"BLOCK_DEVICE":        fmt.Sprintf("{{ index .Hardware.Disks 0 }}%s", PartitionNumber),
+			"BLOCK_DEVICE":        "{{ formatPartition ( index .Hardware.Disks 0 ) (.partition_number | int) }}",
 			"FS_TYPE":             fsType,
 			"CHROOT":              "y",
 			"DEFAULT_INTERPRETER": defaultInterpreter,
@@ -267,7 +267,7 @@ func decodeCloudInitFile(hardwareName string) Action {
 		Image:   "quay.io/tinkerbell/actions/cexec:latest",
 		Timeout: 90,
 		Environment: map[string]string{
-			"BLOCK_DEVICE":        fmt.Sprintf("{{ index .Hardware.Disks 0 }}%s", PartitionNumber),
+			"BLOCK_DEVICE":        "{{ formatPartition ( index .Hardware.Disks 0 ) (.partition_number | int) }}",
 			"FS_TYPE":             fsType,
 			"CHROOT":              "y",
 			"DEFAULT_INTERPRETER": "/bin/sh -c",


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr adds support for using nvme disks for tinkerbell provider. For that we need to use the predefined tinkerbell template function `formatPartition` to respect that such devices have a `p` as a prefix for the device path. For instance the first partition of a device `/dev/nvme0n1`  would be `/dev/nvme0n1p1`. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
