### PR TITLE
fix mirror-images 403 by dropping wrong-org push preset

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -45,6 +45,11 @@ postsubmits:
               cpu: 2
               memory: 1Gi
 
+  # Do not add any preset that injects QUAY_IO_USERNAME or QUAY_IO_PASSWORD
+  # here. hack/mirror-images.sh resolves push credentials at runtime and only
+  # does so when those variables are unset; pre-populating them with creds
+  # scoped to a different organization causes the script to skip credential
+  # resolution and push attempts will fail with 403 UNAUTHORIZED.
   - name: post-machine-controller-mirror-images
     run_if_changed: "^(pkg/mirror/mirror-images\\.yaml|hack/mirror-images\\.sh)$"
     branches:
@@ -55,7 +60,6 @@ postsubmits:
     labels:
       preset-vault: "true"
       preset-docker-mirror: "true"
-      preset-docker-push-kubermatic: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -29,6 +29,32 @@ presubmits:
               memory: 128Mi
               cpu: 100m
 
+  # TEMPORARY: duplicates post-machine-controller-mirror-images so the job
+  # can be validated end-to-end on this PR before merge. Remove before merging.
+  #
+  # Do not add any preset that injects QUAY_IO_USERNAME or QUAY_IO_PASSWORD
+  # here. hack/mirror-images.sh resolves push credentials at runtime and only
+  # does so when those variables are unset; pre-populating them with creds
+  # scoped to a different organization causes the script to skip credential
+  # resolution and push attempts will fail with 403 UNAUTHORIZED.
+  - name: pull-machine-controller-mirror-images
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    path_alias: k8c.io/machine-controller
+    labels:
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+          command:
+            - "./hack/mirror-images.sh"
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 200m
+
   - name: pull-machine-controller-build
     always_run: true
     decorate: true

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -29,32 +29,6 @@ presubmits:
               memory: 128Mi
               cpu: 100m
 
-  # TEMPORARY: duplicates post-machine-controller-mirror-images so the job
-  # can be validated end-to-end on this PR before merge. Remove before merging.
-  #
-  # Do not add any preset that injects QUAY_IO_USERNAME or QUAY_IO_PASSWORD
-  # here. hack/mirror-images.sh resolves push credentials at runtime and only
-  # does so when those variables are unset; pre-populating them with creds
-  # scoped to a different organization causes the script to skip credential
-  # resolution and push attempts will fail with 403 UNAUTHORIZED.
-  - name: pull-machine-controller-mirror-images
-    always_run: true
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
-    path_alias: k8c.io/machine-controller
-    labels:
-      preset-vault: "true"
-      preset-docker-mirror: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
-          command:
-            - "./hack/mirror-images.sh"
-          resources:
-            requests:
-              memory: 256Mi
-              cpu: 200m
-
   - name: pull-machine-controller-build
     always_run: true
     decorate: true

--- a/hack/ci/validate-mirror-images.sh
+++ b/hack/ci/validate-mirror-images.sh
@@ -21,15 +21,36 @@ source hack/lib.sh
 
 MANIFEST_FILE="${MANIFEST_FILE:-pkg/mirror/mirror-images.yaml}"
 SHA_RE='^sha256:[a-f0-9]{64}$'
+# OCI distribution spec: tag must match [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}.
+TAG_RE='^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$'
 
 echodate "Validating ${MANIFEST_FILE}..."
 
+# Ensure yq is installed
 command -v yq > /dev/null || {
-  echo "ERROR: yq not installed"
+  echo "ERROR: yq not installed."
   exit 1
 }
+
+# Ensure we are using mikefarah/yq (Go version), not kislyuk/yq (Python version)
+if yq --version 2>&1 | grep -q "jq wrapper"; then
+  echo "ERROR: Detected Python 'yq' (kislyuk/yq). This script requires the Go version of 'yq' (mikefarah/yq v4+)."
+  exit 1
+fi
+
 [[ -f "$MANIFEST_FILE" ]] || {
   echo "ERROR: ${MANIFEST_FILE} not found"
+  exit 1
+}
+
+# fail fast on malformed YAML; process substitution swallows yq errors otherwise.
+yq 'true' "$MANIFEST_FILE" > /dev/null
+
+fail_if() {
+  local message="$1" offenders="$2"
+  [[ -z "$offenders" ]] && return 0
+  echo "ERROR: ${message}"
+  echo "$offenders" | sed 's/^/  - /'
   exit 1
 }
 
@@ -41,26 +62,29 @@ if [[ "$count" == "0" || "$count" == "null" ]]; then
 fi
 echodate "  ${count} entries found"
 
