### PR TITLE
feat(openstack): add disablePortSecurity to MachineDeployment spec

### DIFF
--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -138,6 +138,10 @@ spec:
                   key: securityGroup
             # The machine won't get a floating ip if you leave this empty
             floatingIpPool: "ext-net"
+            # Optional. If true, disables OpenStack port security on the instance's
+            # network port (and clears its security groups). Required for routing-based
+            # CNIs such as Cilium native routing that need IP/MAC "spoofing".
+            disablePortSecurity: false
             # Only required if there is more than one AZ to choose from
             availabilityZone: ""
             # Only required if there is more than one network available

--- a/examples/openstack-machinedeployment.yaml
+++ b/examples/openstack-machinedeployment.yaml
@@ -139,7 +139,7 @@ spec:
             # The machine won't get a floating ip if you leave this empty
             floatingIpPool: "ext-net"
             # Optional. If true, disables OpenStack port security on the instance's
-            # network port (and clears its security groups). Required for routing-based
+            # network ports (and clears its security groups). Required for routing-based
             # CNIs such as Cilium native routing that need IP/MAC "spoofing".
             disablePortSecurity: false
             # Only required if there is more than one AZ to choose from

--- a/pkg/cloudprovider/provider/openstack/helper.go
+++ b/pkg/cloudprovider/provider/openstack/helper.go
@@ -30,6 +30,7 @@ import (
 	osregions "github.com/gophercloud/gophercloud/openstack/identity/v3/regions"
 	osimagesv2 "github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 	osfloatingips "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/portsecurity"
 	ossecuritygroups "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	osecruritygrouprules "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	osnetworks "github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
@@ -367,6 +368,27 @@ func getInstancePort(netClient *gophercloud.ServiceClient, instanceID, networkID
 	}
 
 	return nil, errNotFound
+}
+
+func disablePortSecurity(netClient *gophercloud.ServiceClient, instanceID, networkID string) error {
+	port, err := getInstancePort(netClient, instanceID, networkID)
+	if err != nil {
+		return err
+	}
+
+	emptySecurityGroups := []string{}
+	portSecurityEnabled := false
+	updateOpts := portsecurity.PortUpdateOptsExt{
+		UpdateOptsBuilder: osports.UpdateOpts{
+			SecurityGroups: &emptySecurityGroups,
+		},
+		PortSecurityEnabled: &portSecurityEnabled,
+	}
+	if _, err := osports.Update(netClient, port.ID, updateOpts).Extract(); err != nil {
+		return fmt.Errorf("failed to update port %s: %w", port.ID, err)
+	}
+
+	return nil
 }
 
 func getDefaultNetwork(netClient *gophercloud.ServiceClient) (*osnetworks.Network, error) {

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -104,6 +104,7 @@ type Config struct {
 	AvailabilityZone      string
 	TrustDevicePath       bool
 	ConfigDrive           bool
+	DisablePortSecurity   bool
 	RootDiskSizeGB        *int
 	RootDiskVolumeType    string
 	NodeVolumeAttachLimit *uint
@@ -311,6 +312,11 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	}
 
 	cfg.ConfigDrive, _, err = p.configVarResolver.GetBoolValue(rawConfig.ConfigDrive)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	cfg.DisablePortSecurity, _, err = p.configVarResolver.GetBoolValue(rawConfig.DisablePortSecurity)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -743,6 +749,19 @@ func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *
 
 		if err := osservers.Create(computeClient, createOpts).ExtractInto(&server); err != nil {
 			return nil, osErrorToTerminalError(log, err, "failed to create server")
+		}
+	}
+
+	if cfg.DisablePortSecurity {
+		instanceLog := log.With("instance", server.ID)
+
+		if err := p.portReadinessWaiter(ctx, instanceLog, netClient, server.ID, primaryNetwork.ID, cfg.InstanceReadyCheckPeriod, cfg.InstanceReadyCheckTimeout); err != nil {
+			instanceLog.Infow("Port for instance did not became active", zap.Error(err))
+		}
+
+		if err := disablePortSecurity(netClient, server.ID, primaryNetwork.ID); err != nil {
+			defer deleteInstanceDueToFatalLogged(instanceLog, computeClient, server.ID)
+			return nil, fmt.Errorf("failed to disable port security for instance %s: %w", server.ID, err)
 		}
 	}
 

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -667,6 +667,7 @@ func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *
 
 	// Get network objects for all specified networks
 	var networks []osservers.Network
