### PR TITLE
openstack: Use OS_USERNAME as a source for username

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -131,7 +131,7 @@ func (p *provider) getProjectNameOrTenantName(rawConfig *openstacktypes.RawConfi
 		return projectName, nil
 	}
 
-	//fallback to tenantName.
+	// fallback to tenantName.
 	return p.configVarResolver.GetStringValueOrEnv(rawConfig.TenantName, "OS_TENANT_NAME")
 }
 
@@ -142,7 +142,7 @@ func (p *provider) getProjectIDOrTenantID(rawConfig *openstacktypes.RawConfig) (
 		return projectID, nil
 	}
 
-	//fallback to tenantName.
+	// fallback to tenantID.
 	return p.configVarResolver.GetStringValueOrEnv(rawConfig.TenantID, "OS_TENANT_ID")
 }
 
@@ -150,30 +150,37 @@ func (p *provider) getConfigAuth(c *Config, rawConfig *openstacktypes.RawConfig)
 	var err error
 	c.ApplicationCredentialID, err = p.configVarResolver.GetStringValueOrEnv(rawConfig.ApplicationCredentialID, "OS_APPLICATION_CREDENTIAL_ID")
 	if err != nil {
-		return fmt.Errorf("failed to get the value of \"applicationCredentialID\" field, error = %w", err)
+		return fmt.Errorf(`failed to get the value of "applicationCredentialID" field, error = %w`, err)
 	}
 	if c.ApplicationCredentialID != "" {
 		c.ApplicationCredentialSecret, err = p.configVarResolver.GetStringValueOrEnv(rawConfig.ApplicationCredentialSecret, "OS_APPLICATION_CREDENTIAL_SECRET")
 		if err != nil {
-			return fmt.Errorf("failed to get the value of \"applicationCredentialSecret\" field, error = %w", err)
+			return fmt.Errorf(`failed to get the value of "applicationCredentialSecret" field, error = %w`, err)
 		}
 		return nil
 	}
-	c.Username, err = p.configVarResolver.GetStringValueOrEnv(rawConfig.Username, "OS_USER_NAME")
+	c.Username, err = p.configVarResolver.GetStringValueOrEnv(rawConfig.Username, "OS_USERNAME")
 	if err != nil {
-		return fmt.Errorf("failed to get the value of \"username\" field, error = %w", err)
+		return fmt.Errorf(`failed to get the value of "username" field, error = %w`, err)
+	}
+	if c.Username == "" {
+		// fallback to legacy OS_USER_NAME
+		c.Username, err = p.configVarResolver.GetStringValueOrEnv(rawConfig.Username, "OS_USER_NAME")
+		if err != nil {
+			return fmt.Errorf(`failed to get the value of "username" field, error = %w`, err)
+		}
 	}
 	c.Password, err = p.configVarResolver.GetStringValueOrEnv(rawConfig.Password, "OS_PASSWORD")
 	if err != nil {
-		return fmt.Errorf("failed to get the value of \"password\" field, error = %w", err)
+		return fmt.Errorf(`failed to get the value of "password" field, error = %w`, err)
 	}
 	c.ProjectName, err = p.getProjectNameOrTenantName(rawConfig)
 	if err != nil {
-		return fmt.Errorf("failed to get the value of \"projectName\" field or fallback to \"tenantName\" field, error = %w", err)
+		return fmt.Errorf(`failed to get the value of "projectName" field or fallback to "tenantName" field, error = %w`, err)
 	}
 	c.ProjectID, err = p.getProjectIDOrTenantID(rawConfig)
 	if err != nil {
-		return fmt.Errorf("failed to get the value of \"projectID\" or fallback to\"tenantID\" field, error = %w", err)
+		return fmt.Errorf(`failed to get the value of "projectID" or fallback to "tenantID" field, error = %w`, err)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
OS_USERNAME is a standard openstack ENV variable name. Use OS_USER_NAME as a legacy fallback.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
openstack: Use OS_USERNAME as a source for username
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
