### PR TITLE
kubevirt: pin Flatcar VMs to PCI root complex to preserve Ignition

### DIFF
--- a/pkg/cloudprovider/provider/kubevirt/provider.go
+++ b/pkg/cloudprovider/provider/kubevirt/provider.go
@@ -834,6 +834,13 @@ func (p *provider) newVirtualMachine(c *Config, pc *providerconfig.Config, machi
 
 	if pc.OperatingSystem == providerconfig.OperatingSystemFlatcar {
 		annotations["kubevirt.io/ignitiondata"] = userdata
+		// Workaround for KubeVirt >= 1.6.4 dropping the fw_cfg (opt/com.coreos/config)
+		// qemu arg that carries Flatcar's Ignition: the PCIe-hotplug port reservation
+		// re-defines the domain and an XML round-trip loses the qemu namespace. Pinning
+		// PCI devices to the root complex skips that second define so Ignition survives.
+		// Harmless for worker VMs (no PCI hotplug). Remove once the upstream fix ships.
+		// Refs: kubevirt/kubevirt#16901, kubevirt/kubevirt#18460.
+		annotations["kubevirt.io/placePCIDevicesOnRootComplex"] = "true"
 	}
 
 	annotations["kubevirt.io/allow-pod-bridge-network-live-migration"] = "true"


### PR DESCRIPTION
**What this PR does / why we need it**:

On KubeVirt 1.6.4 and newer, Flatcar worker VMs boot but never receive their Ignition configuration, so the node never joins the cluster. KubeVirt's PCIe-hotplug port reservation re-defines the libvirt domain a second time, and that path runs an XML round-trip that cannot preserve the qemu namespace — dropping the `<qemu:commandline>` `-fw_cfg opt/com.coreos/config` argument that carries Flatcar's stage-1 Ignition. This PR sets the `kubevirt.io/placePCIDevicesOnRootComplex` annotation on Flatcar VMs, which makes KubeVirt skip the extra hotplug ports and the second domain define, so the fw_cfg argument survives. cloud-init based OSes (e.g. Ubuntu) are unaffected because they are delivered as a disk rather than a qemu command-line argument.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

None (root cause is upstream KubeVirt — see Special notes)

**What type of PR is this?**
<!--
None
-->

**Special notes for your reviewer**:

- Root cause is an upstream KubeVirt defect, not machine-controller: an `xml.Unmarshal` round-trip in `ApplySidecarHooks` silently drops the qemu-namespaced command line, which became fatal once KubeVirt 1.6.4 added a second domain define in the PCIe-hotplug port path. Upstream refs: kubevirt/kubevirt#16901 (root cause), kubevirt/kubevirt#18460 (fix, still open, no `release-1.6` backport yet). This PR is the workaround until that fix ships in the KubeVirt version we deploy.
- Scoped to Flatcar deliberately, to avoid changing behaviour for other operating systems. It is applied unconditionally for Flatcar (not gated on the KubeVirt version) because the annotation is harmless on unaffected versions — it only disables extra PCIe hotplug ports, and worker VMs never hotplug PCI devices.
- Users can still override it per-pool via `spec.template.metadata.annotations` on the MachineDeployment, since machine-controller merges those after this default.
- No `testdata` fixture currently exercises Flatcar (none set `kubevirt.io/ignitiondata`), so no golden files change. Happy to add a Flatcar fixture + case if you'd like the path covered.


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Flatcar-based KubeVirt machines failing to bootstrap on KubeVirt 1.6.4 and newer by setting the kubevirt.io/placePCIDevicesOnRootComplex annotation, which preserves the Ignition (fw_cfg) configuration.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
