### PR TITLE
feat: Machine NodeDrainTimeout possibility

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -529,9 +529,13 @@ func (r *Reconciler) shouldCleanupVolumes(ctx context.Context, log *zap.SugaredL
 
 // evictIfNecessary checks if the machine has a node and evicts it if necessary.
 func (r *Reconciler) shouldEvict(ctx context.Context, log *zap.SugaredLogger, machine *clusterv1alpha1.Machine) (bool, error) {
+	// Retrieve the effective eviction timeout
+	// when a configurable timeout for the machine is nto set, then we take the global timeout
+	// that has the default of 2hrs
+	effectiveTimeoutDuration := r.getEffectiveNodeDrainTimeout(machine)
 	// If the deletion got triggered a few hours ago, skip eviction.
 	// We assume here that the eviction is blocked by misconfiguration or a misbehaving kubelet and/or controller-runtime
-	if machine.DeletionTimestamp != nil && time.Since(machine.DeletionTimestamp.Time) > r.skipEvictionAfter {
+	if machine.DeletionTimestamp != nil && time.Since(machine.DeletionTimestamp.Time) > effectiveTimeoutDuration {
 		log.Infow("Skipping eviction since the deletion got triggered too long ago", "threshold", r.skipEvictionAfter)
 		return false, nil
 	}
@@ -1250,4 +1254,12 @@ func (r *Reconciler) handleNodeFailuresWithExternalCCM(
 
 	log.Debug("Waiting for a node to become %q", corev1.NodeReady)
 	return &reconcile.Result{RequeueAfter: deletionRetryWaitPeriod}, err
+}
+
+// TODO: docuemnt this
+func (r *Reconciler) getEffectiveNodeDrainTimeout(machine *clusterv1alpha1.Machine) time.Duration {
+	if machine != nil && machine.Spec.NodeDrainTimeout != nil {
+		return machine.Spec.NodeDrainTimeout.Duration
+	}
+	return r.skipEvictionAfter
 }

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -529,9 +529,9 @@ func (r *Reconciler) shouldCleanupVolumes(ctx context.Context, log *zap.SugaredL
 
 // evictIfNecessary checks if the machine has a node and evicts it if necessary.
 func (r *Reconciler) shouldEvict(ctx context.Context, log *zap.SugaredLogger, machine *clusterv1alpha1.Machine) (bool, error) {
-	// Retrieve the effective eviction timeout
-	// when a configurable timeout for the machine is nto set, then we take the global timeout
-	// that has the default of 2hrs
+	// Retrieve the effective eviction timeout.
+	// When a configurable timeout for the machine is not set, we use the global timeout
+	// that has the default of 2 hours (last checked: 01.09.2026 18:17).
 	effectiveTimeoutDuration := r.getEffectiveNodeDrainTimeout(machine)
 	// If the deletion got triggered a few hours ago, skip eviction.
 	// We assume here that the eviction is blocked by misconfiguration or a misbehaving kubelet and/or controller-runtime
@@ -1256,7 +1256,11 @@ func (r *Reconciler) handleNodeFailuresWithExternalCCM(
 	return &reconcile.Result{RequeueAfter: deletionRetryWaitPeriod}, err
 }
 
-// TODO: docuemnt this
+// getEffectiveNodeDrainTimeout returns the effective drain timeout for the machine.
+// If the machine has a custom NodeDrainTimeout specified, it returns that value.
+// Otherwise, it returns the global reconciler timeout (skipEvictionAfter).
+// This allows fine-grained control over drain timeouts at the machine level while
+// maintaining a sensible global default.
 func (r *Reconciler) getEffectiveNodeDrainTimeout(machine *clusterv1alpha1.Machine) time.Duration {
 	if machine != nil && machine.Spec.NodeDrainTimeout != nil {
 		return machine.Spec.NodeDrainTimeout.Duration

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -473,6 +473,171 @@ func TestControllerShouldEvict(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "skip eviction due to custom NodeDrainTimeout exceeded",
+			shouldEvict: false,
+			existingNodes: []ctrlruntimeclient.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eviction-destination",
+					},
+				},
+			},
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-30 * time.Minute)},
+					Finalizers:        []string{finalizer},
+				},
+				Status: clusterv1alpha1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{Name: "existing-node"},
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+				},
+			},
+		},
+		{
+			name:        "allow eviction when within custom NodeDrainTimeout",
+			shouldEvict: true,
+			existingNodes: []ctrlruntimeclient.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eviction-destination",
+					},
+				},
+			},
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+					Finalizers:        []string{finalizer},
+				},
+				Status: clusterv1alpha1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{Name: "existing-node"},
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+				},
+			},
+		},
+		{
+			name:        "custom NodeDrainTimeout overrides default longer timeout",
+			shouldEvict: false,
+			existingNodes: []ctrlruntimeclient.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eviction-destination",
+					},
+				},
+			},
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-15 * time.Minute)},
+					Finalizers:        []string{finalizer},
+				},
+				Status: clusterv1alpha1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{Name: "existing-node"},
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: 10 * time.Minute},
+				},
+			},
+		},
+		{
+			name:        "nil NodeDrainTimeout uses default timeout (skip eviction)",
+			shouldEvict: false,
+			existingNodes: []ctrlruntimeclient.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eviction-destination",
+					},
+				},
+			},
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &threeHoursAgo,
+					Finalizers:        []string{finalizer},
+				},
+				Status: clusterv1alpha1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{Name: "existing-node"},
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: nil,
+				},
+			},
+		},
+		{
+			name:        "nil NodeDrainTimeout uses default timeout (allow eviction)",
+			shouldEvict: true,
+			existingNodes: []ctrlruntimeclient.Object{
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "existing-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+						},
+					},
+				},
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "eviction-destination",
+					},
+				},
+			},
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+					Finalizers:        []string{finalizer},
+				},
+				Status: clusterv1alpha1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{Name: "existing-node"},
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: nil,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -723,6 +888,180 @@ func TestControllerFindNodeByProviderID(t *testing.T) {
 			node := findNodeByProviderID(test.instance, test.provider, test.nodes)
 			if (node != nil) != test.expectedNode {
 				t.Errorf("expected %t, but got %t", test.expectedNode, (node != nil))
+			}
+		})
+	}
+}
+
+func TestGetEffectiveNodeDrainTimeout(t *testing.T) {
+	defaultSkipEvictionAfter := 2 * time.Hour
+	customNodeDrainTimeout := 5 * time.Minute
+	anotherCustomTimeout := 30 * time.Minute
+
+	tests := []struct {
+		name              string
+		machine           *clusterv1alpha1.Machine
+		skipEvictionAfter time.Duration
+		expectedTimeout   time.Duration
+		description       string
+	}{
+		{
+			name:              "nil machine returns default timeout",
+			machine:           nil,
+			skipEvictionAfter: defaultSkipEvictionAfter,
+			expectedTimeout:   defaultSkipEvictionAfter,
+			description:       "When machine is nil, should return the reconciler's default skipEvictionAfter",
+		},
+		{
+			name: "machine with nil NodeDrainTimeout returns default",
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine",
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: nil,
+				},
+			},
+			skipEvictionAfter: defaultSkipEvictionAfter,
+			expectedTimeout:   defaultSkipEvictionAfter,
+			description:       "When machine has no custom NodeDrainTimeout, should return the default timeout",
+		},
+		{
+			name: "machine with custom NodeDrainTimeout overrides default",
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine-custom",
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: customNodeDrainTimeout},
+				},
+			},
+			skipEvictionAfter: defaultSkipEvictionAfter,
+			expectedTimeout:   customNodeDrainTimeout,
+			description:       "When machine has custom NodeDrainTimeout, should use that instead of default",
+		},
+		{
+			name: "machine with custom timeout smaller than default",
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine-small-timeout",
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: 1 * time.Minute},
+				},
+			},
+			skipEvictionAfter: defaultSkipEvictionAfter,
+			expectedTimeout:   1 * time.Minute,
+			description:       "Custom timeout smaller than default should be respected",
+		},
+		{
+			name: "machine with custom timeout larger than default",
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine-large-timeout",
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: anotherCustomTimeout},
+				},
+			},
+			skipEvictionAfter: defaultSkipEvictionAfter,
+			expectedTimeout:   anotherCustomTimeout,
+			description:       "Custom timeout larger than default should be respected",
+		},
+		{
+			name: "zero default timeout with nil machine NodeDrainTimeout",
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine",
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: nil,
+				},
+			},
+			skipEvictionAfter: 0,
+			expectedTimeout:   0,
+			description:       "When default timeout is zero, should return zero",
+		},
+		{
+			name: "machine with zero custom NodeDrainTimeout",
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine-zero-timeout",
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: 0},
+				},
+			},
+			skipEvictionAfter: defaultSkipEvictionAfter,
+			expectedTimeout:   0,
+			description:       "When machine has zero custom NodeDrainTimeout, should use zero",
+		},
+		{
+			name: "very large custom timeout",
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine-very-large",
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: 24 * time.Hour},
+				},
+			},
+			skipEvictionAfter: defaultSkipEvictionAfter,
+			expectedTimeout:   24 * time.Hour,
+			description:       "Very large custom timeout should be respected",
+		},
+		{
+			name: "machine with very small custom timeout (1 nanosecond)",
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine-nano",
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: 1 * time.Nanosecond},
+				},
+			},
+			skipEvictionAfter: defaultSkipEvictionAfter,
+			expectedTimeout:   1 * time.Nanosecond,
+			description:       "Very small custom timeout (nanosecond precision) should be respected",
+		},
+		{
+			name:              "different default timeouts are correctly used",
+			machine:           nil,
+			skipEvictionAfter: 10 * time.Minute,
+			expectedTimeout:   10 * time.Minute,
+			description:       "Different default timeout should be returned when no custom timeout is set",
+		},
+		{
+			name: "machine with custom timeout takes precedence over different default",
+			machine: &clusterv1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-machine-precedence",
+				},
+				Spec: clusterv1alpha1.MachineSpec{
+					NodeDrainTimeout: &metav1.Duration{Duration: 3 * time.Hour},
+				},
+			},
+			skipEvictionAfter: 10 * time.Minute,
+			expectedTimeout:   3 * time.Hour,
+			description:       "Machine custom timeout takes precedence regardless of default value",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			reconciler := &Reconciler{
+				skipEvictionAfter: test.skipEvictionAfter,
+			}
+
+			actualTimeout := reconciler.getEffectiveNodeDrainTimeout(test.machine)
+
+			if actualTimeout != test.expectedTimeout {
+				t.Errorf(
+					"getEffectiveNodeDrainTimeout failed: expected %v, got %v. %s",
+					test.expectedTimeout,
+					actualTimeout,
+					test.description,
+				)
 			}
 		})
 	}

