### PR TITLE
fix ProviderData.Update() semantics wrt controller-runtime client cache

### DIFF
--- a/pkg/cloudprovider/types/types.go
+++ b/pkg/cloudprovider/types/types.go
@@ -99,20 +99,27 @@ func GetMachineUpdater(ctx context.Context, client ctrlruntimeclient.Client) Mac
 		// Store name here, because the machine can be nil if an update failed.
 		namespacedName := types.NamespacedName{Namespace: machine.Namespace, Name: machine.Name}
 		return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			if err := client.Get(ctx, namespacedName, machine); err != nil {
+			cachedMachine := &clusterv1alpha1.Machine{}
+			if err := client.Get(ctx, namespacedName, cachedMachine); err != nil {
 				return fmt.Errorf("failed to get machine: %w", err)
 			}
 
 			// Check if we actually change something and only update if that is the case.
-			unmodifiedMachine := machine.DeepCopy()
+			unmodifiedMachine := cachedMachine.DeepCopy()
 			for _, modify := range modifiers {
-				modify(machine)
+				modify(cachedMachine)
 			}
-			if equality.Semantic.DeepEqual(unmodifiedMachine, machine) {
+			if equality.Semantic.DeepEqual(unmodifiedMachine, cachedMachine) {
 				return nil
 			}
 
-			return client.Update(ctx, machine)
+			if err := client.Update(ctx, cachedMachine); err != nil {
+				return err
+			}
+
+			cachedMachine.DeepCopyInto(machine)
+
+			return nil
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes `ProviderData.Update()` semantics to only modify the in-memory representation on successful updates.

Previously, if the modifier did not change anything, the function would still as a side effect fill the passed-in machine struct with the latest version from the controller-runtime cache, which is only ever updated asynchronously in the background and might be arbitrarily outdated.

So e.g. if you called this function twice in a row, the first call might've performed an update and filled the struct with the latest state of the machine from the cluster, but then the next call might've performed no update and filled the struct with an outdated state, potentially behind even what it was before the two calls.

This could lead to hard to find bugs because callers generally don't expect these semantics and proceed working with the returned outdated struct.

This PR changes the function so the machine struct that the caller passes in is only modified if the update succeeded, in which case the structure is filled with the latest state from the cluster, post-update.

If the modifier didn't change anything or the update failed, the struct is left untouched.


**Example

I haven't checked your providers, but in our fork the Openstack provider reconciles a machine kinda as follows (each Ux represents an update of the machine resource performed using `ProviderData.Update()`):

1. (U1) ensure finalizers: `clean-up-openstack-server`, `clean-up-openstack-port`
2. (U2) ensure finalizers: `machine-delete-finalizer`, `machine-node-delete-finalizer`
3. (U3) ensure finalizer: `clean-up-openstack-port`
4. create port named `metakube-machine-<UID>` in Openstack
5. (U4) set port ID annotation on the machine
6. (U5) ensure finalizer: `clean-up-openstack-server`
7. create the server in Openstack, with the port set to the ID from the port ID annotation
8. (U6) set server ID annotation on the machine

(1., 3. and 6. ensure the same finalizers because of a technicality -- we introduced these finalizers a while ago, and older machines didn't have them yet. Anyway, while redundant, this shouldn't be a problem, but it is -- see below)

The update proceeds through the port creation in step 4, it successfully updates the machine writing the port ID annotation in step 5/U4.

Then it gets to U5, where it tries to ensure the Openstack server cleanup finalizer. That finalizer already exists on the machine, usually from U1 in the same reconcile run. The cache happens to already contain U1, but not U4. So the update routine detects no diff (since the finalizer is already in the cached version) and thus it does not send an update request and changes the in-memory `machine` struct to the cached version, i.e. one where the port ID annotation is still "".

Then the controller proceeds to the Openstack server creation (step 7), which requires the port ID, which it gets from the machine struct, where it's set to "". So it calls the Openstack server creation with port ID "", which triggers an error (`Bad network format: missing 'uuid'"`) in the Openstack API.

We had been seeing this error pop up randomly in our logs and in machine events (so users also reported them) and never understood where they came from until we dug into this update routine. Please note that we were involuntarily relying on the Openstack API to perform this error handling here. In other cases or other providers, this might actually change or corrupt data in unwanted ways.

There are probably alternative ways to handle this, like disabling the cache, or fixing all the call sites of the update routine, or maybe waiting for the cache to contain a particular state in certain situations. Maybe you've done some of those things, in which case this PR is not needed.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
