### PR TITLE
[release/v1.65] Update tinkerbell images

### DIFF
--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -45,6 +45,27 @@ postsubmits:
               cpu: 2
               memory: 1Gi
 
+  - name: post-machine-controller-mirror-images
+    run_if_changed: "^(pkg/mirror/mirror-images\\.yaml|hack/mirror-images\\.sh)$"
+    branches:
+      - ^main$
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    path_alias: k8c.io/machine-controller
+    labels:
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-push-kubermatic: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8
+          command:
+            - "./hack/mirror-images.sh"
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 200m
+
   - name: ci-push-machine-controller-upload-gocache
     always_run: true
     decorate: true

--- a/.prow/postsubmits.yaml
+++ b/.prow/postsubmits.yaml
@@ -45,6 +45,11 @@ postsubmits:
               cpu: 2
               memory: 1Gi
 
+  # Do not add any preset that injects QUAY_IO_USERNAME or QUAY_IO_PASSWORD
+  # here. hack/mirror-images.sh resolves push credentials at runtime and only
+  # does so when those variables are unset; pre-populating them with creds
+  # scoped to a different organization causes the script to skip credential
+  # resolution and push attempts will fail with 403 UNAUTHORIZED.
   - name: post-machine-controller-mirror-images
     run_if_changed: "^(pkg/mirror/mirror-images\\.yaml|hack/mirror-images\\.sh)$"
     branches:
@@ -55,7 +60,6 @@ postsubmits:
     labels:
       preset-vault: "true"
       preset-docker-mirror: "true"
-      preset-docker-push-kubermatic: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.25-node-22-kind-0.30-8

--- a/.prow/verify.yaml
+++ b/.prow/verify.yaml
@@ -13,6 +13,22 @@
 # limitations under the License.
 
 presubmits:
+  - name: pull-machine-controller-validate-mirror-images
+    always_run: false
+    run_if_changed: "^pkg/mirror/mirror-images\\.yaml$"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/machine-controller.git"
+    path_alias: k8c.io/machine-controller
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.25-node-22-8
+          command:
+            - "./hack/ci/validate-mirror-images.sh"
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+
   - name: pull-machine-controller-build
     always_run: true
     decorate: true

--- a/hack/ci/validate-mirror-images.sh
+++ b/hack/ci/validate-mirror-images.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Machine Controller Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+source hack/lib.sh
+
+MANIFEST_FILE="${MANIFEST_FILE:-pkg/mirror/mirror-images.yaml}"
+SHA_RE='^sha256:[a-f0-9]{64}$'
+
+echodate "Validating ${MANIFEST_FILE}..."
+
+command -v yq > /dev/null || {
+  echo "ERROR: yq not installed"
+  exit 1
+}
+[[ -f "$MANIFEST_FILE" ]] || {
+  echo "ERROR: ${MANIFEST_FILE} not found"
+  exit 1
+}
+
+# .images must exist and have at least one entry.
+count=$(yq '.images | length' "$MANIFEST_FILE")
+if [[ "$count" == "0" || "$count" == "null" ]]; then
+  echo "ERROR: ${MANIFEST_FILE} has no .images entries"
+  exit 1
+fi
+echodate "  ${count} entries found"
+
+# every entry needs both source and version fields.
+missing=$(yq -r '.images | to_entries[] | select(.value.source == null or .value.version == null) | .key' "$MANIFEST_FILE")
+if [[ -n "$missing" ]]; then
+  echo "ERROR: entries missing source or version:"
+  echo "$missing" | sed 's/^/  - /'
+  exit 1
+fi
+
+# source is a bare registry path -- no tags or digests allowed.
+bad_sources=$(yq -r '.images | to_entries[] | [.key, .value.source] | @tsv' "$MANIFEST_FILE" |
+  awk -F'\t' '$2 ~ /[:@]/ { print $1 " -> " $2 }')
+if [[ -n "$bad_sources" ]]; then
+  echo "ERROR: source field must be a bare registry path (no tag, no digest):"
+  echo "$bad_sources" | sed 's/^/  - /'
+  exit 1
+fi
+
+# version must be an explicit sha256 digest -- tags and "latest" are forbidden.
+bad_versions=$(yq -r '.images | to_entries[] | [.key, .value.version] | @tsv' "$MANIFEST_FILE" |
+  awk -F'\t' -v re="$SHA_RE" '$2 !~ re { print $1 " -> " $2 }')
+if [[ -n "$bad_versions" ]]; then
+  echo "ERROR: version must be sha256:<64-hex>. Found:"
+  echo "$bad_versions" | sed 's/^/  - /'
+  echo
+  echo "Resolve the upstream tag to its digest with:"
+  echo "  crane digest <source>:<tag>"
+  echo
+  echo "Tags (latest, semver, branch names) are forbidden by policy."
+  exit 1
+fi
+
+echodate "All ${MANIFEST_FILE} entries use sha256 digests."

