### PR TITLE
Use flatcar-container-linux-corevm-amd64 for flatcar on Azure

### DIFF
--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -154,9 +154,10 @@ var imageReferences = map[providerconfig.OperatingSystem]compute.ImageReference{
 	},
 	providerconfig.OperatingSystemFlatcar: {
 		Publisher: to.StringPtr("kinvolk"),
-		Offer:     to.StringPtr("flatcar-container-linux"),
-		Sku:       to.StringPtr("stable"),
-		Version:   to.StringPtr("3374.2.0"),
+		// flatcar-container-linux-corevm-amd64 doesn't require a plan. For more info: https://www.flatcar.org/docs/latest/installing/cloud/azure/#corevm
+		Offer:   to.StringPtr("flatcar-container-linux-corevm-amd64"),
+		Sku:     to.StringPtr("stable"),
+		Version: to.StringPtr("4230.2.2"),
 	},
 	providerconfig.OperatingSystemRockyLinux: {
 		Publisher: to.StringPtr("resf"),
@@ -167,11 +168,6 @@ var imageReferences = map[providerconfig.OperatingSystem]compute.ImageReference{
 }
 
 var osPlans = map[providerconfig.OperatingSystem]*compute.Plan{
-	providerconfig.OperatingSystemFlatcar: {
-		Name:      ptr.To("stable"),
-		Publisher: ptr.To("kinvolk"),
-		Product:   ptr.To("flatcar-container-linux"),
-	},
 	providerconfig.OperatingSystemRHEL: {
 		Name:      ptr.To("rhel-lvm85"),
 		Publisher: ptr.To("redhat"),


### PR DESCRIPTION
**What this PR does / why we need it**:
`flatcar-container-linux` is legacy and deprecated. `flatcar-container-linux-corevm-amd64` is the recommended offer and we are switching to that in Machine Controller. Since plan is not required for this offer we are removing it.

For more info: https://www.flatcar.org/docs/latest/installing/cloud/azure/#corevm

I also updated the image version from the archaic 3374.2.0(Release Date: Nov 17, 2022) to the latest 4230.2.2.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Azure: Use `flatcar-container-linux-corevm-amd64` offer for Flatcar and upgrade to version `4230.2.2`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
