### PR TITLE
Fix: Add missing RBAC to access endpointslices

### DIFF
--- a/examples/machine-controller.yaml
+++ b/examples/machine-controller.yaml
@@ -396,9 +396,9 @@ metadata:
     local-testing: "true"
 rules:
 - apiGroups:
-  - ""
+  - discovery.k8s.io
   resources:
-  - endpoints
+  - endpointslices
   verbs:
   - get
   - watch


### PR DESCRIPTION
**What this PR does / why we need it**:

Change RBAC role to endpointslices.

With https://github.com/kubermatic/machine-controller/pull/1992 the fallback to discover the kubernetes API was changed to use endpointslices but the corresponding role was not changed. This leads to healthz resulting in an error and machine-controller not to be healthy (if you rely on the fallback). 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add missing RBAC to access endpointslices
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
