### PR TITLE
fix custom CA e2e waiting on stale replica set

### DIFF
--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -238,7 +238,7 @@ C8QmzsMaZhk+mVFr1sGy
 
 	// wait for deployments to roll out
 	for _, deployment := range deployments {
-		if err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
+		if err := wait.PollUntilContextTimeout(ctx, 3*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 			d := &appsv1.Deployment{}
 			key := types.NamespacedName{Namespace: ns, Name: deployment}
 
@@ -246,7 +246,16 @@ C8QmzsMaZhk+mVFr1sGy
 				return false, fmt.Errorf("failed to get Deployment: %w", err)
 			}
 
-			return d.Status.AvailableReplicas > 0, nil
+			if d.Generation > d.Status.ObservedGeneration {
+				return false, nil
+			}
+
+			desired := int32(1)
+			if d.Spec.Replicas != nil {
+				desired = *d.Spec.Replicas
+			}
+
+			return d.Status.UpdatedReplicas == desired && d.Status.AvailableReplicas == desired, nil
 		}); err != nil {
 			return fmt.Errorf("%s Deployment never became ready: %w", deployment, err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows tests to wait for the rollout to actually finish (observed generation caught up, and all replicas updated and available) before issuing the create. Test-only change.

i observed this on cherry-pick PR

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**:
/kind flake

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