--- a/hack/ci/validate-mirror-images.sh
+++ b/hack/ci/validate-mirror-images.sh
@@ -21,15 +21,36 @@ source hack/lib.sh
 
 MANIFEST_FILE="${MANIFEST_FILE:-pkg/mirror/mirror-images.yaml}"
 SHA_RE='^sha256:[a-f0-9]{64}$'
+# OCI distribution spec: tag must match [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}.
+TAG_RE='^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$'
 
 echodate "Validating ${MANIFEST_FILE}..."
 
+# Ensure yq is installed
 command -v yq > /dev/null || {
-  echo "ERROR: yq not installed"
+  echo "ERROR: yq not installed."
   exit 1
 }
+
+# Ensure we are using mikefarah/yq (Go version), not kislyuk/yq (Python version)
+if yq --version 2>&1 | grep -q "jq wrapper"; then
+  echo "ERROR: Detected Python 'yq' (kislyuk/yq). This script requires the Go version of 'yq' (mikefarah/yq v4+)."
+  exit 1
+fi
+
 [[ -f "$MANIFEST_FILE" ]] || {
   echo "ERROR: ${MANIFEST_FILE} not found"
+  exit 1
+}
+
+# fail fast on malformed YAML; process substitution swallows yq errors otherwise.
+yq 'true' "$MANIFEST_FILE" > /dev/null
+
+fail_if() {
+  local message="$1" offenders="$2"
+  [[ -z "$offenders" ]] && return 0
+  echo "ERROR: ${message}"
+  echo "$offenders" | sed 's/^/  - /'
   exit 1
 }
 
@@ -41,26 +62,29 @@ if [[ "$count" == "0" || "$count" == "null" ]]; then
 fi
 echodate "  ${count} entries found"
 
