### PR TITLE
chore:  Removes unused in-tree csi logic

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -30,7 +30,6 @@ import (
 	"github.com/heptiolabs/healthcheck"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
-
 	"k8c.io/machine-controller/pkg/cloudprovider"
 	cloudprovidererrors "k8c.io/machine-controller/pkg/cloudprovider/errors"
 	"k8c.io/machine-controller/pkg/cloudprovider/instance"
@@ -287,7 +286,7 @@ func enqueueRequestsForNodes(ctx context.Context, log *zap.SugaredLogger, mgr ma
 	})
 }
 
-// clearMachineError is a convenience function to remove a error on the machine if its set.
+// clearMachineError is a convenience function to remove an error on the machine if its set.
 // It does not return an error as it's used around the sync handler.
 func (r *Reconciler) clearMachineError(machine *clusterv1alpha1.Machine) {
 	if machine.Status.ErrorMessage != nil || machine.Status.ErrorReason != nil {
@@ -456,9 +455,8 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, mach
 		return r.ensureInstanceExistsForMachine(ctx, log, prov, machine, providerConfig)
 	}
 
-	// case 3.2: if the node exists and both external and internal CCM are not available. Then set the provider-id for the node.
-	inTree := providerconfig.IntreeCloudProviderImplementationSupported(providerConfig.CloudProvider)
-	if !inTree && !r.nodeSettings.ExternalCloudProvider && node.Spec.ProviderID == "" {
+	// case 3.2: if the node exists and external CCM is not available. Then set the provider-id for the node.
+	if !r.nodeSettings.ExternalCloudProvider && node.Spec.ProviderID == "" {
 		providerID := fmt.Sprintf(ProviderIDPattern, providerConfig.CloudProvider, machine.UID)
 		if err := r.updateNode(ctx, node, func(n *corev1.Node) {
 			n.Spec.ProviderID = providerID
@@ -899,9 +897,8 @@ func (r *Reconciler) ensureInstanceExistsForMachine(
 
 	var providerID string
 	if machine.Spec.ProviderID == nil {
-		inTree := providerconfig.IntreeCloudProviderImplementationSupported(providerConfig.CloudProvider)
-		// If both external and internal CCM are not available. We set provider-id for the machine explicitly.
-		if !inTree && !r.nodeSettings.ExternalCloudProvider {
+		// If both external CCM is not available. We set provider-id for the machine explicitly.
+		if !r.nodeSettings.ExternalCloudProvider {
 			providerID = fmt.Sprintf(ProviderIDPattern, providerConfig.CloudProvider, machine.UID)
 		}
 	}

--- a/sdk/providerconfig/types.go
+++ b/sdk/providerconfig/types.go
@@ -117,13 +117,6 @@ var (
 	}
 )
 
-func IntreeCloudProviderImplementationSupported(cloudProvider CloudProvider) (inTree bool) {
-	if cloudProvider == CloudProviderAzure || cloudProvider == CloudProviderVsphere || cloudProvider == CloudProviderGoogle {
-		return true
-	}
-	return false
-}
-
 // DNSConfig contains a machine's DNS configuration.
 type DNSConfig struct {
 	Servers []string `json:"servers"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes unused `IntreeCloudProviderImplementationSupported` func
The logic has no use as all CSI providers are out-of-tree.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #1984 

**What type of PR is this?**
<!--
Add one of the following kinds:
-->
/kind cleanup
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