+	var networkIDs []string
 	var primaryNetwork *osnetworks.Network // Keep track of first network for floating IP assignment
 
 	for i, networkName := range networkNames {
@@ -676,6 +677,7 @@ func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *
 		}
 
 		networks = append(networks, osservers.Network{UUID: network.ID})
+		networkIDs = append(networkIDs, network.ID)
 
 		// Use first network as primary for floating IP assignment (backwards compatibility)
 		if i == 0 {
@@ -755,13 +757,18 @@ func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *
 	if cfg.DisablePortSecurity {
 		instanceLog := log.With("instance", server.ID)
 
-		if err := p.portReadinessWaiter(ctx, instanceLog, netClient, server.ID, primaryNetwork.ID, cfg.InstanceReadyCheckPeriod, cfg.InstanceReadyCheckTimeout); err != nil {
-			instanceLog.Infow("Port for instance did not became active", zap.Error(err))
-		}
+		// Disable port security on every attached network port so that
+		// routing-based CNIs work on all of the instance's NICs, not just
+		// the primary one.
+		for _, networkID := range networkIDs {
+			if err := p.portReadinessWaiter(ctx, instanceLog, netClient, server.ID, networkID, cfg.InstanceReadyCheckPeriod, cfg.InstanceReadyCheckTimeout); err != nil {
+				instanceLog.Infow("Port for instance did not became active", zap.Error(err))
+			}
 
-		if err := disablePortSecurity(netClient, server.ID, primaryNetwork.ID); err != nil {
-			defer deleteInstanceDueToFatalLogged(instanceLog, computeClient, server.ID)
-			return nil, fmt.Errorf("failed to disable port security for instance %s: %w", server.ID, err)
+			if err := disablePortSecurity(netClient, server.ID, networkID); err != nil {
+				defer deleteInstanceDueToFatalLogged(instanceLog, computeClient, server.ID)
+				return nil, fmt.Errorf("failed to disable port security for instance %s: %w", server.ID, err)
+			}
 		}
 	}
 

--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -762,7 +762,7 @@ func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *
 		// the primary one.
 		for _, networkID := range networkIDs {
 			if err := p.portReadinessWaiter(ctx, instanceLog, netClient, server.ID, networkID, cfg.InstanceReadyCheckPeriod, cfg.InstanceReadyCheckTimeout); err != nil {
-				instanceLog.Infow("Port for instance did not became active", zap.Error(err))
+				instanceLog.Infow("Port for instance did not become active", zap.Error(err))
 			}
 
 			if err := disablePortSecurity(netClient, server.ID, networkID); err != nil {
@@ -776,7 +776,7 @@ func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *
 		instanceLog := log.With("instance", server.ID)
 
 		if err := p.portReadinessWaiter(ctx, instanceLog, netClient, server.ID, primaryNetwork.ID, cfg.InstanceReadyCheckPeriod, cfg.InstanceReadyCheckTimeout); err != nil {
-			instanceLog.Infow("Port for instance did not became active", zap.Error(err))
+			instanceLog.Infow("Port for instance did not become active", zap.Error(err))
 		}
 
 		// Find a free FloatingIP or allocate a new one.

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -185,6 +185,7 @@ type openstackProviderSpecConf struct {
 	TenantID                    string
 	TenantName                  string
 	ConfigDrive                 bool
+	DisablePortSecurity         bool
 	ComputeAPIVersion           string
 	Network                     string
 	Networks                    []string
@@ -252,6 +253,9 @@ func (o openstackProviderSpecConf) rawProviderSpec(t *testing.T) []byte {
 				"password": "this_is_a_password",
 			{{- end }}
 			"tokenId": "",
+			{{- if .DisablePortSecurity }}
+			"disablePortSecurity": true,
+			{{- end }}
 			"trustDevicePath": false
 		},
 		"operatingSystem": "flatcar",
@@ -389,6 +393,46 @@ func TestCreateServer(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("provider.Create() or = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+		})
+	}
+}
+
+func TestDisablePortSecurityIsCorrectlyLoaded(t *testing.T) {
+	tests := []struct {
+		name     string
+		specConf openstackProviderSpecConf
+		expected bool
+	}{
+		{
+			name:     "Defaults to false when omitted",
+			specConf: openstackProviderSpecConf{},
+			expected: false,
+		},
+		{
+			name:     "Resolves to true when set",
+			specConf: openstackProviderSpecConf{DisablePortSecurity: true},
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &provider{
+				configVarResolver: configvar.NewResolver(context.Background(), fakectrlruntimeclient.
+					NewClientBuilder().
+					Build()),
+			}
+			conf, _, _, err := p.getConfig(clusterv1alpha1.ProviderSpec{
+				Value: &runtime.RawExtension{
+					Raw: tt.specConf.rawProviderSpec(t),
+				},
+			})
+			if err != nil {
+				t.Fatalf("getConfig() error = %v", err)
+			}
+
+			if conf.DisablePortSecurity != tt.expected {
+				t.Errorf("DisablePortSecurity = %v, wanted %v", conf.DisablePortSecurity, tt.expected)
 			}
 		})
 	}

--- a/sdk/cloudprovider/openstack/types.go
+++ b/sdk/cloudprovider/openstack/types.go
@@ -54,6 +54,7 @@ type RawConfig struct {
 	NodeVolumeAttachLimit *uint                            `json:"nodeVolumeAttachLimit"`
 	ServerGroup           providerconfig.ConfigVarString   `json:"serverGroup"`
 	ConfigDrive           providerconfig.ConfigVarBool     `json:"configDrive,omitempty"`
+	DisablePortSecurity   providerconfig.ConfigVarBool     `json:"disablePortSecurity,omitempty"`
 	// This tag is related to server metadata, not compute server's tag
 	Tags map[string]string `json:"tags,omitempty"`
 }


### PR DESCRIPTION
## Summary

Adds a `disablePortSecurity` boolean to the OpenStack MachineDeployment provider spec. When set to `true`, the machine-controller disables port security on the instance's Neutron network ports after the instance comes up, and clears their security groups (OpenStack rejects security groups on a port with port security disabled). Default behavior is unchanged.

## Why this matters

Routing-based Kubernetes CNIs such as Cilium native routing rely on a node forwarding traffic for IP/MAC addresses other than the port's own. OpenStack port security blocks that traffic, so those CNIs cannot run on worker nodes unless port security is turned off on the instance ports. As described in #2012, the OpenStack provider had no way to do this, while cluster-api already exposes the equivalent setting. This change closes that gap so operators can provision routing-CNI-ready nodes directly from a MachineDeployment.

## What this PR does / why we need it

- New `DisablePortSecurity providerconfig.ConfigVarBool` field on `RawConfig`, resolved into `Config.DisablePortSecurity` in `getConfig`, mirroring the existing `trustDevicePath` / `configDrive` bool fields.
- After the server is created, when the flag is set, the provider waits for each attached network port to become active (reusing the existing port-readiness waiter) and updates it via Neutron to set `port_security_enabled=false`, clearing the port's security groups in the same call.
- The update is applied to every network in the `networks` list, not just the primary one, so the setting also takes effect on multi-NIC machines.
- When the field is omitted or `false`, no port update is performed and port security stays enabled.

## Testing

- `go test ./pkg/cloudprovider/provider/openstack/...` passes, including a new table test asserting `disablePortSecurity` defaults to `false` and resolves to `true` when set.
- `go build`, `go vet`, and `gofmt` are clean for the touched packages in both the main and `sdk` modules.

**Which issue(s) this PR fixes**:

Fixes #2012

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

The field is documented in `examples/openstack-machinedeployment.yaml`.

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Add a `disablePortSecurity` option to the OpenStack provider spec that disables port security (and clears security groups) on the instance's network ports, enabling routing-based CNIs such as Cilium native routing.
```

**Documentation**:

```documentation
NONE
```
