### PR TITLE
fix AMI query for Ubuntu images

### DIFF
--- a/pkg/cloudprovider/provider/aws/provider.go
+++ b/pkg/cloudprovider/provider/aws/provider.go
@@ -130,7 +130,7 @@ var (
 		providerconfig.OperatingSystemUbuntu: {
 			awstypes.CPUArchitectureX86_64: {
 				// Be as precise as possible - otherwise we might get a nightly dev build
-				description: "Canonical, Ubuntu, 24.04 LTS, amd64 noble image build on ????-??-??",
+				description: "Canonical, Ubuntu, 24.04, amd64 noble image",
 				// The AWS marketplace ID from Canonical
 				owner: "099720109477",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
The old query does not yield any results anymore. With the new one, the following AMI is currently chosen:

* id=ami-0300b7cf57a2ea956,
* owner=679593333241
* ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-20250530-prod-ib2w5aw4ynhey

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix AMI query for Ubuntu images
```

**Documentation**:
```documentation
NONE
```
