### PR TITLE
Check both v1beta1 and v1alpha1 instance types

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 	kubevirtcorev1 "kubevirt.io/api/core/v1"
 	kubevirtinstancetypev1alpha1 "kubevirt.io/api/instancetype/v1alpha1"
+	kubevirtinstancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	cdicorev1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	cloudprovidererrors "k8c.io/machine-controller/pkg/cloudprovider/errors"
@@ -60,6 +61,12 @@ func init() {
 	}
 	if err := cdicorev1beta1.AddToScheme(scheme.Scheme); err != nil {
 		panic(fmt.Sprintf("failed to add cdiv1beta1 to scheme: %v", err))
+	}
+	if err := kubevirtinstancetypev1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		panic(fmt.Sprintf("failed to add kubevirt instancetype v1alpha1 to scheme: %v", err))
+	}
+	if err := kubevirtinstancetypev1beta1.AddToScheme(scheme.Scheme); err != nil {
+		panic(fmt.Sprintf("failed to add kubevirt instancetype v1beta1 to scheme: %v", err))
 	}
 }
 
@@ -1264,18 +1271,32 @@ func defaultVMInstanceType(ctx context.Context, client ctrlruntimeclient.Client,
 		return nil, nil
 	}
 
-	// Check namespace-scoped VirtualMachineInstancetype first
-	instanceType := &kubevirtinstancetypev1alpha1.VirtualMachineInstancetype{}
-	if err := client.Get(ctx, types.NamespacedName{Name: instanceTypeMatcher.Name, Namespace: namespace}, instanceType); err == nil {
+	// Try v1beta1 namespace-scoped VirtualMachineInstancetype first (preferred stable API)
+	if err := client.Get(ctx, types.NamespacedName{Name: instanceTypeMatcher.Name, Namespace: namespace}, &kubevirtinstancetypev1beta1.VirtualMachineInstancetype{}); err == nil {
 		return &kubevirtcorev1.InstancetypeMatcher{
 			Name: instanceTypeMatcher.Name,
 			Kind: "VirtualMachineInstancetype",
 		}, nil
 	}
 
-	// Fall back to cluster-scoped VirtualMachineClusterInstancetype
-	clusterInstanceType := &kubevirtinstancetypev1alpha1.VirtualMachineClusterInstancetype{}
-	if err := client.Get(ctx, types.NamespacedName{Name: instanceTypeMatcher.Name}, clusterInstanceType); err == nil {
+	// Try v1beta1 cluster-scoped VirtualMachineClusterInstancetype
+	if err := client.Get(ctx, types.NamespacedName{Name: instanceTypeMatcher.Name}, &kubevirtinstancetypev1beta1.VirtualMachineClusterInstancetype{}); err == nil {
+		return &kubevirtcorev1.InstancetypeMatcher{
+			Name: instanceTypeMatcher.Name,
+			Kind: "VirtualMachineClusterInstancetype",
+		}, nil
+	}
+
+	// Fall back to v1alpha1 namespace-scoped VirtualMachineInstancetype
+	if err := client.Get(ctx, types.NamespacedName{Name: instanceTypeMatcher.Name, Namespace: namespace}, &kubevirtinstancetypev1alpha1.VirtualMachineInstancetype{}); err == nil {
+		return &kubevirtcorev1.InstancetypeMatcher{
+			Name: instanceTypeMatcher.Name,
+			Kind: "VirtualMachineInstancetype",
+		}, nil
+	}
+
+	// Fall back to v1alpha1 cluster-scoped VirtualMachineClusterInstancetype
+	if err := client.Get(ctx, types.NamespacedName{Name: instanceTypeMatcher.Name}, &kubevirtinstancetypev1alpha1.VirtualMachineClusterInstancetype{}); err == nil {
 		return &kubevirtcorev1.InstancetypeMatcher{
 			Name: instanceTypeMatcher.Name,
 			Kind: "VirtualMachineClusterInstancetype",


### PR DESCRIPTION
**What this PR does / why we need it**:

`defaultVMInstanceType` only queried `v1alpha1` instance type objects. We added v1beta1 to ensure that it works for both api versions 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
