### PR TITLE
Add ClusterNamespace Annotations to Worker Nodes 

### DIFF
--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -131,6 +131,13 @@ func (ad *admissionData) defaultAndValidateMachineSpec(ctx context.Context, spec
 		}
 	}
 
+	// For KubeVirt we need to initialize the annotations for MachineDeployment, to enable setting of the needed annotations.
+	if providerConfig.CloudProvider == providerconfig.CloudProviderKubeVirt {
+		if spec.Annotations == nil {
+			spec.Annotations = make(map[string]string)
+		}
+	}
+
 	configResolver := configvar.NewResolver(ctx, ad.workerClient)
 	prov, err := cloudprovider.ForProvider(providerConfig.CloudProvider, configResolver)
 	if err != nil {

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -80,6 +80,8 @@ const (
 	// node affinity constraints on a PersistentVolume.
 	topologyRegionKey = "topology.kubernetes.io/region"
 	topologyZoneKey   = "topology.kubernetes.io/zone"
+	// clusterNamespace represents the infra cluster namespace, where KubeVirt resources are created.
+	clusterNamespace = "cluster.x-k8s.io/cluster-namespace"
 )
 
 type provider struct {
@@ -674,6 +676,13 @@ func (p *provider) AddDefaults(_ *zap.SugaredLogger, spec clusterv1alpha1.Machin
 		return spec, err
 	}
 
+	annotations := spec.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[clusterNamespace] = c.Namespace
+	spec.Annotations = annotations
 	if err := appendTopologiesLabels(context.TODO(), c, spec.Labels); err != nil {
 		return spec, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The new KubeVirt CSI driver expects the tenant cluster nodes should have an annotation that determines the tenant cluster  namespace in the infra cluster. This PR reads the namespace value from the machine deployment spec and adds it to the node annotations. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support KubeVirt cluster namespace annotations for KubeVirt worker nodes
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
