### PR TITLE
[release/1.61] Add ClusterNamespace Annotations to Worker Nodes  (#1924)

### DIFF
--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -129,6 +129,13 @@ func (ad *admissionData) defaultAndValidateMachineSpec(ctx context.Context, spec
 		}
 	}
 
+	// For KubeVirt we need to initialize the annotations for MachineDeployment, to enable setting of the needed annotations.
+	if providerConfig.CloudProvider == providerconfigtypes.CloudProviderKubeVirt {
+		if spec.Annotations == nil {
+			spec.Annotations = make(map[string]string)
+		}
+	}
+
 	skg := providerconfig.NewConfigVarResolver(ctx, ad.workerClient)
 	prov, err := cloudprovider.ForProvider(providerConfig.CloudProvider, skg)
 	if err != nil {

--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -81,6 +81,8 @@ const (
 	// node affinity constraints on a PersistentVolume.
 	topologyRegionKey = "topology.kubernetes.io/region"
 	topologyZoneKey   = "topology.kubernetes.io/zone"
+	// clusterNamespace represents the infra cluster namespace, where KubeVirt resources are created.
+	clusterNamespace = "cluster.x-k8s.io/cluster-namespace"
 )
 
 type provider struct {
@@ -675,6 +677,13 @@ func (p *provider) AddDefaults(_ *zap.SugaredLogger, spec clusterv1alpha1.Machin
 		return spec, err
 	}
 
+	annotations := spec.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[clusterNamespace] = c.Namespace
+	spec.Annotations = annotations
 	if err := appendTopologiesLabels(context.TODO(), c, spec.Labels); err != nil {
 		return spec, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
A manual cherry pick (cherry picked from commit 7a93ac526de3b0e6a3cf2a31e46b9dc243a2cd7d)

```release-note
Support KubeVirt cluster namespace annotations for KubeVirt worker nodes
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
