### PR TITLE
feat(openstack): propagate instance faults to Machine status on ERROR

### DIFF
--- a/pkg/cloudprovider/provider/openstack/provider.go
+++ b/pkg/cloudprovider/provider/openstack/provider.go
@@ -914,11 +914,28 @@ func (p *provider) Get(_ context.Context, log *zap.SugaredLogger, machine *clust
 
 	for i, s := range allServers {
 		if s.Metadata[machineUIDMetaKey] == string(machine.UID) {
+			if s.Status == "ERROR" && machine.DeletionTimestamp == nil {
+				return nil, cloudprovidererrors.TerminalError{
+					Reason:  common.CreateMachineError,
+					Message: openStackInstanceErrorMessage(s),
+				}
+			}
 			return &osInstance{server: &allServers[i]}, nil
 		}
 	}
 
 	return nil, cloudprovidererrors.ErrInstanceNotFound
+}
+
+func openStackInstanceErrorMessage(s serverWithExt) string {
+	faultMsg := s.Fault.Message
+	if faultMsg == "" {
+		faultMsg = s.Fault.Details
+	}
+	if faultMsg == "" {
+		faultMsg = "instance entered ERROR state"
+	}
+	return fmt.Sprintf("OpenStack instance %s entered ERROR state: %s", s.ID, faultMsg)
 }
 
 func (p *provider) MigrateUID(_ context.Context, log *zap.SugaredLogger, machine *clusterv1alpha1.Machine, newUID types.UID) error {

--- a/pkg/cloudprovider/provider/openstack/provider_test.go
+++ b/pkg/cloudprovider/provider/openstack/provider_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -32,12 +33,16 @@ import (
 	"github.com/gophercloud/gophercloud/testhelper/client"
 	"go.uber.org/zap"
 
+	cloudprovidererrors "k8c.io/machine-controller/pkg/cloudprovider/errors"
 	cloudprovidertesting "k8c.io/machine-controller/pkg/cloudprovider/testing"
 	cloudprovidertypes "k8c.io/machine-controller/pkg/cloudprovider/types"
+	"k8c.io/machine-controller/sdk/apis/cluster/common"
 	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
 	"k8c.io/machine-controller/sdk/providerconfig/configvar"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -436,6 +441,166 @@ func TestDisablePortSecurityIsCorrectlyLoaded(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetInstanceErrorStatus(t *testing.T) {
+	const (
+		machineUID   = "machine-uid-test"
+		serverID     = "server-in-error"
+		faultMessage = "No valid host was found. There are not enough hosts available."
+	)
+
+	tests := []struct {
+		name                  string
+		fault                 string
+		wantMessageSubstrings []string
+	}{
+		{
+			name:  "returns terminal error with provider fault message",
+			fault: fmt.Sprintf(`{"message": %q, "code": 500}`, faultMessage),
+			wantMessageSubstrings: []string{
+				serverID,
+				faultMessage,
+			},
+		},
+		{
+			name:  "returns terminal error with generic message when fault is empty",
+			fault: `{}`,
+			wantMessageSubstrings: []string{
+				serverID,
+				"instance entered ERROR state",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			th.SetupHTTP()
+			defer th.TeardownHTTP()
+
+			p := &provider{
+				configVarResolver: configvar.NewResolver(context.Background(), fakectrlruntimeclient.NewClientBuilder().Build()),
+				clientGetter: func(*Config) (*gophercloud.ProviderClient, error) {
+					pc := client.ServiceClient()
+					pc.EndpointLocator = func(_ gophercloud.EndpointOpts) (string, error) {
+						return pc.Endpoint, nil
+					}
+					return pc.ProviderClient, nil
+				},
+			}
+
+			specConf := openstackProviderSpecConf{IdentityEndpointURL: th.Endpoint()}
+			m := cloudprovidertesting.Creator{
+				Name:               "test",
+				Namespace:          "openstack",
+				ProviderSpecGetter: specConf.rawProviderSpec,
+			}.CreateMachine(t)
+			m.UID = types.UID(machineUID)
+
+			th.Mux.HandleFunc("/servers/detail", func(w http.ResponseWriter, r *http.Request) {
+				th.TestMethod(t, r, http.MethodGet)
+				th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+				th.TestFormValues(t, r, map[string]string{"name": m.Spec.Name})
+
+				w.Header().Add("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{
+					"servers": [
+						{
+							"id": %q,
+							"name": %q,
+							"status": "ERROR",
+							"metadata": {
+								%q: %q
+							},
+							"fault": %s
+						}
+					]
+				}`, serverID, m.Spec.Name, machineUIDMetaKey, machineUID, tt.fault)
+			})
+
+			instance, err := p.Get(context.Background(), zap.NewNop().Sugar(), m, nil)
+			if instance != nil {
+				t.Fatalf("Get() instance = %v, expected nil", instance)
+			}
+
+			isTerminal, reason, message := cloudprovidererrors.IsTerminalError(err)
+			if !isTerminal {
+				t.Fatalf("Get() error = %v, expected terminal error", err)
+			}
+			if reason != common.CreateMachineError {
+				t.Fatalf("terminal error reason = %v, expected %v", reason, common.CreateMachineError)
+			}
+			for _, want := range tt.wantMessageSubstrings {
+				if !strings.Contains(message, want) {
+					t.Fatalf("terminal error message = %q, expected to contain %q", message, want)
+				}
+			}
+		})
+	}
+
+	t.Run("returns instance for deleting machine in error state", func(t *testing.T) {
+		th.SetupHTTP()
+		defer th.TeardownHTTP()
+
+		p := &provider{
+			configVarResolver: configvar.NewResolver(context.Background(), fakectrlruntimeclient.NewClientBuilder().Build()),
+			clientGetter: func(*Config) (*gophercloud.ProviderClient, error) {
+				pc := client.ServiceClient()
+				pc.EndpointLocator = func(_ gophercloud.EndpointOpts) (string, error) {
+					return pc.Endpoint, nil
+				}
+				return pc.ProviderClient, nil
+			},
+		}
+
+		specConf := openstackProviderSpecConf{IdentityEndpointURL: th.Endpoint()}
+		m := cloudprovidertesting.Creator{
+			Name:               "test",
+			Namespace:          "openstack",
+			ProviderSpecGetter: specConf.rawProviderSpec,
+		}.CreateMachine(t)
+		m.UID = types.UID(machineUID)
+		now := metav1.Now()
+		m.DeletionTimestamp = &now
+
+		th.Mux.HandleFunc("/servers/detail", func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, http.MethodGet)
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			th.TestFormValues(t, r, map[string]string{"name": m.Spec.Name})
+
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{
+				"servers": [
+					{
+						"id": %q,
+						"name": %q,
+						"status": "ERROR",
+						"metadata": {
+							%q: %q
+						},
+						"fault": {"message": %q, "code": 500}
+					}
+				]
+			}`, serverID, m.Spec.Name, machineUIDMetaKey, machineUID, faultMessage)
+		})
+
+		instance, err := p.Get(context.Background(), zap.NewNop().Sugar(), m, nil)
+		if err != nil {
+			t.Fatalf("Get() error = %v, expected nil", err)
+		}
+		if instance == nil {
+			t.Fatal("Get() instance = nil, expected instance")
+		}
+		osInstance, ok := instance.(*osInstance)
+		if !ok {
+			t.Fatalf("Get() instance type = %T, expected *osInstance", instance)
+		}
+		if osInstance.ID() != serverID {
+			t.Fatalf("Get() instance ID = %q, expected %q", osInstance.ID(), serverID)
+		}
+	})
 }
 
 func TestProjectAuthVarsAreCorrectlyLoaded(t *testing.T) {


### PR DESCRIPTION
## Summary

Make the OpenStack provider's `Get` return a `TerminalError` (`Reason: CreateError`) when the UID-matched Nova server is in `ERROR` state, so the provider-side fault surfaces on `Machine.status` instead of leaving the machine stuck in an endless "provisioning" state. The message is composed from the server's `fault.message` (falling back to `fault.details`, then a generic string) and includes the server ID.

The existing controller wiring in `ensureInstanceExistsForMachine` already detects terminal errors and writes `Machine.status.errorReason` / `Machine.status.errorMessage`, so no controller change is needed - this mirrors how quota exhaustion already terminates. The ERROR check is skipped when the `Machine` is being deleted (`DeletionTimestamp` set) so `Cleanup` can still retrieve and delete a failed server.

## Motivation

When an OpenStack Nova server enters `ERROR` before the kubelet registers (for example a flavor/GPU shortage that yields "No valid host was found. There are not enough hosts available."), the machine-controller left the `Machine` object's status empty. Consumers (kkp-api / dashboard) only ever saw an endless "provisioning" state with no indication of the underlying cause. The provider-side fault was visible via `openstack server show` but never propagated to the `Machine`, so operators had no signal that the instance had failed and the reconcile loop requeued indefinitely.

## Testing

Added `TestGetInstanceErrorStatus`, which exercises a mocked `/servers/detail` endpoint across three cases: an ERROR server with a populated fault (terminal error carries the fault message and server ID), an ERROR server with an empty fault (non-empty generic terminal message, no panic), and an ERROR server whose `Machine` is being deleted (returns the instance so cleanup can proceed). The change is confined to the OpenStack provider and does not touch the shared `instance.Instance` interface or other providers. `go build`, `go vet`, and `go test` pass for `pkg/cloudprovider/provider/openstack/...`.

**Which issue(s) this PR fixes**:
Fixes #2040

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
OpenStack: instance faults are now propagated to Machine status when a server enters an ERROR state, surfacing the provider-side failure reason instead of leaving the machine stuck in provisioning.
```

**Documentation**:
```documentation
NONE
```
