### PR TITLE
Handle SDK version tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GOOS ?= $(shell go env GOOS)
 
 export CGO_ENABLED := 0
 
-export GIT_TAG ?= $(shell git tag --points-at HEAD)
+export GIT_TAG ?= $(shell git tag --points-at HEAD 'v*')
 
 export GOFLAGS?=-mod=readonly -trimpath
 

--- a/hack/ci/setup-machine-controller-in-kind.sh
+++ b/hack/ci/setup-machine-controller-in-kind.sh
@@ -68,11 +68,10 @@ if [ ! -f machine-controller-deployed ]; then
 fi
 
 OSM_TMP_DIR=/tmp/osm
-echodate "Clone OSM respository"
 (
   # Clone OSM repo
   mkdir -p $OSM_TMP_DIR
-  echodate "Cloning cluster exposer"
+  echodate "Cloning OSM respository"
   git clone --depth 1 --branch "${OSM_REPO_TAG}" "${OSM_REPO_URL}" $OSM_TMP_DIR
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If SDK and main module tags are on the same commit, GIT_TAG could be "sdk/v...", which is not semver anymore and would break anything. This PR is the therefore the equivalent of https://github.com/kubermatic/kubermatic/pull/14636, ensuring only main version tags are considered.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
