### PR TITLE
Skip eviction in case when the Node is NotReady

### DIFF
--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -290,7 +290,9 @@ func TestControllerDeletesMachinesOnJoinTimeout(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "my-machine",
 					CreationTimestamp: test.creationTimestamp,
-					OwnerReferences:   test.ownerReferences}}
+					OwnerReferences:   test.ownerReferences,
+				},
+			}
 
 			node := &corev1.Node{}
 			instance := &fakeInstance{}
@@ -407,13 +409,22 @@ func TestControllerShouldEvict(t *testing.T) {
 		{
 			name:        "Eviction possible because of second node",
 			shouldEvict: true,
-			existingNodes: []ctrlruntimeclient.Object{&corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "existing-node",
-				}}, &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "eviction-destination",
-				}},
+			existingNodes: []ctrlruntimeclient.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eviction-destination",
+					},
+				},
 			},
 			machine: &clusterv1alpha1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
@@ -428,13 +439,22 @@ func TestControllerShouldEvict(t *testing.T) {
 		{
 			name:        "Eviction possible because of machine without noderef",
 			shouldEvict: true,
-			existingNodes: []ctrlruntimeclient.Object{&corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "existing-node",
-				}}, &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "eviction-destination",
-				}},
+			existingNodes: []ctrlruntimeclient.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eviction-destination",
+					},
+				},
 			},
 			machine: &clusterv1alpha1.Machine{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
When the Node is in NotReady condition, it's useless to try to drain it, causes endless loop of drain retrying of half-dead Node.

**Which issue(s) this PR fixes**:
Fixes #1586

**What type of PR is this?**
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip eviction in case when the Node is NotReady
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