--- a/pkg/controller/machinedeployment/sync.go
+++ b/pkg/controller/machinedeployment/sync.go
@@ -140,6 +140,11 @@ func (r *ReconcileMachineDeployment) getNewMachineSet(ctx context.Context, log *
 		minReadySeconds = *d.Spec.MinReadySeconds
 	}
 
+	// Propagate NodeDrainTimeout from MachineDeployment to MachineSet template (when not already set).
+	if d.Spec.NodeDrainTimeout != nil && newMSTemplate.Spec.NodeDrainTimeout == nil {
+		newMSTemplate.Spec.NodeDrainTimeout = d.Spec.NodeDrainTimeout.DeepCopy()
+	}
+
 	// Create new MachineSet
 	newMS := clusterv1alpha1.MachineSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/sdk/apis/cluster/v1alpha1/machine_types.go
+++ b/sdk/apis/cluster/v1alpha1/machine_types.go
@@ -107,7 +107,8 @@ type MachineSpec struct {
 	ProviderID *string `json:"providerID,omitempty"`
 
 	// NodeDrainTimeout specifies a custom time limit for draining pods from the node
-	// during machine deletion. If not set, the default global timeout is used.
+	// during machine deletion. If not set, the global controller timeout (skipEvictionAfter) is used.
+	// This allows per-machine customization of drain timeouts.
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 }