-# every entry needs both source and version fields.
-missing=$(yq -r '.images | to_entries[] | select(.value.source == null or .value.version == null) | .key' "$MANIFEST_FILE")
-if [[ -n "$missing" ]]; then
-  echo "ERROR: entries missing source or version:"
-  echo "$missing" | sed 's/^/  - /'
-  exit 1
-fi
+# every entry needs source, tag, and version fields. MUST run before the
+# regex checks below: yq's test() crashes on null values.
+missing=$(yq -r '
+  .images | to_entries[]
+  | select(.value.source == null or .value.tag == null or .value.version == null)
+  | .key
+' "$MANIFEST_FILE")
+fail_if "entries missing source, tag, or version:" "$missing"
 
 # source is a bare registry path -- no tags or digests allowed.
-bad_sources=$(yq -r '.images | to_entries[] | [.key, .value.source] | @tsv' "$MANIFEST_FILE" |
-  awk -F'\t' '$2 ~ /[:@]/ { print $1 " -> " $2 }')
-if [[ -n "$bad_sources" ]]; then
-  echo "ERROR: source field must be a bare registry path (no tag, no digest):"
-  echo "$bad_sources" | sed 's/^/  - /'
-  exit 1
-fi
+bad_sources=$(yq -r '
+  .images | to_entries[]
+  | select(.value.source | test("[:@]"))
+  | .key + " -> " + .value.source
+' "$MANIFEST_FILE")
+fail_if "source field must be a bare registry path (no tag, no digest):" "$bad_sources"
 
 # version must be an explicit sha256 digest -- tags and "latest" are forbidden.
-bad_versions=$(yq -r '.images | to_entries[] | [.key, .value.version] | @tsv' "$MANIFEST_FILE" |
-  awk -F'\t' -v re="$SHA_RE" '$2 !~ re { print $1 " -> " $2 }')
+bad_versions=$(yq -r "
+  .images | to_entries[]
+  | select(.value.version | test(\"$SHA_RE\") | not)
+  | .key + \" -> \" + .value.version
+" "$MANIFEST_FILE")
 if [[ -n "$bad_versions" ]]; then
   echo "ERROR: version must be sha256:<64-hex>. Found:"
   echo "$bad_versions" | sed 's/^/  - /'
@@ -72,4 +96,12 @@ if [[ -n "$bad_versions" ]]; then
   exit 1
 fi
 
-echodate "All ${MANIFEST_FILE} entries use sha256 digests."
+# tag must match the OCI distribution tag regex.
+bad_tags=$(yq -r "
+  .images | to_entries[]
+  | select(.value.tag | test(\"$TAG_RE\") | not)
+  | .key + \" -> \" + .value.tag
+" "$MANIFEST_FILE")
+fail_if "tag must match [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}. Found:" "$bad_tags"
+
+echodate "All ${MANIFEST_FILE} entries use valid sha256 digests and tags."

--- a/hack/ci/verify-mirror-images-exist.sh
+++ b/hack/ci/verify-mirror-images-exist.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Machine Controller Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+source hack/lib.sh
+
+MANIFEST_FILE="${MANIFEST_FILE:-pkg/mirror/mirror-images.yaml}"
+CRANE="${CRANE:-crane}"
+
+command -v yq > /dev/null || {
+  echo "ERROR: yq not installed"
+  exit 1
+}
+command -v jq > /dev/null || {
+  echo "ERROR: jq not installed"
+  exit 1
+}
+command -v "$CRANE" > /dev/null || {
+  echo "ERROR: crane not installed (set CRANE=/path/to/crane if it is not on PATH)"
+  exit 1
+}
+[[ -f "$MANIFEST_FILE" ]] || {
+  echo "ERROR: ${MANIFEST_FILE} not found"
+  exit 1
+}
+
+# fail fast on malformed YAML; process substitution swallows yq errors otherwise.
+yq 'true' "$MANIFEST_FILE" > /dev/null
+
+# prevent CRANE_PLATFORM from resolving manifest-list digests to a
+# platform-specific digest and causing a false mismatch.
+unset CRANE_PLATFORM
+
+echodate "Verifying upstream existence of images in ${MANIFEST_FILE}..."
+
+pass=0
+fail=0
+failed_keys=()
+
+# one compact JSON object per line; fields parsed by name, not position.
+while IFS= read -r entry; do
+  key=$(jq -r '.key' <<< "$entry")
+  source=$(jq -r '.source' <<< "$entry")
+  tag=$(jq -r '.tag' <<< "$entry")
+  version=$(jq -r '.version' <<< "$entry")
+  ref="${source}@${version}"
+  tag_ref="${source}:${tag}"
+  echodate "Checking ${key} -> ${ref}"
+
+  # crane digest is cheaper than manifest: it only resolves the digest,
+  # without downloading and printing the manifest body.
+  resolved=$("$CRANE" digest "$ref" 2> /tmp/crane.err) || {
+    err=$(cat /tmp/crane.err)
+    echodate "  FAIL ${key}: crane digest failed for ${ref}: ${err}"
+    fail=$((fail + 1))
+    failed_keys+=("$key")
+    continue
+  }
+
+  # anti-tamper: resolving by digest must return the same digest back.
+  if [[ "$resolved" != "$version" ]]; then
+    echodate "  FAIL ${key}: digest mismatch. expected=${version} got=${resolved}"
+    fail=$((fail + 1))
+    failed_keys+=("$key")
+    continue
+  fi
+
+  # tag-to-digest anti-tamper: the human-readable tag we publish to the mirror
+  # must still resolve to the pinned digest upstream. catches stale tag/version
+  # pairs and upstream tag-remappings -- otherwise the mirror would publish
+  # divergent content under a name implying upstream parity.
+  resolved_tag=$("$CRANE" digest "$tag_ref" 2> /tmp/crane.err) || {
+    err=$(cat /tmp/crane.err)
+    echodate "  FAIL ${key}: crane digest failed for ${tag_ref}: ${err}"
+    fail=$((fail + 1))
+    failed_keys+=("$key")
+    continue
+  }
+
+  if [[ "$resolved_tag" != "$version" ]]; then
+    echodate "  FAIL ${key}: tag/digest mismatch. ${tag_ref} resolves to ${resolved_tag}, expected ${version}"
+    fail=$((fail + 1))
+    failed_keys+=("$key")
+    continue
+  fi
+
+  echodate "  PASS ${key}"
+  pass=$((pass + 1))
+done < <(yq -o=json '.images' "$MANIFEST_FILE" | jq -c 'to_entries[] | {key: .key, source: .value.source, tag: .value.tag, version: .value.version}')
+
+echodate "Summary: ${pass} passed, ${fail} failed"
+
+# silent-success guard: if the loop never ran (empty .images, malformed YAML
+# slipping past the early parse check, missing .images key), the script would
+# otherwise exit 0 with nothing verified.
+if [[ "$pass" -eq 0 && "$fail" -eq 0 ]]; then
+  echo "ERROR: no entries verified -- check that ${MANIFEST_FILE} contains a non-empty .images map"
+  exit 1
+fi
+
+if [[ "$fail" -gt 0 ]]; then
+  echodate "Failed entries:"
+  for k in "${failed_keys[@]}"; do
+    echodate "  - ${k}"
+  done
+  exit 1
+fi
+
+exit 0

--- a/hack/mirror-images.sh
+++ b/hack/mirror-images.sh
@@ -79,10 +79,27 @@ image_exists_in_registry() {
 }
 
 # --- Mirror one image --------------------------------------------------------
+# Pulls upstream by digest (anti-tamper) and pushes to the mirror under the
+# human-readable tag so the image is visible in the Quay UI. crane copy of a
+# digest reference to a tag reference produces both a tagged manifest and the
+# same digest-addressable manifest, so digest pulls keep working.
 mirror_image() {
-  local key="$1" source="$2" version="$3"
+  local key="$1" source="$2" tag="$3" version="$4"
+
+  # guard against empty fields. yq emits the literal "null" for missing keys
+  # and "read" leaves missing trailing fields as empty strings -- neither trips
+  # set -u. an empty tag would push to "<key>:" which crane silently rewrites
+  # to "<key>:latest", polluting the registry under an undeclared tag.
+  for field in key source tag version; do
+    local value="${!field}"
+    if [[ -z "$value" || "$value" == "null" ]]; then
+      echo "ERROR: empty or null ${field} field for entry '${key}'" >&2
+      return 1
+    fi
+  done
+
   local src="${source}@${version}"
-  local dst="${REGISTRY_HOST}/${REPOSITORY_PREFIX}/${key}@${version}"
+  local dst="${REGISTRY_HOST}/${REPOSITORY_PREFIX}/${key}:${tag}"
 
   echodate "Mirroring ${key}:"
   echodate "  source:      ${src}"
@@ -98,7 +115,7 @@ mirror_image() {
 
 # --- Read manifest -----------------------------------------------------------
 read_manifest() {
-  yq -r '.images | to_entries[] | [.key, .value.source, .value.version] | @tsv' "$MANIFEST_FILE"
+  yq -r '.images | to_entries[] | [.key, .value.source, .value.tag, .value.version] | @tsv' "$MANIFEST_FILE"
 }
 
 # --- Main --------------------------------------------------------------------
@@ -120,12 +137,18 @@ main() {
     export PATH="${PATH}:$(go env GOPATH)/bin"
   }
 
+  # preflight: verify every upstream digest resolves and matches the manifest
+  # before touching the mirror. anti-tamper.
+  echodate "Running preflight verification of upstream images..."
+  MANIFEST_FILE="$MANIFEST_FILE" hack/ci/verify-mirror-images-exist.sh
+  echodate "Preflight passed."
+
   local only_key="${1:-}"
   login_registry
 
-  while IFS=$'\t' read -r key source version; do
+  while IFS=$'\t' read -r key source tag version; do
     if [[ -n "$only_key" && "$key" != "$only_key" ]]; then continue; fi
-    mirror_image "$key" "$source" "$version"
+    mirror_image "$key" "$source" "$tag" "$version"
   done < <(read_manifest)
 }
 

--- a/hack/mirror-images.sh
+++ b/hack/mirror-images.sh
@@ -58,9 +58,12 @@ login_vault() {
 }
 
 # --- Registry login ----------------------------------------------------------
+# Resolves push credentials from the secret store when not already provided
+# via env. QUAY_IO_USERNAME/QUAY_IO_PASSWORD must NOT be pre-populated by the
+# job spec with credentials scoped to a different organization -- doing so
+# bypasses this lookup and causes pushes to fail with 403 UNAUTHORIZED.
 login_registry() {
   if [ -z "${QUAY_IO_USERNAME:-}" ] || [ -z "${QUAY_IO_PASSWORD:-}" ]; then
-    echo "WARNING: Using read-only ${REGISTRY_HOST} registry credentials from Vault -- for local testing only!"
     login_vault
     : "${QUAY_IO_USERNAME:=$(vault kv get -field=username dev/kubermatic-mirror-quay.io)}"
     : "${QUAY_IO_PASSWORD:=$(vault kv get -field=password dev/kubermatic-mirror-quay.io)}"

--- a/pkg/mirror/mirror-images.yaml
+++ b/pkg/mirror/mirror-images.yaml
@@ -12,37 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Images mirrored to quay.io/kubermatic-mirror/images/<key>@<version>.
+# Images mirrored to quay.io/kubermatic-mirror/images/<key>:<tag>.
 #
 # - `source`: upstream registry path. Must NOT include a tag or digest (no ":", no "@").
 # - `version`: must be a sha256 digest (sha256:<64-hex>). Tags, semver, "latest" forbidden.
-# - The comment above each entry records the human-readable tag the digest was resolved from
-#   (use `crane digest <source>:<tag>` to resolve). The comment is informational only.
+#   The upstream pull is always by digest (anti-tamper).
+# - `tag`: the human-readable tag that resolves to `version` upstream. The mirrored image
+#   is published under this tag in quay.io/kubermatic-mirror so it is browsable in the
+#   Quay UI. Format is whatever upstream uses (semver, git commit SHA, etc.) -- must
+#   match the OCI tag regex [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}.
 # - The map key (e.g. "tinkerbell/actions/cexec") becomes the destination path segment
 #   under quay.io/kubermatic-mirror/images/.
 
 images:
   alpine:
     source: docker.io/library/alpine
-    # alpine:3.23
+    tag: "3.23"
     version: sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
   tinkerbell/actions/image2disk:
     source: quay.io/tinkerbell/actions/image2disk
-    # 2a7c298fe0292737371ca11913e3c0c3bf794981
+    tag: "2a7c298fe0292737371ca11913e3c0c3bf794981"
     version: sha256:4df1274b1a14757fca4b9648429d698336d14e58ff2142cd7f61270590d99db4
 
   tinkerbell/actions/cexec:
     source: quay.io/tinkerbell/actions/cexec
-    # 2a7c298fe0292737371ca11913e3c0c3bf794981
+    tag: "2a7c298fe0292737371ca11913e3c0c3bf794981"
     version: sha256:86d490ea9d5a27d0d11c1df812fdec49877e58e5076c4d5c0417d1a6dac530a9
 
   tinkerbell/actions/writefile:
     source: quay.io/tinkerbell/actions/writefile
-    # 2a7c298fe0292737371ca11913e3c0c3bf794981
+    tag: "2a7c298fe0292737371ca11913e3c0c3bf794981"
     version: sha256:bd3dcbf4c4a302025013bd552cc007658794d3953bdb870b952ff7a83eac3ca6
 
   jacobweinstock/waitdaemon:
     source: ghcr.io/jacobweinstock/waitdaemon
-    # 0.4.3
+    tag: "0.4.3"
     version: sha256:8535eca0df48bb46f523b6a3ec3d9fff925212777f1a2be56436a62495ee1e79


### PR DESCRIPTION
**What this PR does / why we need it**:
Mirror images to `quay.io/kubermatic-mirror` under human-readable tags instead of digest-only destinations, making them browsable in the Quay UI. Adds a `tag` field to the manifest, a preflight verification script that validates tag-to-digest mappings upstream, and anti-tamper guards.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:
The source pull remains digest-pinned; crane copy preserves the digest-addressable manifest so existing digest-based pulls keep working. The Go code in `pkg/mirror/mirror.go` is unaffected - it still constructs `@sha256:...` references.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
