### PR TITLE
Skip admission webhook validation for deleting MachineDeployments

### DIFF
--- a/pkg/admission/machinedeployments.go
+++ b/pkg/admission/machinedeployments.go
@@ -33,9 +33,20 @@ func (ad *admissionData) mutateMachineDeployments(ctx context.Context, ar admiss
 	if err := json.Unmarshal(ar.Object.Raw, &machineDeployment); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal: %w", err)
 	}
-	machineDeploymentOriginal := machineDeployment.DeepCopy()
 
 	log := ad.log.With("machinedeployment", ctrlruntimeclient.ObjectKeyFromObject(&machineDeployment))
+
+	// skip admission for objects under deletion. once DeletionTimestamp is set,
+	// only metadata mutations from controllers (e.g. OSM finalizer removal)
+	// legitimately arrive here. running full validation on a deleting MD blocks
+	// the deletion lifecycle when the cloud provider's Validate() rejects the
+	// current spec (e.g. an image that no longer resolves).
+	if machineDeployment.DeletionTimestamp != nil {
+		log.Debug("Skipping admission for machine deployment under deletion")
+		return &admissionv1.AdmissionResponse{Allowed: true}, nil
+	}
+
+	machineDeploymentOriginal := machineDeployment.DeepCopy()
 	log.Debug("Defaulting and validating machine deployment")
 
 	machineDeploymentDefaultingFunction(&machineDeployment)

