### PR TITLE
Drop support for k8s 1.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Currently supported K8S versions are:
 - 1.35
 - 1.34
 - 1.33
-- 1.32
 
 ### Community Providers
 

--- a/test/e2e/provisioning/helper.go
+++ b/test/e2e/provisioning/helper.go
@@ -34,9 +34,9 @@ var (
 	scenarios = buildScenarios()
 
 	versions = []*semver.Version{
-		semver.MustParse("v1.32.9"),
-		semver.MustParse("v1.33.5"),
-		semver.MustParse("v1.34.1"),
+		semver.MustParse("v1.33.11"),
+		semver.MustParse("v1.34.7"),
+		semver.MustParse("v1.35.4"),
 	}
 
 	operatingSystems = []providerconfigtypes.OperatingSystem{


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop support for k8s 1.32
Also add k8s 1.35 to the test. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Drop support for k8s 1.32
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
