### PR TITLE
update webhooks: handle resourceVersion conflicts properly

### DIFF
--- a/pkg/admission/machinedeployments.go
+++ b/pkg/admission/machinedeployments.go
@@ -55,6 +55,10 @@ func (ad *admissionData) mutateMachineDeployments(ctx context.Context, ar admiss
 		if err := json.Unmarshal(ar.OldObject.Raw, &oldMachineDeployment); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal OldObject: %w", err)
 		}
+		if oldMachineDeployment.ResourceVersion != machineDeployment.ResourceVersion {
+			// resource version conflict. Return success to fall back to the API server's default handler, which will respond with a proper 409
+            return createAdmissionResponse(log, machineDeploymentOriginal, &machineDeployment)
+		}
 		if equal := apiequality.Semantic.DeepEqual(oldMachineDeployment.Spec.Template.Spec, machineDeployment.Spec.Template.Spec); equal {
 			machineSpecNeedsValidation = false
 		}

--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -62,6 +62,10 @@ func (ad *admissionData) mutateMachines(ctx context.Context, ar admissionv1.Admi
 		if err := json.Unmarshal(ar.OldObject.Raw, &oldMachine); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal OldObject: %w", err)
 		}
+		if oldMachine.ResourceVersion != machine.ResourceVersion {
+			// resource version conflict. Return success to fall back to the API server's default handler, which will respond with a proper 409
+			return createAdmissionResponse(log, machineOriginal, &machine)
+		}
 		if oldMachine.Spec.Name != machine.Spec.Name && machine.Spec.Name == machine.Name {
 			oldMachine.Spec.Name = machine.Spec.Name
 		}


### PR DESCRIPTION
This changes the mutating webhook handler's behaviour in case of version conflicts.

If an update had a `metadata.resourceVersion` conflict, it makes no sense to perform the webhook's normal checks, e.g. for .spec immutability, as those checks might fail just because the base resourceVersion isn't the same.

For example, if the client is trying to update based on an outdated version of the resource, the .spec might be different from the in-cluster version just because of that, triggering the corresponding webhook check and responding with a 400, even though 409 would be the correct response that allows the client to perform proper conflict handling.

So in case of a resourceVersion conflict the webhook now just returns success, which causes the API server to fall back to its default handling, which will detect the resourceVersion conflict and return the 409 itself.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind design

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