--- a/pkg/admission/machinedeployments_test.go
+++ b/pkg/admission/machinedeployments_test.go
@@ -17,11 +17,23 @@ limitations under the License.
 package admission
 
 import (
+	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
-	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+	"github.com/Masterminds/semver/v3"
+	"go.uber.org/zap/zaptest"
 
+	"k8c.io/machine-controller/pkg/cloudprovider/provider/fake"
+	machinecontroller "k8c.io/machine-controller/pkg/controller/machine"
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+	"k8c.io/machine-controller/sdk/providerconfig"
+
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestMachineDeploymentDefaulting(t *testing.T) {
@@ -59,6 +71,217 @@ func TestMachineDeploymentDefaulting(t *testing.T) {
 			errs := validateMachineDeployment(*test.machineDeployment)
 			if test.isValid != (len(errs) == 0) {
 				t.Errorf("Expected machine to be valid: %t but got %d errors: %v", test.isValid, len(errs), errs)
+			}
+		})
+	}
+}
+
+func newTestAdmissionData(t *testing.T) *admissionData {
+	t.Helper()
+	c, err := semver.NewConstraint(">= 1.0.0")
+	if err != nil {
+		t.Fatalf("constraint: %v", err)
+	}
+	return &admissionData{
+		log:          zaptest.NewLogger(t).Sugar(),
+		client:       clientfake.NewClientBuilder().Build(),
+		workerClient: clientfake.NewClientBuilder().Build(),
+		nodeSettings: machinecontroller.NodeSettings{},
+		namespace:    "kube-system",
+		constraints:  c,
+	}
+}
+
+func newAdmissionRequest(t *testing.T, op admissionv1.Operation, newMD, oldMD *clusterv1alpha1.MachineDeployment) admissionv1.AdmissionRequest {
+	t.Helper()
+	objRaw, err := json.Marshal(newMD)
+	if err != nil {
+		t.Fatalf("marshal newMD: %v", err)
+	}
+	req := admissionv1.AdmissionRequest{
+		UID:       "test-uid",
+		Operation: op,
+		Object:    runtime.RawExtension{Raw: objRaw},
+	}
+	if oldMD != nil {
+		oldRaw, err := json.Marshal(oldMD)
+		if err != nil {
+			t.Fatalf("marshal oldMD: %v", err)
+		}
+		req.OldObject = runtime.RawExtension{Raw: oldRaw}
+	}
+	return req
+}
+
+type mdBuilder struct {
+	deletionTimestamp *metav1.Time
+	passValidation    bool
+	kubelet           string
+	image             string
+	noProviderSpec    bool
+}
+
+func mdBuild() *mdBuilder {
+	return &mdBuilder{passValidation: true, kubelet: "1.30.0", image: "img-default"}
+}
+
+func (b *mdBuilder) withDeletionTimestamp(ts metav1.Time) *mdBuilder {
+	b.deletionTimestamp = &ts
+	return b
+}
+func (b *mdBuilder) withPassValidation(v bool) *mdBuilder   { b.passValidation = v; return b }
+func (b *mdBuilder) withKubeletVersion(v string) *mdBuilder { b.kubelet = v; return b }
+func (b *mdBuilder) withImage(s string) *mdBuilder          { b.image = s; return b }
+func (b *mdBuilder) withNoProviderSpec() *mdBuilder         { b.noProviderSpec = true; return b }
+
+func (b *mdBuilder) build(t *testing.T) *clusterv1alpha1.MachineDeployment {
+	t.Helper()
+
+	md := &clusterv1alpha1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "md", Namespace: "kube-system"},
+		Spec: clusterv1alpha1.MachineDeploymentSpec{
+			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			Template: clusterv1alpha1.MachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+				Spec: clusterv1alpha1.MachineSpec{
+					Versions: clusterv1alpha1.MachineVersionInfo{Kubelet: b.kubelet},
+				},
+			},
+		},
+	}
+
+	if b.deletionTimestamp != nil {
+		md.DeletionTimestamp = b.deletionTimestamp
+	}
+
+	if b.noProviderSpec {
+		return md
+	}
+
+	fakeSpec := fake.CloudProviderSpec{PassValidation: b.passValidation}
+	fakeRaw, err := json.Marshal(&fakeSpec)
+	if err != nil {
+		t.Fatalf("marshal fake spec: %v", err)
+	}
+	cfg := providerconfig.Config{
+		CloudProvider:     providerconfig.CloudProviderFake,
+		CloudProviderSpec: runtime.RawExtension{Raw: fakeRaw},
+		OperatingSystem:   providerconfig.OperatingSystemUbuntu,
+	}
+	rawCfg, err := json.Marshal(&cfg)
+	if err != nil {
+		t.Fatalf("marshal providerconfig: %v", err)
+	}
+	md.Spec.Template.Spec.ProviderSpec = clusterv1alpha1.ProviderSpec{
+		Value: &runtime.RawExtension{Raw: rawCfg},
+	}
+	return md
+}
+
+func TestMutateMachineDeployments(t *testing.T) {
+	ctx := context.Background()
+	now := metav1.Now()
+
+	tests := []struct {
+		name              string
+		op                admissionv1.Operation
+		newMD             *clusterv1alpha1.MachineDeployment
+		oldMD             *clusterv1alpha1.MachineDeployment
+		wantAllowed       bool
+		wantErrorContains string
+	}{
+		{
+			name:        "create_with_resolvable_image",
+			op:          admissionv1.Create,
+			newMD:       mdBuild().build(t),
+			wantAllowed: true,
+		},
+		{
+			name:              "create_with_unresolvable_image_rejected",
+			op:                admissionv1.Create,
+			newMD:             mdBuild().withPassValidation(false).build(t),
+			wantErrorContains: "failing validation as requested",
+		},
+		{
+			name:              "create_with_empty_kubelet_rejected",
+			op:                admissionv1.Create,
+			newMD:             mdBuild().withKubeletVersion("").build(t),
+			wantErrorContains: "kubelet version must be set",
+		},
+		{
+			name:        "update_label_only_with_resolvable_image",
+			op:          admissionv1.Update,
+			newMD:       mdBuild().build(t),
+			oldMD:       mdBuild().build(t),
+			wantAllowed: true,
+		},
+		{
+			name:              "update_changing_image_to_unresolvable_rejected",
+			op:                admissionv1.Update,
+			newMD:             mdBuild().withPassValidation(false).withImage("new-img").build(t),
+			oldMD:             mdBuild().build(t),
+			wantErrorContains: "failing validation as requested",
+		},
+		{
+			name:        "delete_md_with_resolvable_image_succeeds",
+			op:          admissionv1.Update,
+			newMD:       mdBuild().withDeletionTimestamp(now).build(t),
+			oldMD:       mdBuild().withDeletionTimestamp(now).build(t),
+			wantAllowed: true,
+		},
+		{
+			// https://github.com/kubermatic/kubermatic/issues/15802
+			// oldMD has passValidation=true to ensure the post-mutation provider
+			// config bytes differ from the new MD (passValidation=false), forcing
+			// the webhook to run Validate() on the deleting object.
+			name:        "delete_md_with_unresolvable_image_succeeds",
+			op:          admissionv1.Update,
+			newMD:       mdBuild().withDeletionTimestamp(now).withPassValidation(false).build(t),
+			oldMD:       mdBuild().withDeletionTimestamp(now).withPassValidation(true).build(t),
+			wantAllowed: true,
+		},
+		{
+			name:        "delete_md_with_unresolvable_image_and_empty_kubelet_succeeds",
+			op:          admissionv1.Update,
+			newMD:       mdBuild().withDeletionTimestamp(now).withPassValidation(false).withKubeletVersion("").build(t),
+			oldMD:       mdBuild().withDeletionTimestamp(now).withPassValidation(true).withKubeletVersion("").build(t),
+			wantAllowed: true,
+		},
+		{
+			name:        "delete_md_with_no_provider_spec_succeeds",
+			op:          admissionv1.Update,
+			newMD:       mdBuild().withDeletionTimestamp(now).withNoProviderSpec().build(t),
+			oldMD:       mdBuild().withDeletionTimestamp(now).withNoProviderSpec().build(t),
+			wantAllowed: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ad := newTestAdmissionData(t)
+			req := newAdmissionRequest(t, tc.op, tc.newMD, tc.oldMD)
+			resp, err := ad.mutateMachineDeployments(ctx, req)
+
+			if tc.wantErrorContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrorContains)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrorContains) {
+					t.Fatalf("expected error containing %q, got %v", tc.wantErrorContains, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			if resp == nil {
+				t.Fatal("expected non-nil response")
+			}
+
+			if resp.Allowed != tc.wantAllowed {
+				t.Fatalf("Allowed: want %v, got %v", tc.wantAllowed, resp.Allowed)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The MachineDeployment admission webhook (`/machinedeployments`) runs full cloud provider validation, including live API calls to resolve images on every UPDATE, even when the MachineDeployment has a `DeletionTimestamp` set and is being garbage collected.

When OSM's `operating-system-config-controller` removes its cleanup finalizer (`kubermatic.io/cleanup-operating-system-configs`) via `workerClient.Update()`, the UPDATE is routed through the webhook. If the provider image is invalid or no longer resolves (e.g. an AMI that was deleted from AWS), `Validate()` returns an error, the webhook denies the UPDATE, and OSM cannot remove its finalizer. The MachineDeployment stays stuck in `Terminating` indefinitely.

This PR adds a `DeletionTimestamp` early return to `mutateMachineDeployments`, placed before `DeepCopy()` and the full mutation/validation pipeline. Objects under deletion return `Allowed: true` immediately, skipping the unnecessary deep copy, re-marshaling, and cloud provider validation call.

**Which issue(s) this PR fixes**:
Fixes kubermatic/kubermatic#15802

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
MachineDeployments can now be deleted even when the provider image is invalid or unresolvable. Previously, such MachineDeployments would get stuck in Terminating because the admission webhook blocked OSM from removing its cleanup finalizer.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
TBD
```
