### PR TITLE
migrate deprecated datacenter field to location

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,10 @@ linters:
         text: 'SA1019: s.server.IPv6 is deprecated'
       - path: (.+)\.go$
         text: 'SA1019: mgr.GetEventRecorderFor is deprecated'
+      # the hetzner provider migrates the deprecated datacenter field to
+      # location through the deprecation window; drop once the field is removed.
+      - path: pkg/cloudprovider/provider/hetzner/(.+)\.go$
+        text: 'SA1019: rawConfig.Datacenter is deprecated'
     paths:
       - apis/machines
       - third_party$

--- a/docs/cloud-provider.md
+++ b/docs/cloud-provider.md
@@ -225,7 +225,6 @@ labels:
 ```yaml
 token: "<< HETZNER_API_TOKEN >>"
 serverType: "cx23"
-datacenter: ""
 location: "fsn1"
 # Optional: network IDs or names
 networks:

--- a/examples/hetzner-machinedeployment.yaml
+++ b/examples/hetzner-machinedeployment.yaml
@@ -45,7 +45,6 @@ spec:
                 key: token
             serverType: "cx21"
             # Optional
-            datacenter: ""
             location: "fsn1"
             image: "ubuntu-20.04"
             # Optional: placement group prefix

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gophercloud/gophercloud v1.14.0
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
-	github.com/hetznercloud/hcloud-go/v2 v2.13.1
+	github.com/hetznercloud/hcloud-go/v2 v2.44.0
 	github.com/linode/linodego v1.40.0
 	github.com/nutanix-cloud-native/prism-go-client v0.5.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,8 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb h1:tsEKRC3PU9rMw18w/uAptoijhgG4EvlA5kfJPtwrMDk=
 github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
-github.com/hetznercloud/hcloud-go/v2 v2.13.1 h1:jq0GP4QaYE5d8xR/Zw17s9qoaESRJMXfGmtD1a/qckQ=
-github.com/hetznercloud/hcloud-go/v2 v2.13.1/go.mod h1:dhix40Br3fDiBhwaSG/zgaYOFFddpfBm/6R1Zz0IiF0=
+github.com/hetznercloud/hcloud-go/v2 v2.44.0 h1:1p9qwaZ/H55nLP9c7WfuwUA0LfsexS2YHOhD8+iBga8=
+github.com/hetznercloud/hcloud-go/v2 v2.44.0/go.mod h1:d0s2WLe7jSoStamv3eHoWgBSOxc/K17tYSXsqUkbse0=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=

--- a/pkg/admission/machines.go
+++ b/pkg/admission/machines.go
@@ -191,7 +191,12 @@ func (ad *admissionData) defaultAndValidateMachineSpec(ctx context.Context, spec
 	if err != nil {
 		return fmt.Errorf("failed to default machineSpec: %w", err)
 	}
-	spec = &defaultedSpec
+
+	// AddDefaults works on a copy, so its result must be written back through
+	// the pointer. rebinding it (spec = &defaultedSpec) only affects this
+	// function; the caller would diff an unchanged object and emit an empty
+	// admission patch, silently dropping the defaults.
+	*spec = defaultedSpec
 
 	if err := prov.Validate(ctx, ad.log, *spec); err != nil {
 		return fmt.Errorf("validation failed: %w", err)

--- a/pkg/admission/machines_test.go
+++ b/pkg/admission/machines_test.go
@@ -17,9 +17,20 @@ limitations under the License.
 package admission
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
+
+	"k8c.io/machine-controller/pkg/cloudprovider/provider/fake"
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+	"k8c.io/machine-controller/sdk/providerconfig"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 const (
@@ -33,6 +44,161 @@ const (
 
 	validDSA1024Key = `ssh-dss AAAAB3NzaC1kc3MAAACBAP1/U4EddRIpUt9KnC7s5Of2EbdSPO9EAMMeP4C2USZpRV1AIlH7WT2NWPq/xfW6MPbLm1Vs14E7gB00b/JmYLdrmVClpJ+f6AR7ECLCT7up1/63xhv4O1fnxqimFQ8E+4P208UewwI1VBNaFpEy9nXzrith1yrv8iIDGZ3RSAHHAAAAFQCXYFCPFSMLzLKSuYKi64QL8Fgc9QAAAIEA9+GghdabPd7LvKtcNrhXuXmUr7v6OuqC+VdMCz0HgmdRWVeOutRZT+ZxBxCBgLRJFnEj6EwoFhO3zwkyjMim4TwWeotUfI0o4KOuHiuzpnWRbqN/C/ohNWLx+2J6ASQ7zKTxvqhRkImog9/hWuWfBpKLZl6Ae1UlZAFMO/7PSSoAAACAU5qGNxrBT4VDW1bN1m6szPH4PRlqNSPHNG/1Xs3LrJyGRXxnl218IYyrfAb+lIIEZEcUFGGWyRJOLQhmWv68zBupKv1JJaVAQ4JTMPPmmPwGus01eSGd9NjAS6Qtl9FGMLrLFk4IRFuenHWOas1PzDlOXybUnaXtQpNcKEJgMik=`
 )
+
+// TestDefaultAndValidateMachineSpecPersistsProviderDefaults ensures provider
+// AddDefaults results reach the caller's spec, since mutateMachines builds the
+// admission patch from that object, not from the returned copy. uses the
+// hetzner datacenter -> location migration as the observable default.
+func TestDefaultAndValidateMachineSpecPersistsProviderDefaults(t *testing.T) {
+	// no token keeps the hetzner provider offline: Validate fails with "token
+	// is missing" before any API call, after AddDefaults already ran and its
+	// result was written back.
+	t.Setenv("HZ_TOKEN", "")
+
+	// raw JSON to avoid referencing the deprecated Datacenter field outside
+	// the hetzner package.
+	spec := machineSpecWithProviderConfig(t, providerconfig.CloudProviderHetzner, []byte(`{"serverType":"cx22","datacenter":"nbg1-dc3"}`))
+
+	ad := newTestAdmissionData(t)
+	err := ad.defaultAndValidateMachineSpec(context.Background(), &spec)
+	if err == nil || !strings.Contains(err.Error(), "token is missing") {
+		t.Fatalf("defaultAndValidateMachineSpec() error = %v, want the offline \"token is missing\" validation error", err)
+	}
+
+	defaultedPconfig, err := providerconfig.GetConfig(spec.ProviderSpec)
+	if err != nil {
+		t.Fatalf("failed to read providerconfig back from spec: %v", err)
+	}
+	cloudProviderSpec := map[string]any{}
+	if err := json.Unmarshal(defaultedPconfig.CloudProviderSpec.Raw, &cloudProviderSpec); err != nil {
+		t.Fatalf("failed to unmarshal cloudProviderSpec: %v", err)
+	}
+
+	if dc := cloudProviderSpec["datacenter"]; dc != "" {
+		t.Errorf("caller-visible datacenter = %v, want empty; AddDefaults result was lost", dc)
+	}
+	if loc := cloudProviderSpec["location"]; loc != "nbg1" {
+		t.Errorf("caller-visible location = %v, want %q; AddDefaults result was lost", loc, "nbg1")
+	}
+}
+
+func machineSpecWithProviderConfig(t *testing.T, cloudProvider providerconfig.CloudProvider, cloudProviderSpec []byte) clusterv1alpha1.MachineSpec {
+	t.Helper()
+
+	pconfig := providerconfig.Config{
+		CloudProvider:       cloudProvider,
+		CloudProviderSpec:   runtime.RawExtension{Raw: cloudProviderSpec},
+		OperatingSystem:     providerconfig.OperatingSystemUbuntu,
+		OperatingSystemSpec: runtime.RawExtension{Raw: []byte("{}")},
+	}
+	rawPconfig, err := json.Marshal(pconfig)
+	if err != nil {
+		t.Fatalf("failed to marshal providerconfig: %v", err)
+	}
+
+	return clusterv1alpha1.MachineSpec{
+		ProviderSpec: clusterv1alpha1.ProviderSpec{Value: &runtime.RawExtension{Raw: rawPconfig}},
+		Versions:     clusterv1alpha1.MachineVersionInfo{Kubelet: "1.30.0"},
+	}
+}
+
+// TestDefaultAndValidateMachineSpecPreservesSpecFields guards the write-back of
+// the AddDefaults result (*spec = defaultedSpec): for providers that do not
+// default anything, the round-trip through the by-value copy must not lose or
+// alter any field of the caller's spec.
+func TestDefaultAndValidateMachineSpecPreservesSpecFields(t *testing.T) {
+	fakeSpec, err := json.Marshal(fake.CloudProviderSpec{PassValidation: true})
+	if err != nil {
+		t.Fatalf("failed to marshal fake cloud provider spec: %v", err)
+	}
+
+	spec := machineSpecWithProviderConfig(t, providerconfig.CloudProviderFake, fakeSpec)
+	spec.Name = "worker-0"
+	spec.Labels = map[string]string{"role": "worker"}
+	spec.Annotations = map[string]string{"team": "dev-kkp"}
+	spec.Taints = []corev1.Taint{{Key: "dedicated", Value: "gpu", Effect: corev1.TaintEffectNoSchedule}}
+
+	want := *spec.DeepCopy()
+
+	ad := newTestAdmissionData(t)
+	if err := ad.defaultAndValidateMachineSpec(context.Background(), &spec); err != nil {
+		t.Fatalf("defaultAndValidateMachineSpec() error = %v", err)
+	}
+
+	if spec.Name != want.Name {
+		t.Errorf("name = %q, want %q", spec.Name, want.Name)
+	}
+	if !reflect.DeepEqual(spec.Labels, want.Labels) {
+		t.Errorf("labels = %v, want %v", spec.Labels, want.Labels)
+	}
+	if !reflect.DeepEqual(spec.Annotations, want.Annotations) {
+		t.Errorf("annotations = %v, want %v", spec.Annotations, want.Annotations)
+	}
+	if !reflect.DeepEqual(spec.Taints, want.Taints) {
+		t.Errorf("taints = %v, want %v", spec.Taints, want.Taints)
+	}
+	if !reflect.DeepEqual(spec.Versions, want.Versions) {
+		t.Errorf("versions = %v, want %v", spec.Versions, want.Versions)
+	}
+
+	// the provider spec is re-marshaled for OS defaulting, but must still parse
+	// and keep the cloud provider intact.
+	pconfig, err := providerconfig.GetConfig(spec.ProviderSpec)
+	if err != nil {
+		t.Fatalf("failed to read providerconfig back from spec: %v", err)
+	}
+	if pconfig.CloudProvider != providerconfig.CloudProviderFake {
+		t.Errorf("cloudProvider = %q, want %q", pconfig.CloudProvider, providerconfig.CloudProviderFake)
+	}
+}
+
+// TestDefaultAndValidateMachineSpecKubeVirt covers the KubeVirt call-site
+// contract: the annotations map is initialized on the caller's spec before
+// provider defaulting, so the provider's annotation writes land in a map the
+// caller shares. provider defaulting itself needs a reachable infra cluster
+// and fails offline; the error must propagate without a partial write-back.
+func TestDefaultAndValidateMachineSpecKubeVirt(t *testing.T) {
+	wantLabels := map[string]string{"role": "worker"}
+
+	tests := []struct {
+		name            string
+		annotations     map[string]string
+		wantAnnotations map[string]string
+	}{
+		{
+			name:            "nil annotations are initialized",
+			wantAnnotations: map[string]string{},
+		},
+		{
+			name:            "existing annotations are preserved",
+			annotations:     map[string]string{"team": "dev-kkp"},
+			wantAnnotations: map[string]string{"team": "dev-kkp"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// keep the test hermetic; the provider falls back to this env var.
+			t.Setenv("KUBEVIRT_KUBECONFIG", "")
+
+			spec := machineSpecWithProviderConfig(t, providerconfig.CloudProviderKubeVirt, []byte("{}"))
+			spec.Annotations = tt.annotations
+			spec.Labels = map[string]string{"role": "worker"}
+
+			ad := newTestAdmissionData(t)
+			err := ad.defaultAndValidateMachineSpec(context.Background(), &spec)
+			if err == nil || !strings.Contains(err.Error(), "failed to default machineSpec") {
+				t.Fatalf("defaultAndValidateMachineSpec() error = %v, want the offline provider defaulting error", err)
+			}
+
+			if !reflect.DeepEqual(spec.Annotations, tt.wantAnnotations) {
+				t.Errorf("annotations = %v, want %v", spec.Annotations, tt.wantAnnotations)
+			}
+			if !reflect.DeepEqual(spec.Labels, wantLabels) {
+				t.Errorf("labels = %v, want %v untouched on the error path", spec.Labels, wantLabels)
+			}
+		})
+	}
+}
 
 func TestValidatePublicKeys(t *testing.T) {
 	tests := []struct {

--- a/pkg/cloudprovider/provider/hetzner/provider.go
+++ b/pkg/cloudprovider/provider/hetzner/provider.go
@@ -18,6 +18,7 @@ package hetzner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -38,6 +39,7 @@ import (
 	"k8c.io/machine-controller/sdk/providerconfig"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
@@ -86,56 +88,56 @@ func getClient(token string) *hcloud.Client {
 	)
 }
 
-func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *providerconfig.Config, error) {
+func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *providerconfig.Config, *hetznertypes.RawConfig, error) {
 	pconfig, err := providerconfig.GetConfig(provSpec)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if pconfig.OperatingSystemSpec.Raw == nil {
-		return nil, nil, errors.New("operatingSystemSpec in the MachineDeployment cannot be empty")
+		return nil, nil, nil, errors.New("operatingSystemSpec in the MachineDeployment cannot be empty")
 	}
 
 	rawConfig, err := hetznertypes.GetConfig(*pconfig)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	c := Config{}
 	c.Token, err = p.configVarResolver.GetStringValueOrEnv(rawConfig.Token, "HZ_TOKEN")
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get the value of \"token\" field, error = %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to get the value of \"token\" field, error = %w", err)
 	}
 
 	c.ServerType, err = p.configVarResolver.GetStringValue(rawConfig.ServerType)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	c.Datacenter, err = p.configVarResolver.GetStringValue(rawConfig.Datacenter)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	c.Image, err = p.configVarResolver.GetStringValue(rawConfig.Image)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	c.Location, err = p.configVarResolver.GetStringValue(rawConfig.Location)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	c.PlacementGroupPrefix, err = p.configVarResolver.GetStringValue(rawConfig.PlacementGroupPrefix)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	for _, network := range rawConfig.Networks {
 		networkValue, err := p.configVarResolver.GetStringValue(network)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		c.Networks = append(c.Networks, networkValue)
 	}
@@ -143,14 +145,14 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 	for _, firewall := range rawConfig.Firewalls {
 		firewallValue, err := p.configVarResolver.GetStringValue(firewall)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		c.Firewalls = append(c.Firewalls, firewallValue)
 	}
 
 	ipv4, ipv6, err := p.publicIPsAssignment(rawConfig)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	c.AssignIPv4 = ipv4
@@ -158,7 +160,7 @@ func (p *provider) getConfig(provSpec clusterv1alpha1.ProviderSpec) (*Config, *p
 
 	c.Labels = rawConfig.Labels
 
-	return &c, pconfig, err
+	return &c, pconfig, rawConfig, err
 }
 
 func (p *provider) getServerPlacementGroup(ctx context.Context, client *hcloud.Client, c *Config) (*hcloud.PlacementGroup, error) {
@@ -192,7 +194,7 @@ func (p *provider) getServerPlacementGroup(ctx context.Context, client *hcloud.C
 }
 
 func (p *provider) Validate(ctx context.Context, _ *zap.SugaredLogger, spec clusterv1alpha1.MachineSpec) error {
-	c, pc, err := p.getConfig(spec.ProviderSpec)
+	c, pc, _, err := p.getConfig(spec.ProviderSpec)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %w", err)
 	}
@@ -210,12 +212,6 @@ func (p *provider) Validate(ctx context.Context, _ *zap.SugaredLogger, spec clus
 	if c.Location != "" {
 		if _, _, err = client.Location.Get(ctx, c.Location); err != nil {
 			return fmt.Errorf("failed to get location: %w", err)
-		}
-	}
-
-	if c.Datacenter != "" {
-		if _, _, err = client.Datacenter.Get(ctx, c.Datacenter); err != nil {
-			return fmt.Errorf("failed to get datacenter: %w", err)
 		}
 	}
 
@@ -264,7 +260,7 @@ func (p *provider) Validate(ctx context.Context, _ *zap.SugaredLogger, spec clus
 }
 
 func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData, userdata string) (instance.Instance, error) {
-	c, pc, err := p.getConfig(machine.Spec.ProviderSpec)
+	c, pc, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
 			Reason:  common.InvalidConfigurationMachineError,
@@ -301,15 +297,19 @@ func (p *provider) Create(ctx context.Context, log *zap.SugaredLogger, machine *
 		},
 	}
 
-	if c.Datacenter != "" {
-		dc, _, err := client.Datacenter.Get(ctx, c.Datacenter)
+	if c.Location == "" && c.Datacenter != "" {
+		// webhook migration normally converts datacenter -> location on admission.
+		// this fallback covers specs that bypass admission (webhook disabled, or
+		// pre-upgrade Machines).
+		loc, err := datacenterToLocation(c.Datacenter)
 		if err != nil {
-			return nil, hzErrorToTerminalError(err, "failed to get datacenter")
+			return nil, cloudprovidererrors.TerminalError{
+				Reason:  common.InvalidConfigurationMachineError,
+				Message: err.Error(),
+			}
 		}
-		if dc == nil {
-			return nil, fmt.Errorf("datacenter %q does not exist", c.Datacenter)
-		}
-		serverCreateOpts.Datacenter = dc
+		log.Warnf("Hetzner datacenter %q migrated to location %q at create time", c.Datacenter, loc)
+		c.Location = loc
 	}
 
 	if c.Location != "" {
@@ -417,7 +417,7 @@ func (p *provider) Cleanup(ctx context.Context, log *zap.SugaredLogger, machine 
 		return false, err
 	}
 
-	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	c, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return false, cloudprovidererrors.TerminalError{
 			Reason:  common.InvalidConfigurationMachineError,
@@ -458,12 +458,82 @@ func (p *provider) Cleanup(ctx context.Context, log *zap.SugaredLogger, machine 
 	return false, nil
 }
 
-func (p *provider) AddDefaults(_ *zap.SugaredLogger, spec clusterv1alpha1.MachineSpec) (clusterv1alpha1.MachineSpec, error) {
+func setProviderSpec(rawConfig hetznertypes.RawConfig, provSpec clusterv1alpha1.ProviderSpec) (*runtime.RawExtension, error) {
+	pconfig, err := providerconfig.GetConfig(provSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	rawCloudProviderSpec, err := json.Marshal(rawConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	pconfig.CloudProviderSpec = runtime.RawExtension{Raw: rawCloudProviderSpec}
+	rawPconfig, err := json.Marshal(pconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &runtime.RawExtension{Raw: rawPconfig}, nil
+}
+
+// datacenterToLocation derives the location from a deprecated hetzner
+// datacenter name. names are {location}-dc{N}, e.g. nbg1-dc3 -> nbg1.
+// all-digit values are IDs, not names: datacenter IDs do not map to
+// location IDs (dc 4 is fsn1-dc14, location 4 is ash), so reject them
+// rather than derive a silently wrong location.
+func datacenterToLocation(dc string) (string, error) {
+	if _, err := strconv.Atoi(dc); err == nil {
+		return "", fmt.Errorf("datacenter %q is a numeric ID; Hetzner IDs cannot be migrated automatically, set location explicitly", dc)
+	}
+	location, _, _ := strings.Cut(dc, "-")
+	if location == "" {
+		return "", fmt.Errorf("cannot derive location from datacenter %q", dc)
+	}
+	return location, nil
+}
+
+// AddDefaults migrates the deprecated datacenter field to location. Hetzner
+// removed the datacenter concept from its API, so specs setting datacenter
+// are rewritten to the location derived from the datacenter name prefix.
+// only inline datacenter values are migrated; secret/configmap references
+// resolve at runtime and cannot be rewritten here.
+func (p *provider) AddDefaults(log *zap.SugaredLogger, spec clusterv1alpha1.MachineSpec) (clusterv1alpha1.MachineSpec, error) {
+	_, _, rawConfig, err := p.getConfig(spec.ProviderSpec)
+	if err != nil {
+		return spec, cloudprovidererrors.TerminalError{
+			Reason:  common.InvalidConfigurationMachineError,
+			Message: fmt.Sprintf("Failed to parse MachineSpec, due to %v", err),
+		}
+	}
+
+	dc := rawConfig.Datacenter.Value
+	loc := rawConfig.Location.Value
+
+	if dc != "" && loc != "" {
+		return spec, fmt.Errorf("location and datacenter must not be set at the same time")
+	}
+
+	if dc != "" {
+		derived, err := datacenterToLocation(dc)
+		if err != nil {
+			return spec, err
+		}
+		log.Warnf("Hetzner datacenter %q is deprecated and has been migrated to location %q; switch specs to location before the field is removed", dc, derived)
+		rawConfig.Location.Value = derived
+		rawConfig.Datacenter = providerconfig.ConfigVarString{}
+	}
+
+	spec.ProviderSpec.Value, err = setProviderSpec(*rawConfig, spec.ProviderSpec)
+	if err != nil {
+		return spec, fmt.Errorf("error marshaling providerconfig: %w", err)
+	}
 	return spec, nil
 }
 
 func (p *provider) Get(ctx context.Context, _ *zap.SugaredLogger, machine *clusterv1alpha1.Machine, _ *cloudprovidertypes.ProviderData) (instance.Instance, error) {
-	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	c, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return nil, cloudprovidererrors.TerminalError{
 			Reason:  common.InvalidConfigurationMachineError,
@@ -490,7 +560,7 @@ func (p *provider) Get(ctx context.Context, _ *zap.SugaredLogger, machine *clust
 }
 
 func (p *provider) MigrateUID(ctx context.Context, log *zap.SugaredLogger, machine *clusterv1alpha1.Machine, newUID types.UID) error {
-	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	c, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err != nil {
 		return cloudprovidererrors.TerminalError{
 			Reason:  common.InvalidConfigurationMachineError,
@@ -529,10 +599,9 @@ func (p *provider) MigrateUID(ctx context.Context, log *zap.SugaredLogger, machi
 func (p *provider) MachineMetricsLabels(machine *clusterv1alpha1.Machine) (map[string]string, error) {
 	labels := make(map[string]string)
 
-	c, _, err := p.getConfig(machine.Spec.ProviderSpec)
+	c, _, _, err := p.getConfig(machine.Spec.ProviderSpec)
 	if err == nil {
 		labels["size"] = c.ServerType
-		labels["dc"] = c.Datacenter
 		labels["location"] = c.Location
 	}
 

--- a/pkg/cloudprovider/provider/hetzner/provider_test.go
+++ b/pkg/cloudprovider/provider/hetzner/provider_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 The Machine Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hetzner
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+
+	clusterv1alpha1 "k8c.io/machine-controller/sdk/apis/cluster/v1alpha1"
+	hetznertypes "k8c.io/machine-controller/sdk/cloudprovider/hetzner"
+	"k8c.io/machine-controller/sdk/providerconfig"
+	"k8c.io/machine-controller/sdk/providerconfig/configvar"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestDatacenterToLocation(t *testing.T) {
+	tests := []struct {
+		datacenter   string
+		wantLocation string
+		wantErr      string
+	}{
+		{datacenter: "nbg1-dc3", wantLocation: "nbg1"},
+		{datacenter: "fsn1-dc14", wantLocation: "fsn1"},
+		{datacenter: "ash-dc1", wantLocation: "ash"},
+		{datacenter: "hel1-dc2", wantLocation: "hel1"},
+		{datacenter: "4", wantErr: "is a numeric ID"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.datacenter, func(t *testing.T) {
+			location, err := datacenterToLocation(tt.datacenter)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("datacenterToLocation(%q) error = %v, want error containing %q", tt.datacenter, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("datacenterToLocation(%q) error = %v", tt.datacenter, err)
+			}
+			if location != tt.wantLocation {
+				t.Fatalf("datacenterToLocation(%q) = %q, want %q", tt.datacenter, location, tt.wantLocation)
+			}
+		})
+	}
+}
+
+func hetznerProviderSpec(t *testing.T, datacenter, location string) clusterv1alpha1.ProviderSpec {
+	t.Helper()
+
+	rawConfig := hetznertypes.RawConfig{
+		Token:      providerconfig.ConfigVarString{Value: "fake-token"},
+		ServerType: providerconfig.ConfigVarString{Value: "cx22"},
+		Datacenter: providerconfig.ConfigVarString{Value: datacenter},
+		Location:   providerconfig.ConfigVarString{Value: location},
+	}
+	rawCloudProviderSpec, err := json.Marshal(rawConfig)
+	if err != nil {
+		t.Fatalf("failed to marshal hetzner raw config: %v", err)
+	}
+
+	pconfig := providerconfig.Config{
+		CloudProvider:       providerconfig.CloudProviderHetzner,
+		CloudProviderSpec:   runtime.RawExtension{Raw: rawCloudProviderSpec},
+		OperatingSystem:     providerconfig.OperatingSystemUbuntu,
+		OperatingSystemSpec: runtime.RawExtension{Raw: []byte("{}")},
+	}
+	rawPconfig, err := json.Marshal(pconfig)
+	if err != nil {
+		t.Fatalf("failed to marshal providerconfig: %v", err)
+	}
+
+	return clusterv1alpha1.ProviderSpec{Value: &runtime.RawExtension{Raw: rawPconfig}}
+}
+
+func hetznerRawConfig(t *testing.T, spec clusterv1alpha1.MachineSpec) *hetznertypes.RawConfig {
+	t.Helper()
+
+	pconfig, err := providerconfig.GetConfig(spec.ProviderSpec)
+	if err != nil {
+		t.Fatalf("failed to read providerconfig from defaulted spec: %v", err)
+	}
+	rawConfig, err := hetznertypes.GetConfig(*pconfig)
+	if err != nil {
+		t.Fatalf("failed to read hetzner raw config from defaulted spec: %v", err)
+	}
+	return rawConfig
+}
+
+func TestAddDefaultsMigratesDatacenterToLocation(t *testing.T) {
+	tests := []struct {
+		name           string
+		datacenter     string
+		location       string
+		wantDatacenter string
+		wantLocation   string
+		wantErr        string
+	}{
+		{
+			name:         "datacenter is migrated to location and cleared",
+			datacenter:   "nbg1-dc3",
+			wantLocation: "nbg1",
+		},
+		{
+			name:       "numeric datacenter ID is rejected",
+			datacenter: "4",
+			wantErr:    "is a numeric ID",
+		},
+		{
+			name:       "both set is rejected",
+			datacenter: "nbg1-dc3",
+			location:   "fsn1",
+			wantErr:    "location and datacenter must not be set at the same time",
+		},
+		{
+			name: "both empty is a no-op",
+		},
+		{
+			name:         "location only is a no-op",
+			location:     "fsn1",
+			wantLocation: "fsn1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &provider{
+				configVarResolver: configvar.NewResolver(context.Background(), fakectrlruntimeclient.NewClientBuilder().Build()),
+			}
+			spec := clusterv1alpha1.MachineSpec{
+				ProviderSpec: hetznerProviderSpec(t, tt.datacenter, tt.location),
+			}
+
+			defaultedSpec, err := p.AddDefaults(zap.NewNop().Sugar(), spec)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("AddDefaults() error = %v, want error containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AddDefaults() error = %v", err)
+			}
+
+			rawConfig := hetznerRawConfig(t, defaultedSpec)
+			if rawConfig.Datacenter.Value != tt.wantDatacenter {
+				t.Errorf("datacenter = %q, want %q", rawConfig.Datacenter.Value, tt.wantDatacenter)
+			}
+			if rawConfig.Location.Value != tt.wantLocation {
+				t.Errorf("location = %q, want %q", rawConfig.Location.Value, tt.wantLocation)
+			}
+		})
+	}
+}

--- a/sdk/cloudprovider/hetzner/types.go
+++ b/sdk/cloudprovider/hetzner/types.go
@@ -22,8 +22,10 @@ import (
 )
 
 type RawConfig struct {
-	Token                providerconfig.ConfigVarString   `json:"token,omitempty"`
-	ServerType           providerconfig.ConfigVarString   `json:"serverType"`
+	Token      providerconfig.ConfigVarString `json:"token,omitempty"`
+	ServerType providerconfig.ConfigVarString `json:"serverType"`
+	// Deprecated: Hetzner removed the datacenter concept; use Location instead.
+	// Migrated automatically to Location on admission when Location is empty.
 	Datacenter           providerconfig.ConfigVarString   `json:"datacenter"`
 	Image                providerconfig.ConfigVarString   `json:"image"`
 	Location             providerconfig.ConfigVarString   `json:"location"`

--- a/test/e2e/provisioning/all_e2e_test.go
+++ b/test/e2e/provisioning/all_e2e_test.go
@@ -62,6 +62,7 @@ const (
 	EquinixMetalManifest              = "./testdata/machinedeployment-equinixmetal.yaml"
 	GCEManifest                       = "./testdata/machinedeployment-gce.yaml"
 	HZManifest                        = "./testdata/machinedeployment-hetzner.yaml"
+	HZDatacenterManifest              = "./testdata/machinedeployment-hetzner-datacenter.yaml"
 	LinodeManifest                    = "./testdata/machinedeployment-linode.yaml"
 	VMwareCloudDirectorManifest       = "./testdata/machinedeployment-vmware-cloud-director.yaml"
 	VSPhereManifest                   = "./testdata/machinedeployment-vsphere.yaml"
@@ -696,6 +697,30 @@ func TestHetznerProvisioningE2E(t *testing.T) {
 	// act
 	params := []string{fmt.Sprintf("<< HETZNER_TOKEN >>=%s", hzToken)}
 	runScenarios(context.Background(), t, selector, params, HZManifest, fmt.Sprintf("hz-%s", *testRunIdentifier))
+}
+
+// TestHetznerProvisioningE2EDatacenterMigration verifies that a MachineDeployment
+// still setting the deprecated datacenter field provisions successfully: the
+// admission webhook migrates datacenter to location, and the provider no longer
+// sends datacenter to the Hetzner API.
+func TestHetznerProvisioningE2EDatacenterMigration(t *testing.T) {
+	t.Parallel()
+
+	hzToken := os.Getenv("HZ_E2E_TOKEN")
+	if len(hzToken) == 0 {
+		t.Fatal("Unable to run the test suite, HZ_E2E_TOKEN environment variable cannot be empty")
+	}
+
+	params := []string{fmt.Sprintf("<< HETZNER_TOKEN >>=%s", hzToken)}
+
+	scenario := scenario{
+		name:              "Hetzner deprecated datacenter field",
+		osName:            "ubuntu",
+		containerRuntime:  defaultContainerRuntime,
+		kubernetesVersion: defaultKubernetesVersion,
+		executor:          verifyCreateAndDelete,
+	}
+	testScenario(context.Background(), t, scenario, *testRunIdentifier, params, HZDatacenterManifest, false)
 }
 
 // TestEquinixMetalProvisioningE2E - a test suite that exercises Equinix Metal provider

--- a/test/e2e/provisioning/testdata/machine-invalid.yaml
+++ b/test/e2e/provisioning/testdata/machine-invalid.yaml
@@ -13,7 +13,6 @@ spec:
         cloudProviderSpec:
           token: << HETZNER_TOKEN >>
           serverType: "cx23"
-          datacenter: ""
           location: "fsn1"
         operatingSystem: "<< OS_NAME >>"
         operatingSystemSpec:

--- a/test/e2e/provisioning/testdata/machinedeployment-hetzner-datacenter.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-hetzner-datacenter.yaml
@@ -28,7 +28,8 @@ spec:
           cloudProviderSpec:
             token: << HETZNER_TOKEN >>
             serverType: "cx23"
-            location: "nbg1"
+            # deprecated field; the admission webhook migrates it to location nbg1
+            datacenter: "nbg1-dc3"
             networks:
               - "machine-controller-e2e"
             firewalls:


### PR DESCRIPTION
**What this PR does / why we need it**:

Hetzner removed the `datacenter` property from its Servers API in July 2026, so any MachineDeployment that still sets `cloudProviderSpec.datacenter` either fails to provision or lands in Hetzner's default location. This PR migrates `datacenter` to `location` on admission by deriving the location from the datacenter name prefix (`nbg1-dc3` becomes `nbg1`), removes all calls to the removed datacenter endpoints, and keeps the field parseable through a deprecation window so existing specs do not break on strict unmarshal. Hard removal of the field is left for a later release.

**Which issue(s) this PR fixes**:
Fixes #2053

**What type of PR is this?**
/kind bug
/kind deprecation

**Special notes for your reviewer**:

Numeric `datacenter` values are rejected instead of migrated because Hetzner datacenter IDs do not map to location IDs (datacenter 4 is `fsn1-dc14` while location 4 is `ash`). `Create` derives the location itself for specs that bypass the webhook, so runtime placement stays correct even with the webhook disabled. hcloud-go is bumped from v2.13.1 to v2.44.0 with no other dependency churn and no call site changes. The new `TestHetznerProvisioningE2EDatacenterMigration` runs in the existing hetzner presubmit because its name matches the job's `-run` filter. The `dc` metrics label is gone; dashboards using it need updating.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
machine-controller no longer sends the removed `datacenter` field to the Hetzner API. Hetzner specs setting `cloudProviderSpec.datacenter` are migrated to `location` automatically on admission, and the `dc` metrics label was removed. Update your specs to use `location`; the `datacenter` field will be removed in a future release.
```

**Documentation**:
```documentation
NONE
```

**Test issue**:
```test-issue
Prerequisites: cluster running this machine-controller build with a Hetzner project token.

1. Create a MachineDeployment with cloudProviderSpec.datacenter set to nbg1-dc3 and no location.
2. Verify the webhook rewrote the spec: location is nbg1 and datacenter is empty.
   get machinedeployment <name> -o jsonpath='{.spec.template.spec.providerSpec.value.cloudProviderSpec}'
3. Verify the server is created in nbg1 and the node joins the cluster.
4. Create a MachineDeployment with only location set to fsn1 and verify it provisions unchanged.
```
