### PR TITLE
bump default Flatcar Azure image to 4459.2.3 for containerd v2 support

### DIFF
--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -160,7 +160,7 @@ var imageReferences = map[providerconfig.OperatingSystem]compute.ImageReference{
 		// flatcar-container-linux-corevm-amd64 doesn't require a plan. For more info: https://www.flatcar.org/docs/latest/installing/cloud/azure/#corevm
 		Offer:   to.StringPtr("flatcar-container-linux-corevm-amd64"),
 		Sku:     to.StringPtr("stable"),
-		Version: to.StringPtr("4230.2.2"),
+		Version: to.StringPtr("4593.2.1"),
 	},
 	providerconfig.OperatingSystemRockyLinux: {
 		Publisher: to.StringPtr("resf"),

--- a/pkg/cloudprovider/provider/azure/provider.go
+++ b/pkg/cloudprovider/provider/azure/provider.go
@@ -160,7 +160,7 @@ var imageReferences = map[providerconfig.OperatingSystem]compute.ImageReference{
 		// flatcar-container-linux-corevm-amd64 doesn't require a plan. For more info: https://www.flatcar.org/docs/latest/installing/cloud/azure/#corevm
 		Offer:   to.StringPtr("flatcar-container-linux-corevm-amd64"),
 		Sku:     to.StringPtr("stable"),
-		Version: to.StringPtr("4593.2.1"),
+		Version: to.StringPtr("4459.2.3"),
 	},
 	providerconfig.OperatingSystemRockyLinux: {
 		Publisher: to.StringPtr("resf"),

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -573,7 +573,7 @@ func TestAzureProvisioningE2E(t *testing.T) {
 	}
 
 	// In-tree cloud provider is not supported from Kubernetes v1.30.
-	selector := Not(OsSelector("amzn2"))
+	selector := Not(OsSelector("amzn2", "rhel"))
 
 	// act
 	params := []string{

--- a/test/e2e/provisioning/testdata/machinedeployment-azure-custom-image-reference.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-azure-custom-image-reference.yaml
@@ -33,7 +33,7 @@ spec:
             location: "westeurope"
             resourceGroup: "machine-controller-e2e"
             vnetResourceGroup: ""
-            vmSize: "Standard_F2"
+            vmSize: "Standard_F2s_v2"
             # optional disk size values in GB. If not set, the defaults for the vmSize will be used.
             osDiskSize: << OS_DISK_SIZE >>
             dataDiskSize: << DATA_DISK_SIZE >>
@@ -42,8 +42,8 @@ spec:
             routeTableName: "machine-controller-e2e"
             imageReference:
               publisher: "Canonical"
-              offer: "0001-com-ubuntu-server-focal"
-              sku: "20_04-lts"
+              offer: "ubuntu-24_04-lts"
+              sku: "server"
               version: "latest"
             assignPublicIP: false
             zones:


### PR DESCRIPTION
The previous default 4230.2.2 ships containerd v1.7.23, which rejects the v3 config format OSM generates and leaves nodes stuck in a setup crash loop.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Azure: upgrade Flatcar to version `4459.2.3`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
