### PR TITLE
Fix Gen2 Ubuntu SKU reference for Azure

### DIFF
--- a/pkg/cloudprovider/provider/azure/config.go
+++ b/pkg/cloudprovider/provider/azure/config.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+	azuretypes "k8c.io/machine-controller/sdk/cloudprovider/azure"
+	"k8c.io/machine-controller/sdk/providerconfig"
+)
+
+// newCloudProviderSpec creates a cloud provider specification out of the
+// given ProviderSpec.
+func newCloudProviderSpec(provSpec clusterv1alpha1.ProviderSpec) (*azuretypes.RawConfig, *providerconfig.Config, error) {
+	// Retrieve provider configuration from machine specification.
+	pConfig, err := providerconfig.GetConfig(provSpec)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot unmarshal machine.spec.providerconfig.value: %w", err)
+	}
+
+	if pConfig.OperatingSystemSpec.Raw == nil {
+		return nil, nil, fmt.Errorf("operatingSystemSpec in the MachineDeployment cannot be empty")
+	}
+
+	// Retrieve cloud provider specification from cloud provider specification.
+	cpSpec, err := azuretypes.GetConfig(*pConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("cannot unmarshal cloud provider specification: %w", err)
+	}
+
+	return cpSpec, pConfig, nil
+}

--- a/pkg/cloudprovider/provider/azure/provider_test.go
+++ b/pkg/cloudprovider/provider/azure/provider_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2024 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"testing"
+)
+
+func TestVMSizeSupportsGen2(t *testing.T) {
+	tests := []struct {
+		name     string
+		vmSize   string
+		expected bool
+	}{
+		{
+			name:     "Standard_F2s_v2 should support Gen2",
+			vmSize:   "Standard_F2s_v2",
+			expected: true,
+		},
+		{
+			name:     "Standard_D2s_v3 should support Gen2",
+			vmSize:   "Standard_D2s_v3",
+			expected: true,
+		},
+		{
+			name:     "Standard_E2s_v4 should support Gen2",
+			vmSize:   "Standard_E2s_v4",
+			expected: true,
+		},
+		{
+			name:     "Standard_B2ms should support Gen2",
+			vmSize:   "Standard_B2ms",
+			expected: true,
+		},
+		{
+			name:     "Standard_D2_v2 should support Gen2",
+			vmSize:   "Standard_D2_v2",
+			expected: true,
+		},
+		{
+			name:     "Standard_A2 should not support Gen2",
+			vmSize:   "Standard_A2",
+			expected: false,
+		},
+		{
+			name:     "Standard_D2 (old) should support Gen2",
+			vmSize:   "Standard_D2",
+			expected: true,
+		},
+		{
+			name:     "lowercase Standard_f2s_v2 should support Gen2",
+			vmSize:   "standard_f2s_v2",
+			expected: true,
+		},
+		{
+			name:     "Standard_NC6s_v3 should support Gen2",
+			vmSize:   "Standard_NC6s_v3",
+			expected: true,
+		},
+		{
+			name:     "Standard_NC40ads_H100_v5 should support Gen2",
+			vmSize:   "Standard_NC40ads_H100_v5",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := vmSizeSupportsGen2(tt.vmSize)
+			if result != tt.expected {
+				t.Errorf("vmSizeSupportsGen2(%s) = %v, expected %v", tt.vmSize, result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/cloudprovider/provider/kubevirt/provider_test.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	cdicorev1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 

--- a/sdk/providerconfig/configvar/resolver.go
+++ b/sdk/providerconfig/configvar/resolver.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"k8c.io/machine-controller/sdk/providerconfig"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the reference for the Ubuntu Gen2 SKU used on Azure to ensure the correct image/SKU is selected for Generation 2 virtual machines.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1967 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Gen2 Ubuntu SKU reference for Azure
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