--- a/sdk/apis/cluster/v1alpha1/machine_types.go
+++ b/sdk/apis/cluster/v1alpha1/machine_types.go
@@ -105,6 +105,9 @@ type MachineSpec struct {
 	// be interfacing with cluster-api as generic provider.
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`
+
+	//TODO: document this
+	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 }
 
 /// [MachineSpec]

--- a/sdk/apis/cluster/v1alpha1/machine_types.go
+++ b/sdk/apis/cluster/v1alpha1/machine_types.go
@@ -106,7 +106,9 @@ type MachineSpec struct {
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`
 
-	//TODO: document this
+	// NodeDrainTimeout specifies a custom time limit for draining pods from the node
+	// during machine deletion. If not set, the default global timeout is used.
+	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 }
 

--- a/sdk/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/sdk/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -66,6 +66,11 @@ type MachineDeploymentSpec struct {
 	// reason will be surfaced in the deployment status. Note that progress will
 	// not be estimated during the time a deployment is paused. Defaults to 600s.
 	ProgressDeadlineSeconds *int32 `json:"progressDeadlineSeconds,omitempty"`
+
+	//TODO: document it better tbf.
+	// NodeDrainTimeout sets a time limit how long a node can take to drain.
+	// +optional
+	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 }
 
 /// [MachineDeploymentSpec]

--- a/sdk/apis/cluster/v1alpha1/machinedeployment_types.go
+++ b/sdk/apis/cluster/v1alpha1/machinedeployment_types.go
@@ -67,8 +67,10 @@ type MachineDeploymentSpec struct {
 	// not be estimated during the time a deployment is paused. Defaults to 600s.
 	ProgressDeadlineSeconds *int32 `json:"progressDeadlineSeconds,omitempty"`
 
-	//TODO: document it better tbf.
-	// NodeDrainTimeout sets a time limit how long a node can take to drain.
+	// NodeDrainTimeout specifies a custom time limit for draining pods from nodes
+	// during machine deletion. This value is inherited by Machines created from this
+	// deployment if they don't have their own NodeDrainTimeout set.
+	// If not set, the default global timeout is used.
 	// +optional
 	NodeDrainTimeout *metav1.Duration `json:"nodeDrainTimeout,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:


This feature enables fine-grained control over pod eviction timeouts, allowing different deployment groups to have different drain policies.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #2070 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature
/kind api-change

**Special notes for your reviewer**:

Uhhh, it’s my first pr to this repo, so if anything in the changes is wrong, I’m happy to fix it.

Changes:

* API: Added **NodeDrainTimeout *metav1.Duration** field to **MachineSpec** and **MachineDeploymentSpec**

* Backward Compatible: Fully backward compatible. Machines **without custom timeouts use the existing global default** (Custom timeouts overrides global timeouts)



**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for custom pod drain timeouts on MachineDeployments and Machines via spec.nodeDrainTimeout.  If unset, the global controller timeout applies.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
  TBD (documentation will be added later)
```
