### PR TITLE
Add support to provisioning vcloud workers with multiple nics/networks

### DIFF
--- a/pkg/admission/machinedeployments_validation.go
+++ b/pkg/admission/machinedeployments_validation.go
@@ -128,6 +128,14 @@ func mutationsForMachineDeployment(md *clusterv1alpha1.MachineDeployment) error 
 		}
 	}
 
+	// Migrate
+	if providerConfig.CloudProvider == providerconfigtypes.CloudProviderVMwareCloudDirector {
+		err := migrateVMwareCloudDirector(providerConfig)
+		if err != nil {
+			return fmt.Errorf("failed to migrate VMware Cloud Director Network Settings: %w", err)
+		}
+	}
+
 	// Update value in original object
 	md.Spec.Template.Spec.ProviderSpec.Value.Raw, err = json.Marshal(providerConfig)
 	if err != nil {

--- a/pkg/admission/util.go
+++ b/pkg/admission/util.go
@@ -59,7 +59,7 @@ func migrateVMwareCloudDirector(providerConfig *providerconfigtypes.Config) (err
 	}
 
 	if config.Network.Value != "" {
-		config.Networks = append(config.Networks, config.Network)
+		config.Networks = append([]providerconfigtypes.ConfigVarString{config.Network}, config.Networks...)
 		config.Network.Value = ""
 		p := &providerconfigtypes.ConfigVarString{Value: ""}
 		config.Network = *p

--- a/pkg/admission/util.go
+++ b/pkg/admission/util.go
@@ -65,6 +65,8 @@ func migrateVMwareCloudDirector(providerConfig *providerconfigtypes.Config) (err
 		config.Network = *p
 	}
 
+	config.Networks = Deduplicate(config.Networks)
+
 	cloudProviderSpecRaw, err := json.Marshal(config)
 	if err != nil {
 		return fmt.Errorf("failed to marshal cloudProviderConfig: %w", err)
@@ -72,4 +74,18 @@ func migrateVMwareCloudDirector(providerConfig *providerconfigtypes.Config) (err
 
 	providerConfig.CloudProviderSpec.Raw = cloudProviderSpecRaw
 	return nil
+}
+
+func Deduplicate[T comparable](slice []T) []T {
+	seen := make(map[T]struct{})
+	result := []T{}
+
+	for _, val := range slice {
+		if _, exists := seen[val]; !exists {
+			seen[val] = struct{}{}
+			result = append(result, val)
+		}
+	}
+
+	return result
 }

--- a/pkg/admission/util.go
+++ b/pkg/admission/util.go
@@ -55,7 +55,6 @@ func migrateVMwareCloudDirector(providerConfig *providerconfigtypes.Config) (err
 	config, err := vcdtypes.GetConfig(*providerConfig)
 	if err != nil {
 		return fmt.Errorf("failed to get vcd config: %w", err)
-
 	}
 
 	if config.Network.Value != "" {

--- a/pkg/cloudprovider/provider/vmwareclouddirector/helper.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/helper.go
@@ -123,6 +123,20 @@ func createVM(client *Client, machine *clusterv1alpha1.Machine, c *Config, org *
 		}
 	}
 
+	var networkConnections []*vcdapitypes.NetworkConnection
+	for i, network := range c.Networks {
+		networkConnections = append(networkConnections, &vcdapitypes.NetworkConnection{
+			Network:                 network,
+			NeedsCustomization:      false,
+			IsConnected:             true,
+			IPAddressAllocationMode: string(c.IPAllocationMode),
+			NetworkAdapterType:      "VMXNET3",
+			NetworkConnectionIndex:  i,
+		})
+	}
+
+	fmt.Printf("network connections: %+v\n", networkConnections)
+
 	// 4. At this point we are ready to create our initial VMs.
 	//
 	// Multiple API calls to re-compose the vApp are handled in a synchronous manner, where each request has to wait
@@ -145,15 +159,7 @@ func createVM(client *Client, machine *clusterv1alpha1.Machine, c *Config, org *
 			},
 			InstantiationParams: &vcdapitypes.InstantiationParams{
 				NetworkConnectionSection: &vcdapitypes.NetworkConnectionSection{
-					NetworkConnection: []*vcdapitypes.NetworkConnection{
-						{
-							Network:                 c.Network,
-							NeedsCustomization:      false,
-							IsConnected:             true,
-							IPAddressAllocationMode: string(c.IPAllocationMode),
-							NetworkAdapterType:      "VMXNET3",
-						},
-					},
+					NetworkConnection: networkConnections,
 				},
 			},
 			StorageProfile: storageProfile,

--- a/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
@@ -79,7 +79,7 @@ type Config struct {
 	SizingPolicy    *string
 
 	// Network configuration.
-	Network          string
+	Networks         []string
 	IPAllocationMode vcdtypes.IPAllocationMode
 
 	// Compute configuration.
@@ -375,9 +375,21 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 		return nil, nil, nil, err
 	}
 
-	c.Network, err = p.configVarResolver.GetStringValue(rawConfig.Network)
+	singleNetwork, err := p.configVarResolver.GetStringValue(rawConfig.Network)
 	if err != nil {
 		return nil, nil, nil, err
+	}
+
+	if singleNetwork != "" && len(rawConfig.Networks) == 0 {
+		c.Networks = append(c.Networks, singleNetwork)
+	}
+
+	for _, network := range rawConfig.Networks {
+		networkValue, err := p.configVarResolver.GetStringValue(network)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		c.Networks = append(c.Networks, networkValue)
 	}
 
 	c.IPAllocationMode = rawConfig.IPAllocationMode
@@ -509,11 +521,18 @@ func (p *provider) Validate(_ context.Context, _ *zap.SugaredLogger, spec cluste
 		return fmt.Errorf("diskSizeGB '%v' cannot be less than the template size '%v': %w", *c.DiskSizeGB, catalogItem.CatalogItem.Size, err)
 	}
 
-	// Ensure that the network exists
+	// Ensure that the networks exists
 	// It can either be a vApp network or a vApp Org network.
-	_, err = GetVappNetworkType(c.Network, *vapp)
-	if err != nil {
-		return fmt.Errorf("failed to get network '%s' for vapp '%s': %w", c.Network, c.VApp, err)
+
+	if len(c.Networks) == 0 {
+		return fmt.Errorf("at least one network must be specified")
+	}
+
+	for _, network := range c.Networks {
+		_, err = GetVappNetworkType(network, *vapp)
+		if err != nil {
+			return fmt.Errorf("failed to get network '%s' for vapp '%s': %w", network, c.VApp, err)
+		}
 	}
 
 	if c.SizingPolicy != nil || c.PlacementPolicy != nil {

--- a/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
@@ -381,7 +381,7 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	}
 
 	if singleNetwork != "" {
-		c.Networks = append(c.Networks, singleNetwork)
+		c.Networks = append([]string{singleNetwork}, c.Networks...)
 	}
 
 	for _, network := range rawConfig.Networks {

--- a/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
+++ b/pkg/cloudprovider/provider/vmwareclouddirector/provider.go
@@ -380,7 +380,7 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 		return nil, nil, nil, err
 	}
 
-	if singleNetwork != "" && len(rawConfig.Networks) == 0 {
+	if singleNetwork != "" {
 		c.Networks = append(c.Networks, singleNetwork)
 	}
 

--- a/sdk/cloudprovider/vmwareclouddirector/types.go
+++ b/sdk/cloudprovider/vmwareclouddirector/types.go
@@ -46,8 +46,10 @@ type RawConfig struct {
 	PlacementPolicy *string                        `json:"placementPolicy,omitempty"`
 
 	// Network configuration.
-	Network          providerconfig.ConfigVarString `json:"network"`
-	IPAllocationMode IPAllocationMode               `json:"ipAllocationMode,omitempty"`
+	// Deprecated: Use networks instead.
+	Network          providerconfig.ConfigVarString   `json:"network,omitempty"`
+	Networks         []providerconfig.ConfigVarString `json:"networks"`
+	IPAllocationMode IPAllocationMode                 `json:"ipAllocationMode,omitempty"`
 
 	// Compute configuration.
 	CPUs         int64   `json:"cpus"`

--- a/test/e2e/provisioning/testdata/machinedeployment-vmware-cloud-director.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vmware-cloud-director.yaml
@@ -36,7 +36,8 @@ spec:
             vapp: "kubermatic-e2e"
             catalog: "kubermatic"
             template: "machine-controller-<< OS_NAME >>"
-            network: "kubermatic-e2e-routed-network"
+            networks:
+             - "kubermatic-e2e-routed-network"
             ipAllocationMode: "DHCP"
             cpus: 2
             cpuCores: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
This pr adds the ability to create machines in vmware cloud director with multiple nics using different networks. This is especially useful when you want to use a additional nic for storage

**Which issue(s) this PR fixes**:
-

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

This change just adds the nic to the vm, for the configuration there is a osm pr https://github.com/kubermatic/operating-system-manager/pull/471

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Added the option to provision vmware cloud director nodes with multiple networks/nics
```

**Documentation**:
```documentation
TBD
```