-# every entry needs both source and version fields.
-missing=$(yq -r '.images | to_entries[] | select(.value.source == null or .value.version == null) | .key' "$MANIFEST_FILE")
-if [[ -n "$missing" ]]; then
-  echo "ERROR: entries missing source or version:"
-  echo "$missing" | sed 's/^/  - /'
-  exit 1
-fi
+# every entry needs source, tag, and version fields. MUST run before the
+# regex checks below: yq's test() crashes on null values.
+missing=$(yq -r '
+  .images | to_entries[]
+  | select(.value.source == null or .value.tag == null or .value.version == null)
+  | .key
+' "$MANIFEST_FILE")
+fail_if "entries missing source, tag, or version:" "$missing"
 
 # source is a bare registry path -- no tags or digests allowed.
-bad_sources=$(yq -r '.images | to_entries[] | [.key, .value.source] | @tsv' "$MANIFEST_FILE" |
-  awk -F'\t' '$2 ~ /[:@]/ { print $1 " -> " $2 }')
-if [[ -n "$bad_sources" ]]; then
-  echo "ERROR: source field must be a bare registry path (no tag, no digest):"
-  echo "$bad_sources" | sed 's/^/  - /'
-  exit 1
-fi
+bad_sources=$(yq -r '
+  .images | to_entries[]
+  | select(.value.source | test("[:@]"))
+  | .key + " -> " + .value.source
+' "$MANIFEST_FILE")
+fail_if "source field must be a bare registry path (no tag, no digest):" "$bad_sources"
 
 # version must be an explicit sha256 digest -- tags and "latest" are forbidden.
-bad_versions=$(yq -r '.images | to_entries[] | [.key, .value.version] | @tsv' "$MANIFEST_FILE" |
-  awk -F'\t' -v re="$SHA_RE" '$2 !~ re { print $1 " -> " $2 }')
+bad_versions=$(yq -r "
+  .images | to_entries[]
+  | select(.value.version | test(\"$SHA_RE\") | not)
+  | .key + \" -> \" + .value.version
+" "$MANIFEST_FILE")
 if [[ -n "$bad_versions" ]]; then
   echo "ERROR: version must be sha256:<64-hex>. Found:"
   echo "$bad_versions" | sed 's/^/  - /'
@@ -72,4 +96,12 @@ if [[ -n "$bad_versions" ]]; then
   exit 1
 fi
 
-echodate "All ${MANIFEST_FILE} entries use sha256 digests."
+# tag must match the OCI distribution tag regex.
+bad_tags=$(yq -r "
+  .images | to_entries[]
+  | select(.value.tag | test(\"$TAG_RE\") | not)
+  | .key + \" -> \" + .value.tag
+" "$MANIFEST_FILE")
+fail_if "tag must match [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}. Found:" "$bad_tags"
+
+echodate "All ${MANIFEST_FILE} entries use valid sha256 digests and tags."

--- a/hack/ci/verify-mirror-images-exist.sh
+++ b/hack/ci/verify-mirror-images-exist.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Machine Controller Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+source hack/lib.sh
+
+MANIFEST_FILE="${MANIFEST_FILE:-pkg/mirror/mirror-images.yaml}"
+CRANE="${CRANE:-crane}"
+
+command -v yq > /dev/null || {
+  echo "ERROR: yq not installed"
+  exit 1
+}
+command -v jq > /dev/null || {
+  echo "ERROR: jq not installed"
+  exit 1
+}
+command -v "$CRANE" > /dev/null || {
+  echo "ERROR: crane not installed (set CRANE=/path/to/crane if it is not on PATH)"
+  exit 1
+}
+[[ -f "$MANIFEST_FILE" ]] || {
+  echo "ERROR: ${MANIFEST_FILE} not found"
+  exit 1
+}
+
+# fail fast on malformed YAML; process substitution swallows yq errors otherwise.
+yq 'true' "$MANIFEST_FILE" > /dev/null
+
+# prevent CRANE_PLATFORM from resolving manifest-list digests to a
+# platform-specific digest and causing a false mismatch.
+unset CRANE_PLATFORM
+
+echodate "Verifying upstream existence of images in ${MANIFEST_FILE}..."
+
+pass=0
+fail=0
+failed_keys=()
+
+# one compact JSON object per line; fields parsed by name, not position.
+while IFS= read -r entry; do
+  key=$(jq -r '.key' <<< "$entry")
+  source=$(jq -r '.source' <<< "$entry")
+  tag=$(jq -r '.tag' <<< "$entry")
+  version=$(jq -r '.version' <<< "$entry")
+  ref="${source}@${version}"
+  tag_ref="${source}:${tag}"
+  echodate "Checking ${key} -> ${ref}"
+
+  # crane digest is cheaper than manifest: it only resolves the digest,
+  # without downloading and printing the manifest body.
+  resolved=$("$CRANE" digest "$ref" 2> /tmp/crane.err) || {
+    err=$(cat /tmp/crane.err)
+    echodate "  FAIL ${key}: crane digest failed for ${ref}: ${err}"
+    fail=$((fail + 1))
+    failed_keys+=("$key")
+    continue
+  }
+
+  # anti-tamper: resolving by digest must return the same digest back.
+  if [[ "$resolved" != "$version" ]]; then
+    echodate "  FAIL ${key}: digest mismatch. expected=${version} got=${resolved}"
+    fail=$((fail + 1))
+    failed_keys+=("$key")
+    continue
+  fi
+
+  # tag-to-digest anti-tamper: the human-readable tag we publish to the mirror
+  # must still resolve to the pinned digest upstream. catches stale tag/version
+  # pairs and upstream tag-remappings -- otherwise the mirror would publish
+  # divergent content under a name implying upstream parity.
+  resolved_tag=$("$CRANE" digest "$tag_ref" 2> /tmp/crane.err) || {
+    err=$(cat /tmp/crane.err)
+    echodate "  FAIL ${key}: crane digest failed for ${tag_ref}: ${err}"
+    fail=$((fail + 1))
+    failed_keys+=("$key")
+    continue
+  }
+
+  if [[ "$resolved_tag" != "$version" ]]; then
+    echodate "  FAIL ${key}: tag/digest mismatch. ${tag_ref} resolves to ${resolved_tag}, expected ${version}"
+    fail=$((fail + 1))
+    failed_keys+=("$key")
+    continue
+  fi
+
+  echodate "  PASS ${key}"
+  pass=$((pass + 1))
+done < <(yq -o=json '.images' "$MANIFEST_FILE" | jq -c 'to_entries[] | {key: .key, source: .value.source, tag: .value.tag, version: .value.version}')
+
+echodate "Summary: ${pass} passed, ${fail} failed"
+
+# silent-success guard: if the loop never ran (empty .images, malformed YAML
+# slipping past the early parse check, missing .images key), the script would
+# otherwise exit 0 with nothing verified.
+if [[ "$pass" -eq 0 && "$fail" -eq 0 ]]; then
+  echo "ERROR: no entries verified -- check that ${MANIFEST_FILE} contains a non-empty .images map"
+  exit 1
+fi
+
+if [[ "$fail" -gt 0 ]]; then
+  echodate "Failed entries:"
+  for k in "${failed_keys[@]}"; do
+    echodate "  - ${k}"
+  done
+  exit 1
+fi
+
+exit 0

--- a/hack/mirror-images.sh
+++ b/hack/mirror-images.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Machine Controller Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+# Defaults; environment may override.
+REGISTRY_HOST="${REGISTRY_HOST:-quay.io}"
+REPOSITORY_PREFIX="${REPOSITORY_PREFIX:-kubermatic-mirror/images}"
+MANIFEST_FILE="${MANIFEST_FILE:-pkg/mirror/mirror-images.yaml}"
+
+set -u
+
+# --- Usage -------------------------------------------------------------------
+usage() {
+  echo "Usage: $0 [image-key]"
+  echo "  With no args, mirrors all images defined in ${MANIFEST_FILE}."
+  echo "  With a key, mirrors only that one image."
+  echo
+  echo "Environment overrides: REGISTRY_HOST, REPOSITORY_PREFIX, MANIFEST_FILE,"
+  echo "                       QUAY_IO_USERNAME, QUAY_IO_PASSWORD (skip Vault)."
+  exit 1
+}
+
+# --- Vault login -------------------------------------------------------------
+login_vault() {
+  if [ -z "${VAULT_ADDR:-}" ]; then
+    export VAULT_ADDR=https://vault.kubermatic.com/
+  fi
+
+  if [ -n "${VAULT_TOKEN:-}" ] || vault token lookup &> /dev/null; then
+    return 0
+  fi
+
+  if [ -z "${VAULT_ROLE_ID:-}" ] || [ -z "${VAULT_SECRET_ID:-}" ]; then
+    echo "Logging into Vault interactively using OIDC"
+    vault login --method=oidc --path="${VAULT_OIDC_AUTH_PATH:-loodse}"
+    return 0
+  fi
+
+  echo "Logging into Vault using prow CI credentials"
+  local token
+  token=$(vault write --format=json auth/approle/login "role_id=$VAULT_ROLE_ID" "secret_id=$VAULT_SECRET_ID" | jq -r '.auth.client_token')
+
+  export VAULT_TOKEN="$token"
+}
+
+# --- Registry login ----------------------------------------------------------
+login_registry() {
+  if [ -z "${QUAY_IO_USERNAME:-}" ] || [ -z "${QUAY_IO_PASSWORD:-}" ]; then
+    echo "WARNING: Using read-only ${REGISTRY_HOST} registry credentials from Vault -- for local testing only!"
+    login_vault
+    : "${QUAY_IO_USERNAME:=$(vault kv get -field=username dev/kubermatic-mirror-quay.io)}"
+    : "${QUAY_IO_PASSWORD:=$(vault kv get -field=password dev/kubermatic-mirror-quay.io)}"
+  fi
+
+  crane auth login "${REGISTRY_HOST}" --username "${QUAY_IO_USERNAME}" --password-stdin <<< "${QUAY_IO_PASSWORD}"
+}
+
+# --- Existence check ---------------------------------------------------------
+image_exists_in_registry() {
+  local dst="$1"
+  crane manifest "$dst" > /dev/null 2>&1
+}
+
+# --- Mirror one image --------------------------------------------------------
+mirror_image() {
+  local key="$1" source="$2" version="$3"
+  local src="${source}@${version}"
+  local dst="${REGISTRY_HOST}/${REPOSITORY_PREFIX}/${key}@${version}"
+
+  echodate "Mirroring ${key}:"
+  echodate "  source:      ${src}"
+  echodate "  destination: ${dst}"
+
+  if image_exists_in_registry "$dst"; then
+    echodate "  -> already mirrored, skipping"
+    return 0
+  fi
+  crane copy "$src" "$dst"
+  echodate "  -> done"
+}
+
+# --- Read manifest -----------------------------------------------------------
+read_manifest() {
+  yq -r '.images | to_entries[] | [.key, .value.source, .value.version] | @tsv' "$MANIFEST_FILE"
+}
+
+# --- Main --------------------------------------------------------------------
+main() {
+  cd "$(dirname "$0")/.."
+  source hack/lib.sh
+
+  [[ -f "$MANIFEST_FILE" ]] || {
+    echo "ERROR: ${MANIFEST_FILE} not found"
+    exit 1
+  }
+  command -v yq > /dev/null || {
+    echo "ERROR: yq not installed"
+    exit 1
+  }
+  command -v crane > /dev/null || {
+    echo "Installing crane..."
+    go install github.com/google/go-containerregistry/cmd/crane@latest
+    export PATH="${PATH}:$(go env GOPATH)/bin"
+  }
+
+  local only_key="${1:-}"
+  login_registry
+
+  while IFS=$'\t' read -r key source version; do
+    if [[ -n "$only_key" && "$key" != "$only_key" ]]; then continue; fi
+    mirror_image "$key" "$source" "$version"
+  done < <(read_manifest)
+}
+
+# Sourceable guard -- matches kubermatic/hack/mirror-application-charts.sh.
+# When sourced, expose functions without triggering login or mirroring.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/hack/mirror-images.sh
+++ b/hack/mirror-images.sh
@@ -58,9 +58,12 @@ login_vault() {
 }
 
 # --- Registry login ----------------------------------------------------------
+# Resolves push credentials from the secret store when not already provided
+# via env. QUAY_IO_USERNAME/QUAY_IO_PASSWORD must NOT be pre-populated by the
+# job spec with credentials scoped to a different organization -- doing so
+# bypasses this lookup and causes pushes to fail with 403 UNAUTHORIZED.
 login_registry() {
   if [ -z "${QUAY_IO_USERNAME:-}" ] || [ -z "${QUAY_IO_PASSWORD:-}" ]; then
-    echo "WARNING: Using read-only ${REGISTRY_HOST} registry credentials from Vault -- for local testing only!"
     login_vault
     : "${QUAY_IO_USERNAME:=$(vault kv get -field=username dev/kubermatic-mirror-quay.io)}"
     : "${QUAY_IO_PASSWORD:=$(vault kv get -field=password dev/kubermatic-mirror-quay.io)}"
@@ -76,10 +79,27 @@ image_exists_in_registry() {
 }
 
 # --- Mirror one image --------------------------------------------------------
+# Pulls upstream by digest (anti-tamper) and pushes to the mirror under the
+# human-readable tag so the image is visible in the Quay UI. crane copy of a
+# digest reference to a tag reference produces both a tagged manifest and the
+# same digest-addressable manifest, so digest pulls keep working.
 mirror_image() {
-  local key="$1" source="$2" version="$3"
+  local key="$1" source="$2" tag="$3" version="$4"
+
+  # guard against empty fields. yq emits the literal "null" for missing keys
+  # and "read" leaves missing trailing fields as empty strings -- neither trips
+  # set -u. an empty tag would push to "<key>:" which crane silently rewrites
+  # to "<key>:latest", polluting the registry under an undeclared tag.
+  for field in key source tag version; do
+    local value="${!field}"
+    if [[ -z "$value" || "$value" == "null" ]]; then
+      echo "ERROR: empty or null ${field} field for entry '${key}'" >&2
+      return 1
+    fi
+  done
+
   local src="${source}@${version}"
-  local dst="${REGISTRY_HOST}/${REPOSITORY_PREFIX}/${key}@${version}"
+  local dst="${REGISTRY_HOST}/${REPOSITORY_PREFIX}/${key}:${tag}"
 
   echodate "Mirroring ${key}:"
   echodate "  source:      ${src}"
@@ -95,7 +115,7 @@ mirror_image() {
 
 # --- Read manifest -----------------------------------------------------------
 read_manifest() {
-  yq -r '.images | to_entries[] | [.key, .value.source, .value.version] | @tsv' "$MANIFEST_FILE"
+  yq -r '.images | to_entries[] | [.key, .value.source, .value.tag, .value.version] | @tsv' "$MANIFEST_FILE"
 }
 
 # --- Main --------------------------------------------------------------------
@@ -117,12 +137,18 @@ main() {
     export PATH="${PATH}:$(go env GOPATH)/bin"
   }
 
+  # preflight: verify every upstream digest resolves and matches the manifest
+  # before touching the mirror. anti-tamper.
+  echodate "Running preflight verification of upstream images..."
+  MANIFEST_FILE="$MANIFEST_FILE" hack/ci/verify-mirror-images-exist.sh
+  echodate "Preflight passed."
+
   local only_key="${1:-}"
   login_registry
 
-  while IFS=$'\t' read -r key source version; do
+  while IFS=$'\t' read -r key source tag version; do
     if [[ -n "$only_key" && "$key" != "$only_key" ]]; then continue; fi
-    mirror_image "$key" "$source" "$version"
+    mirror_image "$key" "$source" "$tag" "$version"
   done < <(read_manifest)
 }
 

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template.go
@@ -23,6 +23,8 @@ import (
 	tinkv1alpha1 "github.com/tinkerbell/tink/api/v1alpha1"
 	"gopkg.in/yaml.v3"
 
+	"k8c.io/machine-controller/pkg/mirror"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -172,7 +174,7 @@ echo "All partitions on ${disks} have been wiped."
 `
 	return Action{
 		Name:    "wipe-disk",
-		Image:   "alpine:3.23",
+		Image:   mirror.Image("alpine"),
 		Timeout: 600,
 		Command: []string{"/bin/sh", "-c", wipeScript},
 	}
@@ -181,7 +183,7 @@ echo "All partitions on ${disks} have been wiped."
 func createStreamUbuntuImageAction(destDisk, osImageURL string) Action {
 	return Action{
 		Name:    "stream-ubuntu-image",
-		Image:   "quay.io/tinkerbell-actions/image2disk:v1.0.0",
+		Image:   mirror.Image("tinkerbell/actions/image2disk"),
 		Timeout: 600,
 		Environment: map[string]string{
 			"DEST_DISK":  destDisk,
@@ -194,7 +196,7 @@ func createStreamUbuntuImageAction(destDisk, osImageURL string) Action {
 func createGrowPartitionAction(destDisk string) Action {
 	return Action{
 		Name:    "grow-partition",
-		Image:   "quay.io/tinkerbell/actions/cexec:c5bde803d9f6c90f1a9d5e06930d856d1481854c",
+		Image:   mirror.Image("tinkerbell/actions/cexec"),
 		Timeout: 90,
 		Environment: map[string]string{
 			"BLOCK_DEVICE":        "{{ formatPartition ( index .Hardware.Disks 0 ) (.partition_number | int) }}",
@@ -224,7 +226,7 @@ network:
         via: {{.default_route}}`
 	return Action{
 		Name:    "add-netplan-config",
-		Image:   "quay.io/tinkerbell-actions/writefile:v1.0.0",
+		Image:   mirror.Image("tinkerbell/actions/writefile"),
 		Timeout: 90,
 		Environment: map[string]string{
 			"DEST_DISK": "{{ formatPartition ( index .Hardware.Disks 0 ) (.partition_number | int) }}",
@@ -249,7 +251,7 @@ echo 'local-hostname: {{.hardware_name}}' >> /var/lib/cloud/seed/nocloud/meta-da
 
 	return Action{
 		Name:    "configure-cloud-init",
-		Image:   "quay.io/tinkerbell-actions/cexec:v1.0.0",
+		Image:   mirror.Image("tinkerbell/actions/cexec"),
 		Timeout: 90,
 		Environment: map[string]string{
 			"BLOCK_DEVICE":        "{{ formatPartition ( index .Hardware.Disks 0 ) (.partition_number | int) }}",
@@ -264,7 +266,7 @@ echo 'local-hostname: {{.hardware_name}}' >> /var/lib/cloud/seed/nocloud/meta-da
 func decodeCloudInitFile(hardwareName string) Action {
 	return Action{
 		Name:    "decode-cloud-init-file",
-		Image:   "quay.io/tinkerbell/actions/cexec:latest",
+		Image:   mirror.Image("tinkerbell/actions/cexec"),
 		Timeout: 90,
 		Environment: map[string]string{
 			"BLOCK_DEVICE":        "{{ formatPartition ( index .Hardware.Disks 0 ) (.partition_number | int) }}",
@@ -279,12 +281,12 @@ func decodeCloudInitFile(hardwareName string) Action {
 func createRebootAction() Action {
 	return Action{
 		Name:    "reboot-action",
-		Image:   "ghcr.io/jacobweinstock/waitdaemon:0.1.1",
+		Image:   mirror.Image("jacobweinstock/waitdaemon"),
 		Pid:     "host",
 		Timeout: 90,
 		Command: []string{"reboot"},
 		Environment: map[string]string{
-			"IMAGE":        "alpine",
+			"IMAGE":        mirror.Image("alpine"),
 			"WAIT_SECONDS": "10",
 		},
 		Volumes: []string{

--- a/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template_test.go
+++ b/pkg/cloudprovider/provider/baremetal/plugins/tinkerbell/client/template_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"k8c.io/machine-controller/pkg/mirror"
+)
+
+// tinkerbellImageKeys lists every manifest key Tinkerbell's template.go
+// references. The test asserts each one resolves through pkg/mirror -- if
+// a key disappears from the manifest, the production init() panic would
+// surface only when ProvisionServer runs. Catch it here instead.
+var tinkerbellImageKeys = []string{
+	"alpine",
+	"tinkerbell/actions/image2disk",
+	"tinkerbell/actions/cexec",
+	"tinkerbell/actions/writefile",
+	"jacobweinstock/waitdaemon",
+}
+
+func TestTinkerbellImagesResolve(t *testing.T) {
+	for _, key := range tinkerbellImageKeys {
+		got := mirror.Image(key)
+		want := "quay.io/kubermatic-mirror/images/" + key + "@sha256:"
+		if !strings.HasPrefix(got, want) {
+			t.Errorf("mirror.Image(%q) = %q, want prefix %q", key, got, want)
+		}
+	}
+}

--- a/pkg/mirror/mirror-images.yaml
+++ b/pkg/mirror/mirror-images.yaml
@@ -1,0 +1,48 @@
+# Copyright 2026 The Machine Controller Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Images mirrored to quay.io/kubermatic-mirror/images/<key>@<version>.
+#
+# - `source`: upstream registry path. Must NOT include a tag or digest (no ":", no "@").
+# - `version`: must be a sha256 digest (sha256:<64-hex>). Tags, semver, "latest" forbidden.
+# - The comment above each entry records the human-readable tag the digest was resolved from
+#   (use `crane digest <source>:<tag>` to resolve). The comment is informational only.
+# - The map key (e.g. "tinkerbell/actions/cexec") becomes the destination path segment
+#   under quay.io/kubermatic-mirror/images/.
+
+images:
+  alpine:
+    source: docker.io/library/alpine
+    # alpine:3.23
+    version: sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+
+  tinkerbell/actions/image2disk:
+    source: quay.io/tinkerbell/actions/image2disk
+    # 2a7c298fe0292737371ca11913e3c0c3bf794981
+    version: sha256:4df1274b1a14757fca4b9648429d698336d14e58ff2142cd7f61270590d99db4
+
+  tinkerbell/actions/cexec:
+    source: quay.io/tinkerbell/actions/cexec
+    # 2a7c298fe0292737371ca11913e3c0c3bf794981
+    version: sha256:86d490ea9d5a27d0d11c1df812fdec49877e58e5076c4d5c0417d1a6dac530a9
+
+  tinkerbell/actions/writefile:
+    source: quay.io/tinkerbell/actions/writefile
+    # 2a7c298fe0292737371ca11913e3c0c3bf794981
+    version: sha256:bd3dcbf4c4a302025013bd552cc007658794d3953bdb870b952ff7a83eac3ca6
+
+  jacobweinstock/waitdaemon:
+    source: ghcr.io/jacobweinstock/waitdaemon
+    # 0.4.3
+    version: sha256:8535eca0df48bb46f523b6a3ec3d9fff925212777f1a2be56436a62495ee1e79

--- a/pkg/mirror/mirror-images.yaml
+++ b/pkg/mirror/mirror-images.yaml
@@ -12,37 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Images mirrored to quay.io/kubermatic-mirror/images/<key>@<version>.
+# Images mirrored to quay.io/kubermatic-mirror/images/<key>:<tag>.
 #
 # - `source`: upstream registry path. Must NOT include a tag or digest (no ":", no "@").
 # - `version`: must be a sha256 digest (sha256:<64-hex>). Tags, semver, "latest" forbidden.
-# - The comment above each entry records the human-readable tag the digest was resolved from
-#   (use `crane digest <source>:<tag>` to resolve). The comment is informational only.
+#   The upstream pull is always by digest (anti-tamper).
+# - `tag`: the human-readable tag that resolves to `version` upstream. The mirrored image
+#   is published under this tag in quay.io/kubermatic-mirror so it is browsable in the
+#   Quay UI. Format is whatever upstream uses (semver, git commit SHA, etc.) -- must
+#   match the OCI tag regex [a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}.
 # - The map key (e.g. "tinkerbell/actions/cexec") becomes the destination path segment
 #   under quay.io/kubermatic-mirror/images/.
 
 images:
   alpine:
     source: docker.io/library/alpine
-    # alpine:3.23
+    tag: "3.23"
     version: sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
   tinkerbell/actions/image2disk:
     source: quay.io/tinkerbell/actions/image2disk
-    # 2a7c298fe0292737371ca11913e3c0c3bf794981
+    tag: "2a7c298fe0292737371ca11913e3c0c3bf794981"
     version: sha256:4df1274b1a14757fca4b9648429d698336d14e58ff2142cd7f61270590d99db4
 
   tinkerbell/actions/cexec:
     source: quay.io/tinkerbell/actions/cexec
-    # 2a7c298fe0292737371ca11913e3c0c3bf794981
+    tag: "2a7c298fe0292737371ca11913e3c0c3bf794981"
     version: sha256:86d490ea9d5a27d0d11c1df812fdec49877e58e5076c4d5c0417d1a6dac530a9
 
   tinkerbell/actions/writefile:
     source: quay.io/tinkerbell/actions/writefile
-    # 2a7c298fe0292737371ca11913e3c0c3bf794981
+    tag: "2a7c298fe0292737371ca11913e3c0c3bf794981"
     version: sha256:bd3dcbf4c4a302025013bd552cc007658794d3953bdb870b952ff7a83eac3ca6
 
   jacobweinstock/waitdaemon:
     source: ghcr.io/jacobweinstock/waitdaemon
-    # 0.4.3
+    tag: "0.4.3"
     version: sha256:8535eca0df48bb46f523b6a3ec3d9fff925212777f1a2be56436a62495ee1e79

--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mirror provides a single source of truth for container images
+// that the machine-controller mirrors from upstream registries to
+// quay.io/kubermatic-mirror. Providers import this package and call
+// Image(key) to resolve a manifest key to its fully qualified, digest-pinned
+// reference in the mirror.
+//
+// To add or update an image:
+//  1. Edit pkg/mirror/mirror-images.yaml.
+//  2. Reference the key from the provider code via mirror.Image("<key>").
+//  3. On merge to main, the post-machine-controller-mirror-images
+//     postsubmit pushes the image to the mirror registry.
+package mirror
+
+import (
+	_ "embed"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// registryPrefix is the destination registry path images are mirrored to.
+// Must match the prefix hack/mirror-images.sh writes to and the validator
+// at hack/ci/validate-mirror-images.sh checks against.
+const registryPrefix = "quay.io/kubermatic-mirror/images"
+
+//go:embed mirror-images.yaml
+var manifestBytes []byte
+
+type entry struct {
+	Source  string `yaml:"source"`
+	Version string `yaml:"version"`
+}
+
+type manifest struct {
+	Images map[string]entry `yaml:"images"`
+}
+
+var images map[string]entry
+
+func init() {
+	var m manifest
+	if err := yaml.Unmarshal(manifestBytes, &m); err != nil {
+		panic(fmt.Sprintf("mirror: failed to parse embedded mirror-images.yaml: %v", err))
+	}
+	if len(m.Images) == 0 {
+		panic("mirror: embedded mirror-images.yaml has no .images entries")
+	}
+	images = m.Images
+}
+
+// Image returns the fully qualified, digest-pinned mirror reference
+// for the given manifest key. Panics if the key is missing -- this is a
+// programming error and provisioning with a wrong image is a worse failure
+// mode than crashing at process start.
+func Image(key string) string {
+	e, ok := images[key]
+	if !ok {
+		panic(fmt.Sprintf("mirror: mirror-images.yaml has no entry for key %q", key))
+	}
+	return fmt.Sprintf("%s/%s@%s", registryPrefix, key, e.Version)
+}

--- a/pkg/mirror/mirror_test.go
+++ b/pkg/mirror/mirror_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mirror
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestManifestEmbedded(t *testing.T) {
+	if len(images) == 0 {
+		t.Fatal("expected embedded mirror-images.yaml to populate images map")
+	}
+}
+
+func TestImageReturnsMirrorReference(t *testing.T) {
+	var anyKey string
+	for k := range images {
+		anyKey = k
+		break
+	}
+	if anyKey == "" {
+		t.Fatal("no entries in images map")
+	}
+	got := Image(anyKey)
+	wantPrefix := registryPrefix + "/" + anyKey + "@sha256:"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Errorf("Image(%q) = %q, want prefix %q", anyKey, got, wantPrefix)
+	}
+}
+
+func TestImagePanicsOnUnknownKey(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected Image to panic on unknown key")
+		}
+	}()
+	_ = Image("does-not-exist")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry pick of #2022 and #2023

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Tinkerbell provisioning now pulls all container images from quay.io/kubermatic-mirror instead of upstream registries, eliminating dependency on third-party registry availability.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
